### PR TITLE
[Phase 4-D] RSU 근로소득세 추정 (#22)

### DIFF
--- a/src/app/tax/page.tsx
+++ b/src/app/tax/page.tsx
@@ -3,8 +3,10 @@ import Header from '@/components/layout/Header'
 import GiftTaxGauge from '@/components/tax/GiftTaxGauge'
 import CapitalGainsSummary from '@/components/tax/CapitalGainsSummary'
 import RealizedGainsTable from '@/components/tax/RealizedGainsTable'
+import RSUTaxCard from '@/components/tax/RSUTaxCard'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
 import { calcRealizedGains, calcCapitalGainsSummary } from '@/lib/tax/capital-gains-tax'
+import { calcRSUTaxSummary } from '@/lib/tax/income-tax'
 
 export const dynamic = 'force-dynamic'
 
@@ -86,12 +88,35 @@ export default async function TaxPage({ searchParams }: TaxPageProps) {
   const realizedGains = calcRealizedGains(allTrades, year)
   const capitalGainsSummary = calcCapitalGainsSummary(realizedGains)
 
+  // RSU 근로소득세 데이터: 해당 연도 베스팅 스케줄
+  const rsuSchedules = await prisma.rSUSchedule.findMany({
+    where: {
+      vestingDate: {
+        gte: new Date(`${year}-01-01`),
+        lt: new Date(`${year + 1}-01-01`),
+      },
+    },
+    orderBy: { vestingDate: 'asc' },
+  })
+
+  const rsuTaxSummary = calcRSUTaxSummary(
+    rsuSchedules.map((s) => ({
+      id: s.id,
+      vestingDate: s.vestingDate,
+      shares: s.shares,
+      vestPrice: s.vestPrice,
+      basisPrice: s.basisPrice,
+      basisValue: s.basisValue,
+      status: s.status,
+    }))
+  )
+
   // 연도 선택 옵션
   const years = [currentYear, currentYear - 1, currentYear - 2]
 
   return (
     <div className="px-8 py-7 max-w-[960px]">
-      <Header title="세금 센터" sub="증여세 · 양도세 · 배당소득세" />
+      <Header title="세금 센터" sub="양도세 · RSU 근로소득세 · 증여세 · 배당소득세" />
 
       {/* 연도 선택 */}
       <div className="mt-5 mb-6 flex items-center gap-1 bg-white/[0.02] rounded-lg p-1 border border-white/[0.04] w-fit">
@@ -129,6 +154,16 @@ export default async function TaxPage({ searchParams }: TaxPageProps) {
             <RealizedGainsTable gains={realizedGains} />
           </div>
         )}
+      </div>
+
+      {/* RSU 근로소득세 섹션 */}
+      <div className="mb-8">
+        <h2 className="text-[14px] font-bold text-bright mb-3">RSU 근로소득세 ({year}년)</h2>
+        <RSUTaxCard
+          estimates={rsuTaxSummary.estimates}
+          totalGrossIncome={rsuTaxSummary.totalGrossIncome}
+          totalTax={rsuTaxSummary.totalTax}
+        />
       </div>
 
       {/* 증여세 섹션 */}

--- a/src/components/tax/RSUTaxCard.tsx
+++ b/src/components/tax/RSUTaxCard.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { formatKRW, formatDate, formatPercent } from '@/lib/format'
+import type { RSUTaxEstimate } from '@/lib/tax/income-tax'
+
+interface RSUTaxCardProps {
+  estimates: RSUTaxEstimate[]
+  totalGrossIncome: number
+  totalTax: number
+}
+
+export default function RSUTaxCard({ estimates, totalGrossIncome, totalTax }: RSUTaxCardProps) {
+  if (estimates.length === 0) {
+    return (
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card p-8 text-center">
+        <div className="text-[13px] text-sub">RSU 베스팅 스케줄이 없습니다</div>
+      </div>
+    )
+  }
+
+  const totalEffectiveRate = totalGrossIncome > 0 ? (totalTax / totalGrossIncome) * 100 : 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 개별 RSU */}
+      {estimates.map((e) => (
+        <div key={e.scheduleId} className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+          <div className="px-5 py-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-bold text-bright">
+                  RSU 베스팅
+                </span>
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                  e.status === 'vested'
+                    ? 'bg-green-500/10 text-green-400'
+                    : 'bg-yellow-500/10 text-yellow-400'
+                }`}>
+                  {e.status === 'vested' ? '베스팅 완료' : '대기중'}
+                </span>
+              </div>
+              <span className="text-[12px] text-dim tabular-nums">
+                {formatDate(e.vestingDate)}
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">수량</span>
+                <span className="text-[12px] text-muted tabular-nums">{e.shares}주</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">
+                  {e.status === 'vested' ? '베스팅가' : '예상가'}
+                </span>
+                <span className="text-[12px] text-muted tabular-nums">
+                  {e.vestPrice != null ? formatKRW(e.vestPrice) : '-'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">근로소득</span>
+                <span className="text-[13px] font-semibold text-bright tabular-nums">
+                  {formatKRW(e.grossIncome)}
+                </span>
+              </div>
+              <div className="h-px bg-white/[0.04]" />
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">소득세</span>
+                <span className="text-[12px] text-muted tabular-nums">{formatKRW(e.incomeTax)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-sub">지방소득세</span>
+                <span className="text-[12px] text-dim tabular-nums">{formatKRW(e.localTax)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] font-semibold text-sub">예상 세금</span>
+                <div className="text-right">
+                  <span className="text-[14px] font-bold text-bright tabular-nums">{formatKRW(e.totalTax)}</span>
+                  <span className="text-[11px] text-dim ml-1.5">
+                    ({formatPercent(e.effectiveRate * 100)})
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {e.status === 'pending' && e.vestPrice == null && e.grossIncome === 0 && (
+              <div className="mt-3 bg-white/[0.02] border border-white/[0.06] rounded-lg px-3 py-2">
+                <span className="text-[11px] text-dim">
+                  예상 베스팅가 미설정. RSU 관리에서 기준가를 입력하면 세금이 추정됩니다.
+                </span>
+              </div>
+            )}
+            {e.status === 'pending' && e.grossIncome > 0 && (
+              <div className="mt-3 bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-2">
+                <span className="text-[11px] text-yellow-400/70">
+                  베스팅 전 예상치입니다. 실제 세금은 베스팅일 종가에 따라 변동됩니다.
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+
+      {/* 합계 */}
+      {estimates.length > 1 && totalTax > 0 && (
+        <div className="relative overflow-hidden rounded-[14px] border border-white/[0.08] bg-white/[0.02] px-5 py-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] text-sub">총 근로소득</span>
+              <span className="text-[13px] font-semibold text-muted tabular-nums">{formatKRW(totalGrossIncome)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-[13px] font-bold text-sub">총 예상 세금</span>
+              <div className="text-right">
+                <span className="text-[17px] font-bold text-bright tabular-nums">{formatKRW(totalTax)}</span>
+                <span className="text-[11px] text-dim ml-1.5">
+                  (실효 {totalEffectiveRate.toFixed(1)}%)
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/tax/income-tax.ts
+++ b/src/lib/tax/income-tax.ts
@@ -1,0 +1,119 @@
+/**
+ * 근로소득세 계산 유틸리티
+ *
+ * RSU 베스팅 시 근로소득 = 베스팅일 종가 × 수량
+ * 회사에서 원천징수 (소득세율 적용)
+ * 베스팅 직후 매도 시: 취득가 ≈ 매도가 → 양도차익 ≈ 0
+ */
+
+/** 근로소득세 누진세율 구간 (2024~2026년 동일) */
+const INCOME_TAX_BRACKETS = [
+  { limit: 14_000_000, rate: 0.06 },     // 1,400만 이하 6%
+  { limit: 50_000_000, rate: 0.15 },     // 5,000만 이하 15%
+  { limit: 88_000_000, rate: 0.24 },     // 8,800만 이하 24%
+  { limit: 150_000_000, rate: 0.35 },    // 1.5억 이하 35%
+  { limit: 300_000_000, rate: 0.38 },    // 3억 이하 38%
+  { limit: 500_000_000, rate: 0.40 },    // 5억 이하 40%
+  { limit: 1_000_000_000, rate: 0.42 },  // 10억 이하 42%
+  { limit: Infinity, rate: 0.45 },        // 10억 초과 45%
+] as const
+
+/** 지방소득세율 (소득세의 10%) */
+const LOCAL_TAX_RATE = 0.10
+
+export interface RSUTaxEstimate {
+  /** RSU ID */
+  scheduleId: string
+  /** 베스팅일 */
+  vestingDate: string
+  /** 수량 */
+  shares: number
+  /** 베스팅 가격 (1주당) */
+  vestPrice: number | null
+  /** 근로소득 (vestPrice × shares) */
+  grossIncome: number
+  /** 예상 소득세 (누진세율) */
+  incomeTax: number
+  /** 예상 지방소득세 */
+  localTax: number
+  /** 총 예상 세금 */
+  totalTax: number
+  /** 실효세율 */
+  effectiveRate: number
+  /** 상태 */
+  status: string
+}
+
+export interface RSUTaxSummary {
+  /** 개별 RSU 세금 추정 */
+  estimates: RSUTaxEstimate[]
+  /** 총 근로소득 */
+  totalGrossIncome: number
+  /** 총 예상 세금 */
+  totalTax: number
+}
+
+interface RSUScheduleInput {
+  id: string
+  vestingDate: Date | string
+  shares: number
+  vestPrice: number | null
+  basisPrice: number | null
+  basisValue: number | null
+  status: string
+}
+
+/**
+ * 누진세율로 소득세 계산
+ */
+export function calcIncomeTax(taxableIncome: number): number {
+  if (taxableIncome <= 0) return 0
+
+  let tax = 0
+  let prev = 0
+
+  for (const bracket of INCOME_TAX_BRACKETS) {
+    const taxableInBracket = Math.min(taxableIncome, bracket.limit) - prev
+    if (taxableInBracket <= 0) break
+    tax += taxableInBracket * bracket.rate
+    prev = bracket.limit
+  }
+
+  return Math.round(tax)
+}
+
+/**
+ * RSU 스케줄 목록에서 세금 추정 계산
+ * - vested: vestPrice 사용
+ * - pending: basisPrice (예상가) 사용
+ */
+export function calcRSUTaxSummary(schedules: RSUScheduleInput[]): RSUTaxSummary {
+  const estimates: RSUTaxEstimate[] = schedules.map((s) => {
+    const basisFallback = s.basisPrice ?? (s.basisValue != null && s.shares > 0 ? s.basisValue / s.shares : null)
+    const price = s.status === 'vested' ? s.vestPrice : (s.vestPrice ?? basisFallback)
+    const grossIncome = price != null ? Math.round(price * s.shares) : 0
+
+    const incomeTax = calcIncomeTax(grossIncome)
+    const localTax = Math.round(incomeTax * LOCAL_TAX_RATE)
+    const totalTax = incomeTax + localTax
+    const effectiveRate = grossIncome > 0 ? totalTax / grossIncome : 0
+
+    return {
+      scheduleId: s.id,
+      vestingDate: new Date(s.vestingDate).toISOString(),
+      shares: s.shares,
+      vestPrice: price,
+      grossIncome,
+      incomeTax,
+      localTax,
+      totalTax,
+      effectiveRate,
+      status: s.status,
+    }
+  })
+
+  const totalGrossIncome = estimates.reduce((s, e) => s + e.grossIncome, 0)
+  const totalTax = estimates.reduce((s, e) => s + e.totalTax, 0)
+
+  return { estimates, totalGrossIncome, totalTax }
+}


### PR DESCRIPTION
## Summary
- 근로소득세 누진세율(6~45%) + 지방소득세 10% 계산 유틸리티 (`income-tax.ts`)
- RSU 베스팅별 세금 추정 카드 컴포넌트 (`RSUTaxCard.tsx`)
- 세금 센터 페이지에 RSU 섹션 통합 (연도별 베스팅 스케줄 조회)
- `basisValue/shares` 폴백으로 `basisPrice` null 대응
- pending 상태에서 가격 미설정 시 별도 안내 메시지

Closes #22

## Checklist
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` — 컴파일 성공 (DB 미연결로 prerender만 실패, 기존 환경 이슈)
- [x] 코드 리뷰 2회 (P1: 3건 → 0건, P2: 0건)

## Code Review
- 1차: P1 3건 (누진세 합산 방식, basisPrice null 폴백, 세율 연도 주석), P0 2건
- 2차: P1/P2 0건 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)