### PR TITLE
[Phase 4-B] 증여세 대시보드 — 한도 게이지 + 10년 리셋 (#20)

### DIFF
--- a/src/app/api/tax/gift/route.ts
+++ b/src/app/api/tax/gift/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const accounts = await prisma.account.findMany({
+      select: {
+        id: true,
+        name: true,
+        ownerAge: true,
+        deposits: {
+          where: {
+            source: { in: GIFT_SOURCES },
+          },
+          select: { amount: true, source: true, depositedAt: true },
+          orderBy: { depositedAt: 'asc' },
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    const summaries = accounts.map((account) => {
+      const isMinor = account.ownerAge != null && account.ownerAge < 19
+      const summary = calcGiftTaxSummary(account.deposits, isMinor)
+
+      return {
+        accountId: account.id,
+        accountName: account.name,
+        ownerAge: account.ownerAge,
+        isMinor,
+        ...summary,
+        resetDate: summary.resetDate?.toISOString() ?? null,
+        firstGiftDate: summary.firstGiftDate?.toISOString() ?? null,
+      }
+    })
+
+    return NextResponse.json({ summaries })
+  } catch (error) {
+    console.error('GET /api/tax/gift error:', error)
+    return NextResponse.json({ error: '증여세 현황을 불러올 수 없습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/tax/page.tsx
+++ b/src/app/tax/page.tsx
@@ -1,0 +1,115 @@
+import { prisma } from '@/lib/prisma'
+import Header from '@/components/layout/Header'
+import GiftTaxGauge from '@/components/tax/GiftTaxGauge'
+import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
+
+export const dynamic = 'force-dynamic'
+
+export default async function TaxPage() {
+  const accounts = await prisma.account.findMany({
+    select: {
+      id: true,
+      name: true,
+      ownerAge: true,
+      deposits: {
+        where: {
+          source: { in: GIFT_SOURCES },
+        },
+        select: { amount: true, source: true, depositedAt: true },
+        orderBy: { depositedAt: 'asc' },
+      },
+    },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  const summaries = accounts.map((account) => {
+    const isMinor = account.ownerAge != null && account.ownerAge < 19
+    const summary = calcGiftTaxSummary(account.deposits, isMinor)
+
+    return {
+      accountId: account.id,
+      accountName: account.name,
+      ownerAge: account.ownerAge,
+      isMinor,
+      ...summary,
+      resetDate: summary.resetDate?.toISOString() ?? null,
+      firstGiftDate: summary.firstGiftDate?.toISOString() ?? null,
+    }
+  })
+
+  const minorAccounts = summaries.filter((s) => s.isMinor)
+  const adultGiftAccounts = summaries.filter((s) => !s.isMinor && s.totalGifted > 0)
+
+  return (
+    <div className="px-8 py-7 max-w-[960px]">
+      <Header title="세금 센터" sub="증여세 · 양도세 · 배당소득세" />
+
+      {/* 증여세 섹션 */}
+      <div className="mt-6">
+        <h2 className="text-[14px] font-bold text-bright mb-3">증여세 현황</h2>
+
+        {minorAccounts.length > 0 ? (
+          <div className="flex flex-col gap-4">
+            {minorAccounts.map((s) => (
+              <GiftTaxGauge
+                key={s.accountId}
+                accountName={s.accountName}
+                ownerAge={s.ownerAge}
+                isMinor={s.isMinor}
+                totalGifted={s.totalGifted}
+                exemptLimit={s.exemptLimit}
+                usageRate={s.usageRate}
+                remaining={s.remaining}
+                estimatedTax={s.estimatedTax}
+                resetDate={s.resetDate}
+                firstGiftDate={s.firstGiftDate}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="relative overflow-hidden rounded-[14px] border border-border bg-card p-8 text-center">
+            <div className="text-[13px] text-sub">미성년 계좌의 증여 기록이 없습니다</div>
+          </div>
+        )}
+
+        {/* 성인 계좌 증여 현황 */}
+        {adultGiftAccounts.length > 0 && (
+          <div className="mt-4">
+            <h3 className="text-[12px] font-semibold text-sub mb-2">성인 계좌</h3>
+            <div className="flex flex-col gap-4">
+              {adultGiftAccounts.map((s) => (
+                <GiftTaxGauge
+                  key={s.accountId}
+                  accountName={s.accountName}
+                  ownerAge={s.ownerAge}
+                  isMinor={s.isMinor}
+                  totalGifted={s.totalGifted}
+                  exemptLimit={s.exemptLimit}
+                  usageRate={s.usageRate}
+                  remaining={s.remaining}
+                  estimatedTax={s.estimatedTax}
+                  resetDate={s.resetDate}
+                  firstGiftDate={s.firstGiftDate}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Placeholder for future tax sections */}
+      <div className="mt-8 flex flex-col gap-3">
+        <div className="relative overflow-hidden rounded-[14px] border border-white/[0.04] bg-white/[0.015] px-5 py-4">
+          <span className="text-[13px] text-dim">양도소득세 계산기 — Phase 4-C에서 추가 예정</span>
+        </div>
+        <div className="relative overflow-hidden rounded-[14px] border border-white/[0.04] bg-white/[0.015] px-5 py-4">
+          <span className="text-[13px] text-dim">배당소득세 추적 — Phase 4-F에서 추가 예정</span>
+        </div>
+      </div>
+
+      <p className="text-[11px] text-dim mt-6">
+        세금 정보는 참고용이며 법적 조언이 아닙니다. 정확한 세금 계산은 세무사에게 문의하세요.
+      </p>
+    </div>
+  )
+}

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -69,6 +69,16 @@ export default function BottomTab({ accounts }: BottomTabProps) {
           <span className="text-[11px] font-semibold">입금</span>
         </Link>
 
+        <Link
+          href="/tax"
+          className={`flex flex-col items-center gap-1 py-2 px-3 rounded-lg ${
+            pathname.startsWith('/tax') ? 'text-bright' : 'text-dim'
+          }`}
+        >
+          <span className="text-lg">🧾</span>
+          <span className="text-[11px] font-semibold">세금</span>
+        </Link>
+
         {accounts.map((account) => (
           <Link
             key={account.id}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -90,6 +90,18 @@ export default function Sidebar({ accounts }: SidebarProps) {
           입금/증여
         </Link>
 
+        <Link
+          href="/tax"
+          className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-[13px] font-medium transition-all border border-transparent
+            ${pathname.startsWith('/tax')
+              ? 'bg-white/5 text-bright font-semibold border-border'
+              : 'text-sub hover:bg-white/[0.03] hover:text-muted'
+            }`}
+        >
+          <span className="text-[15px] w-5 text-center">🧾</span>
+          세금
+        </Link>
+
         <div className="text-[10px] font-bold text-dim tracking-[1.5px] uppercase px-3 pt-4 pb-2">
           계좌
         </div>

--- a/src/components/tax/GiftTaxGauge.tsx
+++ b/src/components/tax/GiftTaxGauge.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { formatKRW, formatDate } from '@/lib/format'
+
+interface GiftTaxGaugeProps {
+  accountName: string
+  ownerAge: number | null
+  isMinor: boolean
+  totalGifted: number
+  exemptLimit: number
+  usageRate: number
+  remaining: number
+  estimatedTax: number
+  resetDate: string | null
+  firstGiftDate: string | null
+}
+
+const ACCOUNT_COLORS: Record<string, { bar: string; text: string; bg: string }> = {
+  '세진': { bar: 'bg-sejin', text: 'text-sejin', bg: 'bg-sejin/10' },
+  '소담': { bar: 'bg-sodam', text: 'text-sodam', bg: 'bg-sodam/10' },
+  '다솜': { bar: 'bg-dasom', text: 'text-dasom', bg: 'bg-dasom/10' },
+}
+
+export default function GiftTaxGauge({
+  accountName,
+  ownerAge,
+  isMinor,
+  totalGifted,
+  exemptLimit,
+  usageRate,
+  remaining,
+  estimatedTax,
+  resetDate,
+  firstGiftDate,
+}: GiftTaxGaugeProps) {
+  const colors = ACCOUNT_COLORS[accountName] ?? { bar: 'bg-dim', text: 'text-muted', bg: 'bg-white/5' }
+  const clampedRate = Math.min(usageRate, 1)
+  const isOver = remaining < 0
+
+  return (
+    <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+      <div className="px-5 py-4">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2.5">
+            <span className={`text-[15px] font-bold ${colors.text}`}>{accountName}</span>
+            {ownerAge != null && (
+              <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-white/[0.04]">
+                {ownerAge}세 · {isMinor ? '미성년' : '성인'}
+              </span>
+            )}
+          </div>
+          <div className="text-right">
+            <div className={`text-[13px] font-bold tabular-nums ${isOver ? 'text-red-400' : 'text-bright'}`}>
+              {formatKRW(totalGifted)}
+            </div>
+            <div className="text-[11px] text-dim">
+              / {formatKRW(exemptLimit)}
+            </div>
+          </div>
+        </div>
+
+        {/* Gauge Bar */}
+        <div className="relative h-3 rounded-full bg-white/[0.04] overflow-hidden mb-3">
+          <div
+            className={`absolute inset-y-0 left-0 rounded-full transition-all duration-500 ${
+              isOver ? 'bg-red-400/80' : colors.bar
+            }`}
+            style={{ width: `${Math.min(clampedRate * 100, 100)}%` }}
+          />
+          {isOver && (
+            <div
+              className="absolute inset-y-0 rounded-full bg-red-500/30"
+              style={{ left: '100%', width: `${Math.min((usageRate - 1) * 100, 50)}%` }}
+            />
+          )}
+        </div>
+
+        {/* Usage percentage */}
+        <div className="flex items-center justify-between mb-4">
+          <span className={`text-[12px] font-semibold ${isOver ? 'text-red-400' : colors.text}`}>
+            {(usageRate * 100).toFixed(1)}% 사용
+          </span>
+          <span className={`text-[12px] tabular-nums ${isOver ? 'text-red-400' : 'text-sub'}`}>
+            {isOver ? `${formatKRW(Math.abs(remaining))} 초과` : `${formatKRW(remaining)} 잔여`}
+          </span>
+        </div>
+
+        {/* Details */}
+        <div className="grid grid-cols-2 gap-3">
+          {firstGiftDate && (
+            <div className="bg-white/[0.02] rounded-lg px-3 py-2.5">
+              <div className="text-[10px] text-dim mb-0.5">최초 증여일</div>
+              <div className="text-[12px] text-muted tabular-nums">{formatDate(firstGiftDate)}</div>
+            </div>
+          )}
+          {resetDate && (
+            <div className="bg-white/[0.02] rounded-lg px-3 py-2.5">
+              <div className="text-[10px] text-dim mb-0.5">10년 리셋</div>
+              <div className="text-[12px] text-muted tabular-nums">{formatDate(resetDate)}</div>
+            </div>
+          )}
+        </div>
+
+        {/* Estimated tax if over */}
+        {isOver && estimatedTax > 0 && (
+          <div className="mt-3 bg-red-500/10 border border-red-500/15 rounded-lg px-3.5 py-2.5 flex items-center justify-between">
+            <span className="text-[11px] text-red-400/80">예상 증여세</span>
+            <span className="text-[13px] font-bold text-red-400 tabular-nums">{formatKRW(estimatedTax)}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/tax/gift-tax.ts
+++ b/src/lib/tax/gift-tax.ts
@@ -1,0 +1,150 @@
+/**
+ * 증여세 계산 유틸리티
+ *
+ * 미성년(19세 미만): 10년간 2,000만원 비과세
+ * 성인(19세 이상): 10년간 5,000만원 비과세
+ * 초과 시 누진세율 적용
+ */
+
+/** 비과세 한도 (원) */
+export const GIFT_TAX_EXEMPT_MINOR = 20_000_000 // 미성년
+export const GIFT_TAX_EXEMPT_ADULT = 50_000_000 // 성인
+
+/** 증여로 인정되는 source 값 (소문자 기준, DB 쿼리에서도 사용) */
+export const GIFT_SOURCES = ['증여', 'gift']
+
+/** 누진세율 구간 */
+const GIFT_TAX_BRACKETS = [
+  { limit: 100_000_000, rate: 0.10 },  // 1억 이하 10%
+  { limit: 500_000_000, rate: 0.20 },  // 5억 이하 20%
+  { limit: 1_000_000_000, rate: 0.30 }, // 10억 이하 30%
+  { limit: 3_000_000_000, rate: 0.40 }, // 30억 이하 40%
+  { limit: Infinity, rate: 0.50 },      // 30억 초과 50%
+] as const
+
+export interface GiftTaxSummary {
+  /** 10년 윈도우 내 증여 총액 */
+  totalGifted: number
+  /** 비과세 한도 */
+  exemptLimit: number
+  /** 사용률 (0~1+) */
+  usageRate: number
+  /** 잔여 한도 (음수면 초과) */
+  remaining: number
+  /** 초과분에 대한 예상 세금 */
+  estimatedTax: number
+  /** 10년 리셋 시점 (윈도우 내 가장 오래된 증여일 + 10년) */
+  resetDate: Date | null
+  /** 전체 최초 증여일 */
+  firstGiftDate: Date | null
+}
+
+interface Deposit {
+  amount: number
+  source: string
+  depositedAt: Date | string
+}
+
+/** 날짜의 시각을 00:00:00으로 절삭 (날짜 단위 비교용) */
+function startOfDay(date: Date): Date {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+/** 캘린더 기준 N년 전 날짜 계산 (시각 절삭) */
+function subYears(date: Date, years: number): Date {
+  const result = startOfDay(date)
+  result.setFullYear(result.getFullYear() - years)
+  return result
+}
+
+function isGiftSource(source: string): boolean {
+  return GIFT_SOURCES.includes(source.toLowerCase())
+}
+
+/**
+ * 계좌의 증여세 현황 계산
+ * @param deposits 해당 계좌의 전체 입금 내역
+ * @param isMinor 미성년 여부
+ * @param referenceDate 기준일 (기본: 오늘)
+ */
+export function calcGiftTaxSummary(
+  deposits: Deposit[],
+  isMinor: boolean,
+  referenceDate: Date = new Date()
+): GiftTaxSummary {
+  const exemptLimit = isMinor ? GIFT_TAX_EXEMPT_MINOR : GIFT_TAX_EXEMPT_ADULT
+
+  // 증여 건만 필터 ('증여' 또는 'gift')
+  const gifts = deposits.filter((d) => isGiftSource(d.source))
+
+  if (gifts.length === 0) {
+    return {
+      totalGifted: 0,
+      exemptLimit,
+      usageRate: 0,
+      remaining: exemptLimit,
+      estimatedTax: 0,
+      resetDate: null,
+      firstGiftDate: null,
+    }
+  }
+
+  // 날짜 순 정렬
+  const sorted = [...gifts].sort(
+    (a, b) => new Date(a.depositedAt).getTime() - new Date(b.depositedAt).getTime()
+  )
+
+  const firstGiftDate = new Date(sorted[0].depositedAt)
+
+  // 캘린더 기준 10년 윈도우
+  const windowStart = subYears(referenceDate, 10)
+
+  // 10년 윈도우 내 증여만 (날짜 단위 비교 — 경계일 포함, 미래 제외)
+  const refDay = startOfDay(referenceDate)
+  const windowGifts = sorted.filter((d) => {
+    const day = startOfDay(new Date(d.depositedAt)).getTime()
+    return day >= windowStart.getTime() && day <= refDay.getTime()
+  })
+  const totalGifted = windowGifts.reduce((sum, d) => sum + d.amount, 0)
+
+  // 리셋 시점: 윈도우 내 가장 오래된 증여일 + 10년
+  const oldestInWindow = windowGifts.length > 0 ? new Date(windowGifts[0].depositedAt) : null
+  const resetDate = oldestInWindow
+    ? new Date(new Date(oldestInWindow).setFullYear(oldestInWindow.getFullYear() + 10))
+    : null
+
+  const remaining = exemptLimit - totalGifted
+  const usageRate = exemptLimit > 0 ? totalGifted / exemptLimit : 0
+  const estimatedTax = calcProgressiveTax(Math.max(0, totalGifted - exemptLimit))
+
+  return {
+    totalGifted,
+    exemptLimit,
+    usageRate,
+    remaining,
+    estimatedTax,
+    resetDate,
+    firstGiftDate,
+  }
+}
+
+/**
+ * 누진세율로 세금 계산
+ */
+export function calcProgressiveTax(taxableAmount: number): number {
+  if (taxableAmount <= 0) return 0
+
+  let tax = 0
+  let prev = 0
+
+  for (const bracket of GIFT_TAX_BRACKETS) {
+    const taxableInBracket = Math.min(taxableAmount, bracket.limit) - prev
+    if (taxableInBracket <= 0) break
+    tax += taxableInBracket * bracket.rate
+    prev = bracket.limit
+  }
+
+  return Math.round(tax)
+}


### PR DESCRIPTION
## Summary
- 증여세 계산 유틸 (`src/lib/tax/gift-tax.ts`): 비과세 한도, 누진세율, 10년 윈도우 계산
- API `GET /api/tax/gift`: 계좌별 증여세 요약 (DB 선필터)
- `GiftTaxGauge` 컴포넌트: 게이지 바 + 사용률 + 잔여/초과 표시 + 예상 세금
- `/tax` 페이지: 미성년/성인 계좌별 증여세 현황 + Phase 4-C/F placeholder + 면책 문구
- Sidebar + BottomTab 세금 메뉴 추가

Closes #20

## Checklist
- [x] ESLint 통과
- [x] TypeScript 타입체크 통과
- [x] 코드 리뷰 통과 (4회, P1/P2: 0건)

## Code Review
- 1차: P0=2, P1=4, P2=1
- 2차: P0=0, P1=2, P2=1 (GIFT_SOURCES 하드코딩 중복, 대소문자 취약, 경계일 시각 문제)
- 3차: P0=0, P1=1, P2=0 (미래 입금 합산)
- 4차: P0=0, P1=0, P2=0 ✅

## Test plan
- [ ] `/tax` 페이지 접근 → 소담/다솜 증여세 게이지 표시
- [ ] 게이지 바 사용률 정확한지 확인
- [ ] 10년 리셋 시점 표시 확인
- [ ] 세금 메뉴 사이드바/모바일 탭 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)