### PR TITLE
chore(seed): Holding + Trade 일괄 생성 (#9)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -35,7 +35,9 @@ async function createHoldingWithTrade(tx: TxClient, accountId: string, seed: Hol
   const isUSD = seed.currency === 'USD'
   const avgPrice = isUSD ? Math.round(seed.avgPriceFx * SEED_FX_RATE) : seed.avgPrice
   const price = isUSD ? seed.avgPriceFx : seed.avgPrice
-  const totalKRW = avgPrice * seed.shares
+  const totalKRW = isUSD
+    ? Math.round(price * seed.shares * SEED_FX_RATE)
+    : Math.round(price * seed.shares)
 
   await tx.holding.create({
     data: {


### PR DESCRIPTION
## Summary
- 기존 seed가 Holding만 생성하여 거래 기록(Trade)이 누락되던 문제 해결
- `createHoldingWithTrade()` 헬퍼로 Holding + 대응 BUY Trade를 원자적으로 생성
- 17개 전체 보유종목에 대해 초기 매수 거래 기록 추가 (approximate tradedAt 포함)

Relates to #9

## Changes
- `prisma/seed.ts`: `HoldingSeed` 인터페이스에 `tradedAt` 필드 추가, `createHoldingWithTrade()` 함수로 Holding+Trade 동시 생성

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)