### PR TITLE
[Phase 4-A] 입금/증여 CRUD (#19)

### DIFF
--- a/src/app/api/deposits/[id]/route.ts
+++ b/src/app/api/deposits/[id]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+interface RouteParams {
+  params: { id: string }
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const existing = await prisma.deposit.findUnique({ where: { id: params.id } })
+    if (!existing) {
+      return NextResponse.json({ error: '입금 기록을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+    }
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+    }
+    const { amount, source, note, depositedAt } = body as Record<string, unknown>
+
+    if (amount !== undefined && (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0)) {
+      return NextResponse.json({ error: '금액은 0보다 커야 합니다.' }, { status: 400 })
+    }
+    if (source !== undefined && (typeof source !== 'string' || !source.trim())) {
+      return NextResponse.json({ error: '출처를 입력해주세요.' }, { status: 400 })
+    }
+    if (depositedAt !== undefined && (typeof depositedAt !== 'string' || isNaN(Date.parse(depositedAt)))) {
+      return NextResponse.json({ error: '유효한 입금일을 입력해주세요.' }, { status: 400 })
+    }
+    if (note !== undefined && note !== null && typeof note !== 'string') {
+      return NextResponse.json({ error: '메모는 문자열이어야 합니다.' }, { status: 400 })
+    }
+
+    if (typeof amount === 'number') {
+      const roundedAmount = Math.round(amount)
+      if (roundedAmount <= 0) {
+        return NextResponse.json({ error: '금액은 1원 이상이어야 합니다.' }, { status: 400 })
+      }
+    }
+
+    const updated = await prisma.deposit.update({
+      where: { id: params.id },
+      data: {
+        amount: typeof amount === 'number' ? Math.round(amount) : undefined,
+        source: typeof source === 'string' ? source.trim() : undefined,
+        note: note !== undefined ? (typeof note === 'string' ? (note.trim() || null) : null) : undefined,
+        depositedAt: typeof depositedAt === 'string' ? new Date(depositedAt) : undefined,
+      },
+    })
+
+    return NextResponse.json(updated)
+  } catch (error) {
+    console.error('PUT /api/deposits/[id] error:', error)
+    return NextResponse.json({ error: '입금 수정에 실패했습니다.' }, { status: 500 })
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const existing = await prisma.deposit.findUnique({ where: { id: params.id } })
+    if (!existing) {
+      return NextResponse.json({ error: '입금 기록을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    await prisma.deposit.delete({ where: { id: params.id } })
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('DELETE /api/deposits/[id] error:', error)
+    return NextResponse.json({ error: '입금 삭제에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/deposits/route.ts
+++ b/src/app/api/deposits/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { validateDepositInput } from '@/lib/deposit-utils'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl
+    const accountId = searchParams.get('accountId')
+    const year = searchParams.get('year')
+    const rawLimit = parseInt(searchParams.get('limit') ?? '50')
+    const rawOffset = parseInt(searchParams.get('offset') ?? '0')
+    const limit = Math.min(isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit, 200)
+    const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
+
+    const where: Record<string, unknown> = {}
+    if (accountId) where.accountId = accountId
+    if (year) {
+      if (!/^\d{4}$/.test(year)) {
+        return NextResponse.json({ error: '유효한 연도를 입력해주세요.' }, { status: 400 })
+      }
+      const y = parseInt(year)
+      where.depositedAt = {
+        gte: new Date(`${y}-01-01`),
+        lt: new Date(`${y + 1}-01-01`),
+      }
+    }
+
+    const [deposits, total] = await Promise.all([
+      prisma.deposit.findMany({
+        where,
+        orderBy: [{ depositedAt: 'desc' }, { createdAt: 'desc' }],
+        take: limit,
+        skip: offset,
+        include: { account: { select: { name: true } } },
+      }),
+      prisma.deposit.count({ where }),
+    ])
+
+    return NextResponse.json({ deposits, total, limit, offset })
+  } catch (error) {
+    console.error('GET /api/deposits error:', error)
+    return NextResponse.json(
+      { error: '입금 내역을 불러올 수 없습니다.' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+    }
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+    }
+    const errors = validateDepositInput(body as Record<string, unknown>)
+    if (errors.length > 0) {
+      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+    }
+
+    const { accountId, amount, source, note, depositedAt } = body as Record<string, unknown>
+
+    if (note !== undefined && note !== null && typeof note !== 'string') {
+      return NextResponse.json({ error: '메모는 문자열이어야 합니다.' }, { status: 400 })
+    }
+
+    const account = await prisma.account.findUnique({ where: { id: accountId as string } })
+    if (!account) {
+      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    const roundedAmount = Math.round(amount as number)
+    if (roundedAmount <= 0) {
+      return NextResponse.json({ error: '금액은 1원 이상이어야 합니다.' }, { status: 400 })
+    }
+
+    const deposit = await prisma.deposit.create({
+      data: {
+        accountId: accountId as string,
+        amount: roundedAmount,
+        source: (source as string).trim(),
+        note: typeof note === 'string' ? (note.trim() || null) : null,
+        depositedAt: new Date(depositedAt as string),
+      },
+    })
+
+    return NextResponse.json(deposit, { status: 201 })
+  } catch (error) {
+    console.error('POST /api/deposits error:', error)
+    return NextResponse.json(
+      { error: '입금 기록에 실패했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/deposits/new/page.tsx
+++ b/src/app/deposits/new/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import Header from '@/components/layout/Header'
+import DepositForm from '@/components/deposit/DepositForm'
+
+export default async function NewDepositPage() {
+  const accounts = await prisma.account.findMany({
+    select: { id: true, name: true },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  return (
+    <div className="px-8 py-7 max-w-[960px]">
+      <Header title="입금 기록">
+        <Link
+          href="/deposits"
+          className="text-[13px] text-sub hover:text-muted transition-colors"
+        >
+          ← 입금 내역
+        </Link>
+      </Header>
+
+      <div className="mt-6">
+        <DepositForm accounts={accounts} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/deposits/page.tsx
+++ b/src/app/deposits/page.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import Header from '@/components/layout/Header'
+import DepositFilters from '@/components/deposit/DepositFilters'
+import DepositTable from '@/components/deposit/DepositTable'
+
+export const dynamic = 'force-dynamic'
+
+interface DepositsPageProps {
+  searchParams: {
+    accountId?: string | string[]
+    year?: string | string[]
+    offset?: string | string[]
+  }
+}
+
+function first(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v
+}
+
+export default async function DepositsPage({ searchParams }: DepositsPageProps) {
+  const accountId = first(searchParams.accountId)
+  const yearStr = first(searchParams.year)
+  const rawOffset = parseInt(first(searchParams.offset) ?? '0')
+  const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
+  const limit = 20
+
+  const year = yearStr && /^\d{4}$/.test(yearStr) ? parseInt(yearStr) : undefined
+
+  const where: Record<string, unknown> = {}
+  if (accountId) where.accountId = accountId
+  if (year) {
+    where.depositedAt = {
+      gte: new Date(`${year}-01-01`),
+      lt: new Date(`${year + 1}-01-01`),
+    }
+  }
+
+  const [total, accounts] = await Promise.all([
+    prisma.deposit.count({ where }),
+    prisma.account.findMany({
+      select: { id: true, name: true },
+      orderBy: { createdAt: 'asc' },
+    }),
+  ])
+
+  // Clamp offset to valid range
+  const clampedOffset = total > 0 && offset >= total
+    ? Math.max(0, Math.floor((total - 1) / limit) * limit)
+    : offset
+
+  const deposits = await prisma.deposit.findMany({
+    where,
+    orderBy: [{ depositedAt: 'desc' }, { createdAt: 'desc' }],
+    take: limit,
+    skip: clampedOffset,
+    include: { account: { select: { name: true } } },
+  })
+
+  // Summary: total amount via DB aggregate
+  const agg = await prisma.deposit.aggregate({
+    _sum: { amount: true },
+    where,
+  })
+  const totalAmount = agg._sum.amount ?? 0
+
+  const serialized = deposits.map((d) => ({
+    ...d,
+    depositedAt: d.depositedAt.toISOString(),
+    createdAt: undefined,
+  }))
+
+  return (
+    <div className="px-8 py-7 max-w-[960px]">
+      <Header title="입금/증여" sub={`총 ${total}건`}>
+        <Link
+          href="/deposits/new"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-sodam/15 text-sodam text-[13px] font-semibold border border-sodam/25 hover:bg-sodam/25 transition-all"
+        >
+          + 입금 기록
+        </Link>
+      </Header>
+
+      <div className="mt-5 mb-4">
+        <DepositFilters accounts={accounts} />
+      </div>
+
+      {/* 총 입금액 요약 */}
+      {totalAmount > 0 && (
+        <div className="mb-4 relative overflow-hidden rounded-[14px] border border-border bg-card px-5 py-4">
+          <div className="flex items-center justify-between">
+            <span className="text-[12px] text-sub">
+              {year ? `${year}년` : '전체'} 입금 총액
+            </span>
+            <span className="text-[17px] font-bold text-bright tabular-nums">
+              {totalAmount.toLocaleString('ko-KR')}원
+            </span>
+          </div>
+        </div>
+      )}
+
+      <DepositTable
+        deposits={serialized as Parameters<typeof DepositTable>[0]['deposits']}
+        total={total}
+        limit={limit}
+        offset={clampedOffset}
+      />
+
+      <p className="text-[11px] text-dim mt-4">
+        증여세 정보는 참고용이며 법적 조언이 아닙니다.
+      </p>
+    </div>
+  )
+}

--- a/src/components/deposit/DepositDeleteModal.tsx
+++ b/src/components/deposit/DepositDeleteModal.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { formatKRW, formatDate } from '@/lib/format'
+import type { DepositRow } from './DepositTable'
+
+interface DepositDeleteModalProps {
+  deposit: DepositRow
+  onClose: () => void
+}
+
+export default function DepositDeleteModal({ deposit, onClose }: DepositDeleteModalProps) {
+  const router = useRouter()
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleDelete = async () => {
+    setError(null)
+    setIsDeleting(true)
+
+    try {
+      const res = await fetch(`/api/deposits/${deposit.id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '삭제에 실패했습니다.')
+        return
+      }
+      onClose()
+      router.refresh()
+    } catch {
+      setError('네트워크 오류가 발생했습니다.')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" onClick={onClose} />
+      <div className="fixed inset-0 flex items-center justify-center z-50 px-4">
+        <div className="w-full max-w-[380px] bg-bg-raised border border-border rounded-[14px] overflow-hidden">
+          <div className="px-6 py-5">
+            <h2 className="text-[15px] font-bold text-bright mb-4">입금 삭제</h2>
+
+            <div className="bg-white/[0.025] border border-white/[0.04] rounded-lg px-4 py-3 mb-4">
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] text-dim">계좌</span>
+                  <span className="text-[13px] font-semibold text-bright">{deposit.account.name}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] text-dim">금액</span>
+                  <span className="text-[13px] text-muted tabular-nums">{formatKRW(deposit.amount)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] text-dim">출처</span>
+                  <span className="text-[13px] text-muted">{deposit.source}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] text-dim">입금일</span>
+                  <span className="text-[13px] text-muted tabular-nums">{formatDate(deposit.depositedAt)}</span>
+                </div>
+              </div>
+            </div>
+
+            <p className="text-[12px] text-red-400/80 leading-relaxed">
+              삭제된 입금 기록은 복구할 수 없습니다.
+            </p>
+
+            {error && (
+              <div className="mt-3 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400">{error}</div>
+            )}
+          </div>
+
+          <div className="px-6 py-4 border-t border-border flex gap-3">
+            <button onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-white/[0.06] hover:bg-white/[0.04] transition-all">
+              취소
+            </button>
+            <button onClick={handleDelete} disabled={isDeleting} className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-red-500/15 text-red-400 border border-red-500/25 hover:bg-red-500/25 disabled:opacity-40 transition-all">
+              {isDeleting ? '삭제 중...' : '삭제'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/deposit/DepositEditPanel.tsx
+++ b/src/components/deposit/DepositEditPanel.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { DEPOSIT_SOURCES } from '@/lib/deposit-utils'
+import type { DepositRow } from './DepositTable'
+
+interface DepositEditPanelProps {
+  deposit: DepositRow
+  onClose: () => void
+}
+
+const ACCOUNT_COLORS: Record<string, string> = {
+  '세진': 'text-sejin',
+  '소담': 'text-sodam',
+  '다솜': 'text-dasom',
+}
+
+export default function DepositEditPanel({ deposit, onClose }: DepositEditPanelProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [amount, setAmount] = useState(String(deposit.amount))
+  const [source, setSource] = useState(
+    (DEPOSIT_SOURCES as readonly string[]).includes(deposit.source) ? deposit.source : '기타'
+  )
+  const [customSource, setCustomSource] = useState(
+    (DEPOSIT_SOURCES as readonly string[]).includes(deposit.source) ? '' : deposit.source
+  )
+  const [note, setNote] = useState(deposit.note ?? '')
+  const [depositedAt, setDepositedAt] = useState(deposit.depositedAt.slice(0, 10))
+
+  const parsedAmount = Math.floor(Number(amount)) || 0
+  const effectiveSource = source === '기타' ? customSource.trim() : source
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    if (parsedAmount <= 0) {
+      setError('금액은 0보다 커야 합니다.')
+      setIsSubmitting(false)
+      return
+    }
+    if (!effectiveSource) {
+      setError('출처를 입력해주세요.')
+      setIsSubmitting(false)
+      return
+    }
+
+    try {
+      const res = await fetch(`/api/deposits/${deposit.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount: parsedAmount,
+          source: effectiveSource,
+          note: note || null,
+          depositedAt,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '수정에 실패했습니다.')
+        return
+      }
+
+      onClose()
+      router.refresh()
+    } catch {
+      setError('네트워크 오류가 발생했습니다.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const inputClasses = 'w-full bg-white/[0.035] border border-white/[0.06] rounded-lg px-3.5 py-2.5 text-[13px] text-bright placeholder-dim focus:outline-none focus:bg-white/[0.055] focus:border-white/[0.14] transition-colors'
+  const labelClasses = 'block text-[12px] font-semibold text-sub mb-1.5'
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" onClick={onClose} />
+      <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
+        <div className="px-6 py-5 border-b border-border flex items-center justify-between">
+          <h2 className="text-[15px] font-bold text-bright">입금 수정</h2>
+          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-white/[0.05] transition-all">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M4 4l8 8M12 4l-8 8" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">
+          {/* 고정 정보 */}
+          <div className="bg-white/[0.02] rounded-lg px-4 py-3 flex items-center justify-between">
+            <span className="text-[11px] text-dim">계좌</span>
+            <span className={`text-[13px] font-semibold ${ACCOUNT_COLORS[deposit.account.name] ?? 'text-muted'}`}>
+              {deposit.account.name}
+            </span>
+          </div>
+
+          {/* 금액 */}
+          <div>
+            <label className={labelClasses}>금액</label>
+            <div className="relative">
+              <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-[12px] text-dim">₩</span>
+              <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                min="1"
+                step="1"
+                className={`${inputClasses} pl-8`}
+              />
+            </div>
+          </div>
+
+          {/* 출처 */}
+          <div>
+            <label className={labelClasses}>출처</label>
+            <div className="flex flex-wrap gap-2">
+              {DEPOSIT_SOURCES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setSource(s)}
+                  className={`px-3 py-1.5 rounded-lg text-[12px] font-semibold border transition-all ${
+                    source === s
+                      ? 'bg-white/[0.07] text-bright border-white/[0.1]'
+                      : 'border-white/[0.06] text-sub hover:bg-white/[0.03]'
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+            {source === '기타' && (
+              <input
+                type="text"
+                value={customSource}
+                onChange={(e) => setCustomSource(e.target.value)}
+                placeholder="출처를 입력하세요"
+                className={`${inputClasses} mt-2`}
+                maxLength={50}
+              />
+            )}
+          </div>
+
+          {/* 입금일 */}
+          <div>
+            <label className={labelClasses}>입금일</label>
+            <input
+              type="date"
+              value={depositedAt}
+              onChange={(e) => setDepositedAt(e.target.value)}
+              className={inputClasses}
+            />
+          </div>
+
+          {/* 메모 */}
+          <div>
+            <label className={labelClasses}>메모 (선택)</label>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="메모를 입력하세요"
+              maxLength={200}
+              className={inputClasses}
+            />
+          </div>
+
+          {/* 요약 */}
+          {parsedAmount > 0 && (
+            <div className="bg-white/[0.025] border border-white/[0.06] rounded-lg px-4 py-3 flex items-center justify-between">
+              <span className="text-[12px] text-sub">수정 후 금액</span>
+              <div className="text-[15px] font-bold text-bright tabular-nums">
+                {parsedAmount.toLocaleString('ko-KR')}원
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400">{error}</div>
+          )}
+
+          <div className="flex gap-3">
+            <button type="button" onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-white/[0.06] hover:bg-white/[0.04] transition-all">
+              취소
+            </button>
+            <button type="submit" disabled={isSubmitting} className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-sodam/15 text-sodam border border-sodam/25 hover:bg-sodam/25 disabled:opacity-40 transition-all">
+              {isSubmitting ? '수정 중...' : '수정'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <style jsx>{`
+        @keyframes slideIn {
+          from { transform: translateX(100%); }
+          to { transform: translateX(0); }
+        }
+        .animate-slide-in {
+          animation: slideIn 0.2s ease-out;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/src/components/deposit/DepositFilters.tsx
+++ b/src/components/deposit/DepositFilters.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { useCallback } from 'react'
+
+interface Account {
+  id: string
+  name: string
+}
+
+interface DepositFiltersProps {
+  accounts: Account[]
+}
+
+const ACCOUNT_COLORS: Record<string, string> = {
+  '세진': 'text-sejin',
+  '소담': 'text-sodam',
+  '다솜': 'text-dasom',
+}
+
+export default function DepositFilters({ accounts }: DepositFiltersProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const activeAccountId = searchParams.get('accountId') ?? ''
+  const activeYear = searchParams.get('year') ?? ''
+
+  const updateFilter = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+      params.delete('offset')
+      router.push(`${pathname}?${params.toString()}`)
+    },
+    [router, pathname, searchParams]
+  )
+
+  const currentYear = new Date().getFullYear()
+  const years = [currentYear, currentYear - 1, currentYear - 2]
+
+  const segmentBase = 'px-3 py-1.5 text-[12px] font-semibold rounded-md transition-all cursor-pointer'
+  const segmentActive = 'bg-white/[0.07] text-bright'
+  const segmentInactive = 'text-sub hover:text-muted hover:bg-white/[0.03]'
+
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      {/* 계좌 필터 */}
+      <div className="flex items-center gap-1 bg-white/[0.02] rounded-lg p-1 border border-white/[0.04]">
+        <button
+          onClick={() => updateFilter('accountId', '')}
+          className={`${segmentBase} ${!activeAccountId ? segmentActive : segmentInactive}`}
+        >
+          전체
+        </button>
+        {accounts.map((account) => (
+          <button
+            key={account.id}
+            onClick={() => updateFilter('accountId', account.id)}
+            className={`${segmentBase} ${
+              activeAccountId === account.id ? segmentActive : segmentInactive
+            }`}
+          >
+            <span className="flex items-center gap-1.5">
+              <span className={`inline-block w-1.5 h-1.5 rounded-full ${
+                activeAccountId === account.id
+                  ? (ACCOUNT_COLORS[account.name]?.replace('text-', 'bg-') ?? 'bg-dim')
+                  : 'bg-dim'
+              }`} />
+              {account.name}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* 연도 필터 */}
+      <div className="flex items-center gap-1 bg-white/[0.02] rounded-lg p-1 border border-white/[0.04]">
+        <button
+          onClick={() => updateFilter('year', '')}
+          className={`${segmentBase} ${!activeYear ? segmentActive : segmentInactive}`}
+        >
+          전체
+        </button>
+        {years.map((year) => (
+          <button
+            key={year}
+            onClick={() => updateFilter('year', String(year))}
+            className={`${segmentBase} ${activeYear === String(year) ? segmentActive : segmentInactive}`}
+          >
+            {year}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/deposit/DepositForm.tsx
+++ b/src/components/deposit/DepositForm.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Card from '@/components/ui/Card'
+import { DEPOSIT_SOURCES } from '@/lib/deposit-utils'
+
+interface Account {
+  id: string
+  name: string
+}
+
+interface DepositFormProps {
+  accounts: Account[]
+}
+
+const ACCOUNT_COLORS: Record<string, { border: string; bg: string; text: string }> = {
+  '세진': { border: 'border-sejin', bg: 'bg-sejin/10', text: 'text-sejin' },
+  '소담': { border: 'border-sodam', bg: 'bg-sodam/10', text: 'text-sodam' },
+  '다솜': { border: 'border-dasom', bg: 'bg-dasom/10', text: 'text-dasom' },
+}
+
+export default function DepositForm({ accounts }: DepositFormProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [accountId, setAccountId] = useState('')
+  const [amount, setAmount] = useState('')
+  const [source, setSource] = useState('증여')
+  const [customSource, setCustomSource] = useState('')
+  const [note, setNote] = useState('')
+  const [depositedAt, setDepositedAt] = useState(() => {
+    const now = new Date()
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+  })
+
+  const parsedAmount = Math.floor(Number(amount)) || 0
+  const effectiveSource = source === '기타' ? customSource.trim() : source
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      const res = await fetch('/api/deposits', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          accountId,
+          amount: parsedAmount,
+          source: effectiveSource,
+          note: note || undefined,
+          depositedAt,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '입금 기록에 실패했습니다.')
+        return
+      }
+
+      router.push('/deposits')
+      router.refresh()
+    } catch {
+      setError('네트워크 오류가 발생했습니다.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const inputClasses = 'w-full bg-white/[0.035] border border-white/[0.06] rounded-lg px-3.5 py-2.5 text-[13px] text-bright placeholder-dim focus:outline-none focus:bg-white/[0.055] focus:border-white/[0.14] transition-colors'
+  const labelClasses = 'block text-[12px] font-semibold text-sub mb-1.5'
+
+  return (
+    <Card className="max-w-[560px] mx-auto">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+        {/* 계좌 선택 */}
+        <div>
+          <label className={labelClasses}>계좌</label>
+          <div className="grid grid-cols-3 gap-2">
+            {accounts.map((account) => {
+              const colors = ACCOUNT_COLORS[account.name]
+              const isActive = accountId === account.id
+              return (
+                <button
+                  key={account.id}
+                  type="button"
+                  onClick={() => setAccountId(account.id)}
+                  className={`py-2.5 rounded-lg text-[13px] font-semibold border transition-all ${
+                    isActive
+                      ? `${colors?.bg} ${colors?.border} ${colors?.text}`
+                      : 'border-white/[0.06] text-sub hover:bg-white/[0.03] hover:text-muted'
+                  }`}
+                >
+                  {account.name}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* 금액 */}
+        <div>
+          <label className={labelClasses}>금액</label>
+          <div className="relative">
+            <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-[12px] text-dim">₩</span>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="0"
+              min="1"
+              step="1"
+              className={`${inputClasses} pl-8`}
+            />
+          </div>
+        </div>
+
+        {/* 출처 */}
+        <div>
+          <label className={labelClasses}>출처</label>
+          <div className="flex flex-wrap gap-2">
+            {DEPOSIT_SOURCES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setSource(s)}
+                className={`px-3 py-1.5 rounded-lg text-[12px] font-semibold border transition-all ${
+                  source === s
+                    ? 'bg-white/[0.07] text-bright border-white/[0.1]'
+                    : 'border-white/[0.06] text-sub hover:bg-white/[0.03]'
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+          {source === '기타' && (
+            <input
+              type="text"
+              value={customSource}
+              onChange={(e) => setCustomSource(e.target.value)}
+              placeholder="출처를 입력하세요"
+              className={`${inputClasses} mt-2`}
+              maxLength={50}
+            />
+          )}
+        </div>
+
+        {/* 입금일 */}
+        <div>
+          <label className={labelClasses}>입금일</label>
+          <input
+            type="date"
+            value={depositedAt}
+            onChange={(e) => setDepositedAt(e.target.value)}
+            className={inputClasses}
+          />
+        </div>
+
+        {/* 메모 */}
+        <div>
+          <label className={labelClasses}>메모 (선택)</label>
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="메모를 입력하세요"
+            maxLength={200}
+            className={inputClasses}
+          />
+        </div>
+
+        {/* 요약 */}
+        {parsedAmount > 0 && (
+          <div className="bg-white/[0.025] border border-white/[0.06] rounded-lg px-4 py-3 flex items-center justify-between">
+            <span className="text-[12px] text-sub">입금액</span>
+            <div className="text-[15px] font-bold text-bright tabular-nums">
+              {parsedAmount.toLocaleString('ko-KR')}원
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full py-3 rounded-lg text-[14px] font-bold transition-all disabled:opacity-40 bg-sodam/20 text-sodam hover:bg-sodam/30 border border-sodam/30"
+        >
+          {isSubmitting ? '처리 중...' : '입금 기록'}
+        </button>
+      </form>
+    </Card>
+  )
+}

--- a/src/components/deposit/DepositTable.tsx
+++ b/src/components/deposit/DepositTable.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { formatKRW, formatDate } from '@/lib/format'
+import DepositEditPanel from './DepositEditPanel'
+import DepositDeleteModal from './DepositDeleteModal'
+
+export interface DepositRow {
+  id: string
+  accountId: string
+  amount: number
+  source: string
+  note: string | null
+  depositedAt: string
+  account: { name: string }
+}
+
+interface DepositTableProps {
+  deposits: DepositRow[]
+  total: number
+  limit: number
+  offset: number
+}
+
+const ACCOUNT_DOT_COLORS: Record<string, string> = {
+  '세진': 'bg-sejin',
+  '소담': 'bg-sodam',
+  '다솜': 'bg-dasom',
+}
+
+export default function DepositTable({ deposits, total, limit, offset }: DepositTableProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [editItem, setEditItem] = useState<DepositRow | null>(null)
+  const [deleteItem, setDeleteItem] = useState<DepositRow | null>(null)
+
+  const totalPages = Math.ceil(total / limit)
+  const currentPage = Math.floor(offset / limit) + 1
+
+  const goToPage = (page: number) => {
+    const params = new URLSearchParams(searchParams.toString())
+    const newOffset = (page - 1) * limit
+    if (newOffset > 0) {
+      params.set('offset', String(newOffset))
+    } else {
+      params.delete('offset')
+    }
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  if (total === 0) {
+    return (
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card p-12 text-center">
+        <div className="text-[14px] text-sub mb-4">입금 기록이 없습니다</div>
+        <button
+          onClick={() => router.push('/deposits/new')}
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-sodam/15 text-sodam text-[13px] font-semibold border border-sodam/25 hover:bg-sodam/25 transition-all"
+        >
+          + 입금 기록
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+        <div className="px-5 py-3.5 border-b border-border flex justify-between items-center">
+          <div className="text-[13px] font-bold text-bright">입금 목록</div>
+          <div className="text-[12px] text-sub">{total}건</div>
+        </div>
+
+        {/* Desktop table */}
+        <div className="overflow-x-auto hidden sm:block">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                {['입금일', '계좌', '금액', '출처', '메모', ''].map((col, i) => (
+                  <th
+                    key={i}
+                    className={`px-3 py-2.5 text-[11px] font-semibold text-sub tracking-wide uppercase border-b border-border bg-white/[0.02] ${
+                      i === 2 ? 'text-right' : 'text-left'
+                    } ${i === 0 ? 'pl-4' : ''} ${i === 5 ? 'pr-4 w-16' : ''}`}
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {deposits.map((d) => (
+                <tr key={d.id} className="hover:bg-white/[0.015]">
+                  <td className="pl-4 px-3 py-3 text-[13px] text-muted border-b border-white/[0.025] tabular-nums whitespace-nowrap">
+                    {formatDate(d.depositedAt)}
+                  </td>
+                  <td className="px-3 py-3 text-[13px] border-b border-white/[0.025]">
+                    <span className="flex items-center gap-1.5">
+                      <span className={`w-1.5 h-1.5 rounded-full ${ACCOUNT_DOT_COLORS[d.account.name] ?? 'bg-dim'}`} />
+                      <span className="text-muted">{d.account.name}</span>
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 text-right border-b border-white/[0.025]">
+                    <span className="text-[13px] font-semibold text-bright tabular-nums">
+                      {formatKRW(d.amount)}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 text-[13px] text-muted border-b border-white/[0.025]">
+                    {d.source}
+                  </td>
+                  <td className="px-3 py-3 text-[12px] text-dim border-b border-white/[0.025] max-w-[200px] truncate">
+                    {d.note ?? '-'}
+                  </td>
+                  <td className="pr-4 px-3 py-3 border-b border-white/[0.025]">
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => setEditItem(d)}
+                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-white/[0.05] transition-all"
+                        title="수정"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => setDeleteItem(d)}
+                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
+                        title="삭제"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
+                        </svg>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile card view */}
+        <div className="sm:hidden divide-y divide-white/[0.025]">
+          {deposits.map((d) => (
+            <div key={d.id} className="px-4 py-3.5 hover:bg-white/[0.015]">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <span className={`w-1.5 h-1.5 rounded-full ${ACCOUNT_DOT_COLORS[d.account.name] ?? 'bg-dim'}`} />
+                  <span className="text-[13px] font-bold text-bright">{d.account.name}</span>
+                  <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-white/[0.04]">{d.source}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => setEditItem(d)}
+                    className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-white/[0.05] transition-all"
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => setDeleteItem(d)}
+                    className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-[12px]">
+                <span className="text-dim tabular-nums">{formatDate(d.depositedAt)}</span>
+                <span className="text-bright font-semibold tabular-nums">{formatKRW(d.amount)}</span>
+              </div>
+              {d.note && (
+                <div className="text-[11px] text-dim mt-1 truncate">{d.note}</div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="px-5 py-3.5 border-t border-border flex items-center justify-between">
+            <div className="text-[12px] text-dim">
+              {offset + 1}–{Math.min(offset + limit, total)} / {total}건
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => goToPage(currentPage - 1)}
+                disabled={currentPage <= 1}
+                className="px-2.5 py-1.5 rounded-md text-[12px] text-sub border border-white/[0.06] hover:bg-white/[0.04] disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              >
+                이전
+              </button>
+              {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+                let page: number
+                if (totalPages <= 5) {
+                  page = i + 1
+                } else if (currentPage <= 3) {
+                  page = i + 1
+                } else if (currentPage >= totalPages - 2) {
+                  page = totalPages - 4 + i
+                } else {
+                  page = currentPage - 2 + i
+                }
+                return (
+                  <button
+                    key={page}
+                    onClick={() => goToPage(page)}
+                    className={`w-8 h-8 rounded-md text-[12px] font-semibold transition-all ${
+                      page === currentPage
+                        ? 'bg-white/[0.08] text-bright border border-white/[0.1]'
+                        : 'text-sub hover:bg-white/[0.04]'
+                    }`}
+                  >
+                    {page}
+                  </button>
+                )
+              })}
+              <button
+                onClick={() => goToPage(currentPage + 1)}
+                disabled={currentPage >= totalPages}
+                className="px-2.5 py-1.5 rounded-md text-[12px] text-sub border border-white/[0.06] hover:bg-white/[0.04] disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              >
+                다음
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {editItem && (
+        <DepositEditPanel deposit={editItem} onClose={() => setEditItem(null)} />
+      )}
+      {deleteItem && (
+        <DepositDeleteModal deposit={deleteItem} onClose={() => setDeleteItem(null)} />
+      )}
+    </>
+  )
+}

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -59,6 +59,16 @@ export default function BottomTab({ accounts }: BottomTabProps) {
           <span className="text-[11px] font-semibold">배당금</span>
         </Link>
 
+        <Link
+          href="/deposits"
+          className={`flex flex-col items-center gap-1 py-2 px-3 rounded-lg ${
+            pathname.startsWith('/deposits') ? 'text-bright' : 'text-dim'
+          }`}
+        >
+          <span className="text-lg">🎁</span>
+          <span className="text-[11px] font-semibold">입금</span>
+        </Link>
+
         {accounts.map((account) => (
           <Link
             key={account.id}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -78,6 +78,18 @@ export default function Sidebar({ accounts }: SidebarProps) {
           배당금
         </Link>
 
+        <Link
+          href="/deposits"
+          className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-[13px] font-medium transition-all border border-transparent
+            ${pathname.startsWith('/deposits')
+              ? 'bg-white/5 text-bright font-semibold border-border'
+              : 'text-sub hover:bg-white/[0.03] hover:text-muted'
+            }`}
+        >
+          <span className="text-[15px] w-5 text-center">🎁</span>
+          입금/증여
+        </Link>
+
         <div className="text-[10px] font-bold text-dim tracking-[1.5px] uppercase px-3 pt-4 pb-2">
           계좌
         </div>

--- a/src/lib/deposit-utils.ts
+++ b/src/lib/deposit-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * 입금/증여 유틸리티: 입력 검증, 출처 상수
+ */
+
+export const DEPOSIT_SOURCES = ['증여', '용돈', '배당재투자', '기타'] as const
+
+export interface DepositValidationError {
+  field: string
+  message: string
+}
+
+export function validateDepositInput(body: Record<string, unknown>): DepositValidationError[] {
+  const errors: DepositValidationError[] = []
+
+  if (!body.accountId || typeof body.accountId !== 'string') {
+    errors.push({ field: 'accountId', message: '계좌를 선택해주세요.' })
+  }
+  if (typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount <= 0) {
+    errors.push({ field: 'amount', message: '금액은 0보다 커야 합니다.' })
+  }
+  if (typeof body.source !== 'string' || !body.source.trim()) {
+    errors.push({ field: 'source', message: '출처를 입력해주세요.' })
+  }
+  if (!body.depositedAt || typeof body.depositedAt !== 'string' || isNaN(Date.parse(body.depositedAt))) {
+    errors.push({ field: 'depositedAt', message: '유효한 입금일을 입력해주세요.' })
+  }
+
+  return errors
+}


### PR DESCRIPTION
## Summary
- 입금/증여 CRUD API (GET/POST/PUT/DELETE) + 입력 검증
- DepositForm (계좌 선택, 금액, 출처 pill, 날짜, 메모)
- DepositTable (데스크톱 테이블 + 모바일 카드 + 페이지네이션)
- DepositEditPanel (슬라이드인 수정) + DepositDeleteModal (삭제 확인)
- DepositFilters (계좌/연도 필터)
- /deposits 페이지 (SSR + aggregate 총액 요약 + offset clamping)
- Sidebar + BottomTab 네비게이션 추가

Closes #19

## Checklist
- [x] ESLint 통과
- [x] TypeScript 타입체크 통과
- [x] 빌드 성공 (DB 없는 환경 prerender 제외)
- [x] 코드 리뷰 통과 (3회, P1/P2: 0건)

## Code Review
- 1차: P0=2, P1=3, P2=1
- 2차: P0=0, P1=0, P2=1 (Math.round 후 0원 저장 가능)
- 3차: P0=0, P1=0, P2=0 ✅

## Test plan
- [ ] `/deposits/new` → 입금 기록 생성 확인
- [ ] `/deposits` → 목록 표시, 필터(계좌/연도), 페이지네이션
- [ ] 수정 패널에서 금액/출처/날짜/메모 수정
- [ ] 삭제 모달에서 삭제 후 목록 반영 확인
- [ ] 모바일 뷰 카드 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)