### PR TITLE
[Phase 4-C] 양도소득세 계산기 — 해외주식 + 국내 ETF (#21)

### DIFF
--- a/src/app/tax/page.tsx
+++ b/src/app/tax/page.tsx
@@ -1,20 +1,36 @@
 import { prisma } from '@/lib/prisma'
 import Header from '@/components/layout/Header'
 import GiftTaxGauge from '@/components/tax/GiftTaxGauge'
+import CapitalGainsSummary from '@/components/tax/CapitalGainsSummary'
+import RealizedGainsTable from '@/components/tax/RealizedGainsTable'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
+import { calcRealizedGains, calcCapitalGainsSummary } from '@/lib/tax/capital-gains-tax'
 
 export const dynamic = 'force-dynamic'
 
-export default async function TaxPage() {
+interface TaxPageProps {
+  searchParams: {
+    year?: string | string[]
+  }
+}
+
+function first(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v
+}
+
+export default async function TaxPage({ searchParams }: TaxPageProps) {
+  const currentYear = new Date().getFullYear()
+  const yearStr = first(searchParams.year)
+  const year = yearStr && /^\d{4}$/.test(yearStr) ? parseInt(yearStr) : currentYear
+
+  // 증여세 데이터
   const accounts = await prisma.account.findMany({
     select: {
       id: true,
       name: true,
       ownerAge: true,
       deposits: {
-        where: {
-          source: { in: GIFT_SOURCES },
-        },
+        where: { source: { in: GIFT_SOURCES } },
         select: { amount: true, source: true, depositedAt: true },
         orderBy: { depositedAt: 'asc' },
       },
@@ -22,10 +38,9 @@ export default async function TaxPage() {
     orderBy: { createdAt: 'asc' },
   })
 
-  const summaries = accounts.map((account) => {
+  const giftSummaries = accounts.map((account) => {
     const isMinor = account.ownerAge != null && account.ownerAge < 19
     const summary = calcGiftTaxSummary(account.deposits, isMinor)
-
     return {
       accountId: account.id,
       accountName: account.name,
@@ -37,15 +52,87 @@ export default async function TaxPage() {
     }
   })
 
-  const minorAccounts = summaries.filter((s) => s.isMinor)
-  const adultGiftAccounts = summaries.filter((s) => !s.isMinor && s.totalGifted > 0)
+  const minorAccounts = giftSummaries.filter((s) => s.isMinor)
+  const adultGiftAccounts = giftSummaries.filter((s) => !s.isMinor && s.totalGifted > 0)
+
+  // 양도소득세 데이터: 매도 거래가 있는 종목의 전체 거래 히스토리
+  // 해당 연도에 매도한 계좌+종목 조합 조회
+  const sellPairs = await prisma.trade.findMany({
+    where: {
+      type: 'SELL',
+      tradedAt: {
+        gte: new Date(`${year}-01-01`),
+        lt: new Date(`${year + 1}-01-01`),
+      },
+    },
+    select: { accountId: true, ticker: true },
+    distinct: ['accountId', 'ticker'],
+  })
+
+  // 각 계좌+종목의 전체 거래 히스토리 (해당 연도 말까지만)
+  const allTrades = sellPairs.length > 0
+    ? await prisma.trade.findMany({
+        where: {
+          OR: sellPairs.map((p) => ({
+            accountId: p.accountId,
+            ticker: p.ticker,
+          })),
+          tradedAt: { lt: new Date(`${year + 1}-01-01`) },
+        },
+        orderBy: [{ tradedAt: 'asc' }, { createdAt: 'asc' }],
+      })
+    : []
+
+  const realizedGains = calcRealizedGains(allTrades, year)
+  const capitalGainsSummary = calcCapitalGainsSummary(realizedGains)
+
+  // 연도 선택 옵션
+  const years = [currentYear, currentYear - 1, currentYear - 2]
 
   return (
     <div className="px-8 py-7 max-w-[960px]">
       <Header title="세금 센터" sub="증여세 · 양도세 · 배당소득세" />
 
+      {/* 연도 선택 */}
+      <div className="mt-5 mb-6 flex items-center gap-1 bg-white/[0.02] rounded-lg p-1 border border-white/[0.04] w-fit">
+        {years.map((y) => (
+          <a
+            key={y}
+            href={`/tax?year=${y}`}
+            className={`px-3 py-1.5 text-[12px] font-semibold rounded-md transition-all ${
+              year === y
+                ? 'bg-white/[0.07] text-bright'
+                : 'text-sub hover:text-muted hover:bg-white/[0.03]'
+            }`}
+          >
+            {y}
+          </a>
+        ))}
+      </div>
+
+      {/* 양도소득세 섹션 */}
+      <div className="mb-8">
+        <h2 className="text-[14px] font-bold text-bright mb-3">양도소득세 ({year}년)</h2>
+        <CapitalGainsSummary
+          year={year}
+          foreignStockGain={capitalGainsSummary.foreignStockGain}
+          foreignStockTaxable={capitalGainsSummary.foreignStockTaxable}
+          foreignStockTax={capitalGainsSummary.foreignStockTax}
+          krEtfGain={capitalGainsSummary.krEtfGain}
+          krEtfTax={capitalGainsSummary.krEtfTax}
+          totalEstimatedTax={capitalGainsSummary.totalEstimatedTax}
+          hasSales={realizedGains.length > 0}
+        />
+
+        {realizedGains.length > 0 && (
+          <div className="mt-4">
+            <RealizedGainsTable gains={realizedGains} />
+          </div>
+        )}
+      </div>
+
       {/* 증여세 섹션 */}
-      <div className="mt-6">
+      <div className="mb-8">
         <h2 className="text-[14px] font-bold text-bright mb-3">증여세 현황</h2>
 
         {minorAccounts.length > 0 ? (
@@ -72,7 +159,6 @@ export default async function TaxPage() {
           </div>
         )}
 
-        {/* 성인 계좌 증여 현황 */}
         {adultGiftAccounts.length > 0 && (
           <div className="mt-4">
             <h3 className="text-[12px] font-semibold text-sub mb-2">성인 계좌</h3>
@@ -97,17 +183,14 @@ export default async function TaxPage() {
         )}
       </div>
 
-      {/* Placeholder for future tax sections */}
-      <div className="mt-8 flex flex-col gap-3">
-        <div className="relative overflow-hidden rounded-[14px] border border-white/[0.04] bg-white/[0.015] px-5 py-4">
-          <span className="text-[13px] text-dim">양도소득세 계산기 — Phase 4-C에서 추가 예정</span>
-        </div>
+      {/* Placeholder */}
+      <div className="mb-6">
         <div className="relative overflow-hidden rounded-[14px] border border-white/[0.04] bg-white/[0.015] px-5 py-4">
           <span className="text-[13px] text-dim">배당소득세 추적 — Phase 4-F에서 추가 예정</span>
         </div>
       </div>
 
-      <p className="text-[11px] text-dim mt-6">
+      <p className="text-[11px] text-dim">
         세금 정보는 참고용이며 법적 조언이 아닙니다. 정확한 세금 계산은 세무사에게 문의하세요.
       </p>
     </div>

--- a/src/components/tax/CapitalGainsSummary.tsx
+++ b/src/components/tax/CapitalGainsSummary.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { formatKRW } from '@/lib/format'
+import {
+  FOREIGN_STOCK_DEDUCTION,
+  FOREIGN_STOCK_TAX_RATE,
+  KR_ETF_TAX_RATE,
+} from '@/lib/tax/capital-gains-tax'
+
+interface CapitalGainsSummaryProps {
+  year: number
+  foreignStockGain: number
+  foreignStockTaxable: number
+  foreignStockTax: number
+  krEtfGain: number
+  krEtfTax: number
+  totalEstimatedTax: number
+  hasSales: boolean
+}
+
+export default function CapitalGainsSummary({
+  year,
+  foreignStockGain,
+  foreignStockTaxable,
+  foreignStockTax,
+  krEtfGain,
+  krEtfTax,
+  totalEstimatedTax,
+  hasSales,
+}: CapitalGainsSummaryProps) {
+  if (!hasSales) {
+    return (
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card p-8 text-center">
+        <div className="text-[13px] text-sub">{year}년 매도 거래가 없습니다</div>
+      </div>
+    )
+  }
+
+  const hasForeign = foreignStockGain !== 0
+  const hasKrEtf = krEtfGain > 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 해외주식 */}
+      {hasForeign && (
+        <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+          <div className="px-5 py-4">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-[13px] font-bold text-bright">해외주식 양도소득세</h3>
+              <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-white/[0.04]">
+                {(FOREIGN_STOCK_TAX_RATE * 100).toFixed(0)}%
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-2.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">실현 손익</span>
+                <span className={`text-[13px] font-semibold tabular-nums ${
+                  foreignStockGain >= 0 ? 'text-green-400' : 'text-red-400'
+                }`}>
+                  {foreignStockGain >= 0 ? '+' : ''}{formatKRW(foreignStockGain)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">기본공제</span>
+                <span className="text-[12px] text-dim tabular-nums">-{formatKRW(FOREIGN_STOCK_DEDUCTION)}</span>
+              </div>
+              <div className="h-px bg-white/[0.04]" />
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">과세 대상</span>
+                <span className="text-[13px] font-semibold text-muted tabular-nums">
+                  {formatKRW(foreignStockTaxable)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] font-semibold text-sub">예상 세금</span>
+                <span className="text-[14px] font-bold text-bright tabular-nums">
+                  {formatKRW(foreignStockTax)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 국내 ETF */}
+      {hasKrEtf && (
+        <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+          <div className="px-5 py-4">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-[13px] font-bold text-bright">국내 ETF 배당소득세</h3>
+              <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-white/[0.04]">
+                {(KR_ETF_TAX_RATE * 100).toFixed(1)}%
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-2.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">매매 차익</span>
+                <span className="text-[13px] font-semibold text-green-400 tabular-nums">
+                  +{formatKRW(krEtfGain)}
+                </span>
+              </div>
+              <div className="h-px bg-white/[0.04]" />
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] font-semibold text-sub">예상 세금</span>
+                <span className="text-[14px] font-bold text-bright tabular-nums">
+                  {formatKRW(krEtfTax)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 합계 */}
+      {(hasForeign || hasKrEtf) && totalEstimatedTax > 0 && (
+        <div className="relative overflow-hidden rounded-[14px] border border-white/[0.08] bg-white/[0.02] px-5 py-4">
+          <div className="flex items-center justify-between">
+            <span className="text-[13px] font-bold text-sub">{year}년 예상 양도세 합계</span>
+            <span className="text-[17px] font-bold text-bright tabular-nums">
+              {formatKRW(totalEstimatedTax)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/tax/RealizedGainsTable.tsx
+++ b/src/components/tax/RealizedGainsTable.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { formatKRW, formatUSD, formatDate } from '@/lib/format'
+import type { RealizedGain } from '@/lib/tax/capital-gains-tax'
+
+interface RealizedGainsTableProps {
+  gains: RealizedGain[]
+}
+
+const MARKET_LABEL: Record<string, string> = {
+  US: '해외주식',
+  KR: '국내 ETF',
+}
+
+export default function RealizedGainsTable({ gains }: RealizedGainsTableProps) {
+  if (gains.length === 0) return null
+
+  const formatPrice = (amount: number, currency: string) =>
+    currency === 'USD' ? formatUSD(amount) : formatKRW(amount)
+
+  return (
+    <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+      <div className="px-5 py-3.5 border-b border-border flex justify-between items-center">
+        <div className="text-[13px] font-bold text-bright">매도 내역 상세</div>
+        <div className="text-[12px] text-sub">{gains.length}건</div>
+      </div>
+
+      {/* Desktop table */}
+      <div className="overflow-x-auto hidden sm:block">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              {['매도일', '종목', '구분', '수량', '매도가', '평균단가', '손익'].map((col, i) => (
+                <th
+                  key={i}
+                  className={`px-3 py-2.5 text-[11px] font-semibold text-sub tracking-wide uppercase border-b border-border bg-white/[0.02] ${
+                    i >= 3 ? 'text-right' : 'text-left'
+                  } ${i === 0 ? 'pl-4' : ''} ${i === 6 ? 'pr-4' : ''}`}
+                >
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {gains.map((g) => (
+              <tr key={g.tradeId} className="hover:bg-white/[0.015]">
+                <td className="pl-4 px-3 py-3 text-[13px] text-muted border-b border-white/[0.025] tabular-nums whitespace-nowrap">
+                  {formatDate(g.tradedAt)}
+                </td>
+                <td className="px-3 py-3 text-[13px] border-b border-white/[0.025]">
+                  <span className="font-bold text-bright">{g.displayName}</span>
+                  <span className="text-[11px] text-dim ml-1.5">{g.ticker}</span>
+                </td>
+                <td className="px-3 py-3 text-[11px] border-b border-white/[0.025]">
+                  <span className="px-1.5 py-0.5 rounded bg-white/[0.04] text-dim">
+                    {MARKET_LABEL[g.market] ?? g.market}
+                  </span>
+                </td>
+                <td className="px-3 py-3 text-right text-[12px] text-muted border-b border-white/[0.025] tabular-nums">
+                  {g.shares}주
+                </td>
+                <td className="px-3 py-3 text-right text-[12px] text-muted border-b border-white/[0.025] tabular-nums">
+                  {formatPrice(g.sellPrice, g.currency)}
+                </td>
+                <td className="px-3 py-3 text-right text-[12px] text-dim border-b border-white/[0.025] tabular-nums">
+                  {formatPrice(g.avgCostPrice, g.currency)}
+                </td>
+                <td className="pr-4 px-3 py-3 text-right border-b border-white/[0.025]">
+                  <span className={`text-[13px] font-semibold tabular-nums ${
+                    g.realizedGainKRW >= 0 ? 'text-green-400' : 'text-red-400'
+                  }`}>
+                    {g.realizedGainKRW >= 0 ? '+' : ''}{formatKRW(g.realizedGainKRW)}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile card view */}
+      <div className="sm:hidden divide-y divide-white/[0.025]">
+        {gains.map((g) => (
+          <div key={g.tradeId} className="px-4 py-3.5 hover:bg-white/[0.015]">
+            <div className="flex items-center justify-between mb-1.5">
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-bold text-bright">{g.displayName}</span>
+                <span className="text-[10px] text-dim px-1 py-0.5 rounded bg-white/[0.04]">
+                  {MARKET_LABEL[g.market] ?? g.market}
+                </span>
+              </div>
+              <span className={`text-[13px] font-semibold tabular-nums ${
+                g.realizedGainKRW >= 0 ? 'text-green-400' : 'text-red-400'
+              }`}>
+                {g.realizedGainKRW >= 0 ? '+' : ''}{formatKRW(g.realizedGainKRW)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-[11px] text-dim">
+              <span className="tabular-nums">{formatDate(g.tradedAt)} · {g.shares}주</span>
+              <span className="tabular-nums">
+                {formatPrice(g.avgCostPrice, g.currency)} → {formatPrice(g.sellPrice, g.currency)}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/tax/capital-gains-tax.ts
+++ b/src/lib/tax/capital-gains-tax.ts
@@ -1,0 +1,187 @@
+/**
+ * 양도소득세 계산 유틸리티
+ *
+ * 해외주식: 연 250만원 기본공제, 초과분 22% (양도소득세 20% + 지방소득세 2%)
+ * 국내 해외주식형 ETF: 매매차익 15.4% (배당소득세)
+ * 손익통산: 해외주식 간 가능
+ */
+
+/** 해외주식 기본공제 (원) */
+export const FOREIGN_STOCK_DEDUCTION = 2_500_000
+
+/** 해외주식 양도소득세율 (20% + 지방소득세 2%) */
+export const FOREIGN_STOCK_TAX_RATE = 0.22
+
+/** 국내 ETF 배당소득세율 */
+export const KR_ETF_TAX_RATE = 0.154
+
+/** 금융소득종합과세 기준선 */
+export const FINANCIAL_INCOME_THRESHOLD = 20_000_000
+
+interface TradeRecord {
+  id: string
+  accountId: string
+  ticker: string
+  displayName: string
+  market: string
+  type: string       // "BUY" | "SELL"
+  shares: number
+  price: number      // 원본 통화 단가
+  currency: string   // "USD" | "KRW"
+  fxRate: number | null
+  totalKRW: number
+  tradedAt: Date | string
+  createdAt: Date | string
+}
+
+export interface RealizedGain {
+  tradeId: string
+  ticker: string
+  displayName: string
+  market: string
+  currency: string
+  shares: number
+  sellPrice: number       // 매도 단가 (원본 통화)
+  avgCostPrice: number    // 매입 평균단가 (원본 통화)
+  sellFxRate: number | null
+  avgCostFxRate: number | null
+  proceedsKRW: number    // 매도 총액 (원화)
+  costBasisKRW: number   // 매입 총액 (원화)
+  realizedGainKRW: number // 실현 손익 (원화)
+  tradedAt: string
+}
+
+export interface CapitalGainsSummary {
+  /** 해외주식 실현 손익 합계 */
+  foreignStockGain: number
+  /** 해외주식 공제 후 과세 대상 */
+  foreignStockTaxable: number
+  /** 해외주식 예상 세금 */
+  foreignStockTax: number
+  /** 국내 ETF 실현 이익 합계 */
+  krEtfGain: number
+  /** 국내 ETF 예상 세금 */
+  krEtfTax: number
+  /** 총 예상 세금 */
+  totalEstimatedTax: number
+  /** 개별 매도 거래별 실현 손익 */
+  realizedGains: RealizedGain[]
+}
+
+/**
+ * 이동평균법 기반 실현 손익 계산
+ * trades: 해당 연도의 모든 관련 거래 (ticker 무관, tradedAt 오름차순)
+ * 전체 거래 히스토리를 순회하여 각 SELL 시점의 avgPrice 추적
+ */
+export function calcRealizedGains(allTrades: TradeRecord[], year: number): RealizedGain[] {
+  // accountId + ticker 단위로 그룹핑 (계좌별 평균단가 분리)
+  const byKey = new Map<string, TradeRecord[]>()
+  for (const t of allTrades) {
+    const key = `${t.accountId}:${t.ticker}`
+    const list = byKey.get(key) ?? []
+    list.push(t)
+    byKey.set(key, list)
+  }
+
+  const gains: RealizedGain[] = []
+
+  for (const trades of Array.from(byKey.values())) {
+    // tradedAt + createdAt 오름차순 정렬 (같은 날 BUY/SELL 순서 결정적)
+    const sorted = [...trades].sort((a, b) => {
+      const dateDiff = new Date(a.tradedAt).getTime() - new Date(b.tradedAt).getTime()
+      if (dateDiff !== 0) return dateDiff
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    })
+
+    let shares = 0
+    let avgPriceFx = 0  // USD 원본 통화 평균단가
+    let avgFxRate = 0   // 가중평균 환율
+    let avgPrice = 0    // KRW 평균단가
+
+    for (const trade of sorted) {
+      if (trade.type === 'BUY') {
+        if (trade.currency === 'USD') {
+          const fxRate = trade.fxRate ?? 0
+          const newShares = shares + trade.shares
+          avgPriceFx = newShares > 0
+            ? (shares * avgPriceFx + trade.shares * trade.price) / newShares
+            : 0
+          avgFxRate = newShares > 0
+            ? (shares * avgFxRate + trade.shares * fxRate) / newShares
+            : 0
+          avgPrice = Math.round(avgPriceFx * avgFxRate)
+          shares = newShares
+        } else {
+          const newShares = shares + trade.shares
+          avgPrice = newShares > 0
+            ? Math.round((shares * avgPrice + trade.shares * trade.price) / newShares)
+            : 0
+          shares = newShares
+        }
+      } else if (trade.type === 'SELL') {
+        const tradedAt = new Date(trade.tradedAt)
+        const tradeYear = tradedAt.getUTCFullYear()
+
+        // 매도 시점의 손익 계산
+        const proceedsKRW = trade.totalKRW
+        const costBasisKRW = avgPrice * trade.shares
+
+        // 해당 연도 매도만 결과에 포함
+        if (tradeYear === year) {
+          gains.push({
+            tradeId: trade.id,
+            ticker: trade.ticker,
+            displayName: trade.displayName,
+            market: trade.market,
+            currency: trade.currency,
+            shares: trade.shares,
+            sellPrice: trade.price,
+            avgCostPrice: trade.currency === 'USD' ? avgPriceFx : avgPrice,
+            sellFxRate: trade.fxRate,
+            avgCostFxRate: trade.currency === 'USD' ? avgFxRate : null,
+            proceedsKRW,
+            costBasisKRW,
+            realizedGainKRW: proceedsKRW - costBasisKRW,
+            tradedAt: tradedAt.toISOString(),
+          })
+        }
+
+        // 수량 차감 (avgPrice 불변 — 이동평균법)
+        shares -= trade.shares
+      }
+    }
+  }
+
+  // 매도일 기준 정렬
+  gains.sort((a, b) => new Date(a.tradedAt).getTime() - new Date(b.tradedAt).getTime())
+
+  return gains
+}
+
+/**
+ * 연간 양도소득세 요약 계산
+ */
+export function calcCapitalGainsSummary(realizedGains: RealizedGain[]): CapitalGainsSummary {
+  // 해외주식 (US market): 손익통산 가능
+  const foreignGains = realizedGains.filter((g) => g.market === 'US')
+  const foreignStockGain = foreignGains.reduce((s, g) => s + g.realizedGainKRW, 0)
+  const foreignStockTaxable = Math.max(0, foreignStockGain - FOREIGN_STOCK_DEDUCTION)
+  const foreignStockTax = Math.round(foreignStockTaxable * FOREIGN_STOCK_TAX_RATE)
+
+  // 국내 해외주식형 ETF (KR market): 이익에만 과세
+  // 현재 KR 종목은 모두 해외주식형 ETF (SOL 다우존스, SOL 미국채혼합 등)
+  // TODO: KR 일반주식 추가 시 ETF 여부 구분 필드 필요
+  const krEtfGains = realizedGains.filter((g) => g.market === 'KR')
+  const krEtfGain = Math.max(0, krEtfGains.reduce((s, g) => s + g.realizedGainKRW, 0))
+  const krEtfTax = Math.round(krEtfGain * KR_ETF_TAX_RATE)
+
+  return {
+    foreignStockGain,
+    foreignStockTaxable,
+    foreignStockTax,
+    krEtfGain,
+    krEtfTax,
+    totalEstimatedTax: foreignStockTax + krEtfTax,
+    realizedGains,
+  }
+}


### PR DESCRIPTION
## Summary
- 이동평균법 기반 실현 손익 계산 (`capital-gains-tax.ts`)
  - accountId+ticker 그룹핑으로 계좌별 평균단가 분리
  - 해외주식: 연 250만 공제 + 22% (손익통산 적용)
  - 국내 ETF: 매매차익 15.4%
- `CapitalGainsSummary` 컴포넌트: 해외주식/국내 ETF 세금 카드 + 합계
- `RealizedGainsTable`: 매도 내역 상세 (데스크톱+모바일)
- `/tax` 페이지에 연도 선택 + 양도소득세 섹션 추가

Closes #21

## Checklist
- [x] ESLint 통과
- [x] TypeScript 타입체크 통과
- [x] 코드 리뷰 통과 (2회, P1/P2: 0건)

## Code Review
- 1차: P0=2, P1=5, P2=0 (계좌 미분리, KR 일반주 혼재, 비결정적 정렬, 빈상태 오표기, 쿼리 무제한)
- 2차: P0=0, P1=0, P2=0 ✅

## Test plan
- [ ] `/tax` 페이지 → 양도소득세 섹션 표시
- [ ] 연도 선택 (2026/2025/2024) 전환 확인
- [ ] 매도 거래 없을 때 "매도 거래가 없습니다" 표시
- [ ] 매도 거래 있을 때 실현 손익 + 예상 세금 표시
- [ ] 매도 내역 상세 테이블 데스크톱/모바일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)