### PR TITLE
[Phase 4-E] 매도 전 세금 미리보기 (#23)

### DIFF
--- a/src/app/tax/page.tsx
+++ b/src/app/tax/page.tsx
@@ -4,6 +4,7 @@ import GiftTaxGauge from '@/components/tax/GiftTaxGauge'
 import CapitalGainsSummary from '@/components/tax/CapitalGainsSummary'
 import RealizedGainsTable from '@/components/tax/RealizedGainsTable'
 import RSUTaxCard from '@/components/tax/RSUTaxCard'
+import SellTaxSimulator from '@/components/tax/SellTaxSimulator'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
 import { calcRealizedGains, calcCapitalGainsSummary } from '@/lib/tax/capital-gains-tax'
 import { calcRSUTaxSummary } from '@/lib/tax/income-tax'
@@ -111,6 +112,36 @@ export default async function TaxPage({ searchParams }: TaxPageProps) {
     }))
   )
 
+  // 매도 시뮬레이터 데이터: 보유종목 + 현재가 + 현재환율
+  const holdings = await prisma.holding.findMany({
+    where: { shares: { gt: 0 } },
+    include: { account: { select: { name: true } } },
+    orderBy: [{ accountId: 'asc' }, { ticker: 'asc' }],
+  })
+
+  const tickers = Array.from(new Set(holdings.map((h) => h.ticker)))
+  const priceCaches = await prisma.priceCache.findMany({
+    where: { ticker: { in: [...tickers, 'USDKRW=X'] } },
+    select: { ticker: true, price: true },
+  })
+  const priceMap = new Map(priceCaches.map((p) => [p.ticker, p.price]))
+  const currentFxRate = priceMap.get('USDKRW=X') ?? null
+
+  const holdingOptions = holdings.map((h) => ({
+    id: h.id,
+    accountName: h.account.name,
+    ticker: h.ticker,
+    displayName: h.displayName,
+    market: h.market,
+    currency: h.currency,
+    shares: h.shares,
+    avgPrice: h.avgPrice,
+    avgPriceFx: h.avgPriceFx,
+    avgFxRate: h.avgFxRate,
+    currentPrice: priceMap.get(h.ticker) ?? null,
+    currentFxRate: h.currency === 'USD' ? currentFxRate : null,
+  }))
+
   // 연도 선택 옵션
   const years = [currentYear, currentYear - 1, currentYear - 2]
 
@@ -213,6 +244,23 @@ export default async function TaxPage({ searchParams }: TaxPageProps) {
                   firstGiftDate={s.firstGiftDate}
                 />
               ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 매도 전 세금 미리보기 (현재 연도만) */}
+      <div className="mb-8">
+        <h2 className="text-[14px] font-bold text-bright mb-3">매도 전 세금 미리보기</h2>
+        {year === currentYear ? (
+          <SellTaxSimulator
+            holdings={holdingOptions}
+            ytdForeignGain={capitalGainsSummary.foreignStockGain}
+          />
+        ) : (
+          <div className="relative overflow-hidden rounded-[14px] border border-border bg-card p-8 text-center">
+            <div className="text-[13px] text-sub">
+              매도 시뮬레이션은 현재 연도({currentYear}년)에서만 사용할 수 있습니다
             </div>
           </div>
         )}

--- a/src/components/tax/SellTaxSimulator.tsx
+++ b/src/components/tax/SellTaxSimulator.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { formatKRW, formatUSD } from '@/lib/format'
+import { simulateSellTax } from '@/lib/tax/sell-simulator'
+import {
+  FOREIGN_STOCK_DEDUCTION,
+  FOREIGN_STOCK_TAX_RATE,
+  KR_ETF_TAX_RATE,
+} from '@/lib/tax/capital-gains-tax'
+
+interface HoldingOption {
+  id: string
+  accountName: string
+  ticker: string
+  displayName: string
+  market: string
+  currency: string
+  shares: number
+  avgPrice: number
+  avgPriceFx: number | null
+  avgFxRate: number | null
+  currentPrice: number | null
+  currentFxRate: number | null
+}
+
+interface SellTaxSimulatorProps {
+  holdings: HoldingOption[]
+  ytdForeignGain: number
+}
+
+export default function SellTaxSimulator({ holdings, ytdForeignGain }: SellTaxSimulatorProps) {
+  const [selectedId, setSelectedId] = useState('')
+  const [sellShares, setSellShares] = useState('')
+  const [sellPrice, setSellPrice] = useState('')
+  const [sellFxRate, setSellFxRate] = useState('')
+
+  const selected = holdings.find((h) => h.id === selectedId) ?? null
+
+  // 종목 선택 시 현재가/환율 자동 세팅
+  const handleSelect = (id: string) => {
+    setSelectedId(id)
+    setSellShares('')
+    const h = holdings.find((x) => x.id === id)
+    if (h) {
+      setSellPrice(h.currentPrice != null ? String(h.currentPrice) : '')
+      setSellFxRate(h.currentFxRate != null ? String(h.currentFxRate) : '')
+    }
+  }
+
+  const rawShares = Number(sellShares)
+  const parsedShares = Number.isInteger(rawShares) && rawShares > 0 ? rawShares : 0
+  const parsedPrice = parseFloat(sellPrice) || 0
+  const parsedFxRate = parseFloat(sellFxRate) || 0
+
+  const isValid = selected != null
+    && parsedShares > 0
+    && parsedShares <= selected.shares
+    && parsedPrice > 0
+    && (selected.currency !== 'USD' || parsedFxRate > 0)
+
+  const result = useMemo(() => {
+    if (!isValid || !selected) return null
+    return simulateSellTax({
+      market: selected.market,
+      currency: selected.currency,
+      sellShares: parsedShares,
+      sellPrice: parsedPrice,
+      sellFxRate: selected.currency === 'USD' ? parsedFxRate : null,
+      avgPrice: selected.avgPrice,
+      avgPriceFx: selected.avgPriceFx,
+      avgFxRate: selected.avgFxRate,
+      ytdForeignGain,
+    })
+  }, [isValid, selected, parsedShares, parsedPrice, parsedFxRate, ytdForeignGain])
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 입력 영역 */}
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+        <div className="px-5 py-3.5 border-b border-border">
+          <div className="text-[13px] font-bold text-bright">매도 시뮬레이션</div>
+        </div>
+
+        <div className="px-5 py-4 flex flex-col gap-4">
+          {/* 종목 선택 */}
+          <div>
+            <label className="text-[12px] text-sub mb-1.5 block">종목 선택</label>
+            <select
+              value={selectedId}
+              onChange={(e) => handleSelect(e.target.value)}
+              className="w-full bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2.5 text-[13px] text-bright outline-none focus:border-white/[0.12] transition-colors"
+            >
+              <option value="">종목을 선택하세요</option>
+              {holdings.map((h) => (
+                <option key={h.id} value={h.id}>
+                  [{h.accountName}] {h.displayName} ({h.ticker}) · {h.shares}주
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {selected && (
+            <>
+              {/* 보유 정보 요약 */}
+              <div className="bg-white/[0.02] rounded-lg px-3 py-2.5 flex flex-col gap-1">
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-dim">보유 수량</span>
+                  <span className="text-muted tabular-nums">{selected.shares}주</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-dim">평균 매입단가</span>
+                  <span className="text-muted tabular-nums">
+                    {selected.currency === 'USD' && selected.avgPriceFx != null
+                      ? formatUSD(selected.avgPriceFx)
+                      : formatKRW(selected.avgPrice)}
+                  </span>
+                </div>
+                {selected.currency === 'USD' && selected.avgFxRate != null && (
+                  <div className="flex justify-between text-[11px]">
+                    <span className="text-dim">매입 평균환율</span>
+                    <span className="text-muted tabular-nums">{selected.avgFxRate.toFixed(2)}원</span>
+                  </div>
+                )}
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-dim">시장 구분</span>
+                  <span className="text-muted">
+                    {selected.market === 'US' ? '해외주식' : '국내 ETF'} · 세율 {((selected.market === 'US' ? FOREIGN_STOCK_TAX_RATE : KR_ETF_TAX_RATE) * 100).toFixed(0)}%
+                  </span>
+                </div>
+              </div>
+
+              {/* 매도 수량 */}
+              <div>
+                <label className="text-[12px] text-sub mb-1.5 block">
+                  매도 수량
+                  <span className="text-dim ml-1">(최대 {selected.shares}주)</span>
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="number"
+                    value={sellShares}
+                    onChange={(e) => setSellShares(e.target.value)}
+                    min={1}
+                    max={selected.shares}
+                    step={1}
+                    placeholder="0"
+                    className="flex-1 bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2.5 text-[13px] text-bright tabular-nums outline-none focus:border-white/[0.12] transition-colors"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setSellShares(String(selected.shares))}
+                    className="px-3 py-2 text-[11px] font-semibold text-sub bg-white/[0.04] border border-white/[0.06] rounded-lg hover:bg-white/[0.07] transition-colors"
+                  >
+                    전량
+                  </button>
+                </div>
+                {parsedShares > selected.shares && (
+                  <p className="text-[11px] text-red-400 mt-1">보유 수량을 초과할 수 없습니다</p>
+                )}
+              </div>
+
+              {/* 매도 단가 */}
+              <div>
+                <label className="text-[12px] text-sub mb-1.5 block">
+                  매도 단가 ({selected.currency})
+                </label>
+                <input
+                  type="number"
+                  value={sellPrice}
+                  onChange={(e) => setSellPrice(e.target.value)}
+                  min={0}
+                  step={selected.currency === 'USD' ? 0.01 : 1}
+                  placeholder={selected.currentPrice != null ? String(selected.currentPrice) : '0'}
+                  className="w-full bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2.5 text-[13px] text-bright tabular-nums outline-none focus:border-white/[0.12] transition-colors"
+                />
+              </div>
+
+              {/* 환율 (USD only) */}
+              {selected.currency === 'USD' && (
+                <div>
+                  <label className="text-[12px] text-sub mb-1.5 block">매도 환율 (₩/USD)</label>
+                  <input
+                    type="number"
+                    value={sellFxRate}
+                    onChange={(e) => setSellFxRate(e.target.value)}
+                    min={0}
+                    step={0.01}
+                    placeholder={selected.currentFxRate != null ? String(selected.currentFxRate) : '0'}
+                    className="w-full bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-2.5 text-[13px] text-bright tabular-nums outline-none focus:border-white/[0.12] transition-colors"
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 결과 영역 */}
+      {result && (
+        <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+          <div className="px-5 py-3.5 border-b border-border flex justify-between items-center">
+            <div className="text-[13px] font-bold text-bright">예상 세금</div>
+            <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-white/[0.04] text-dim">
+              시뮬레이션
+            </span>
+          </div>
+
+          <div className="px-5 py-4 flex flex-col gap-2.5">
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] text-sub">매도 총액</span>
+              <span className="text-[12px] text-muted tabular-nums">{formatKRW(result.proceedsKRW)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] text-sub">매입 원가</span>
+              <span className="text-[12px] text-dim tabular-nums">{formatKRW(result.costBasisKRW)}</span>
+            </div>
+            <div className="h-px bg-white/[0.04]" />
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] font-semibold text-sub">실현 손익</span>
+              <span className={`text-[13px] font-semibold tabular-nums ${
+                result.realizedGainKRW >= 0 ? 'text-green-400' : 'text-red-400'
+              }`}>
+                {result.realizedGainKRW >= 0 ? '+' : ''}{formatKRW(result.realizedGainKRW)}
+              </span>
+            </div>
+
+            {/* USD 종목: 주가분/환율분 분리 */}
+            {selected?.currency === 'USD' && result.priceGainKRW != null && result.fxGainKRW != null && (
+              <div className="bg-white/[0.02] rounded-lg px-3 py-2 flex flex-col gap-1">
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-dim">주가 변동분</span>
+                  <span className={`tabular-nums ${result.priceGainKRW >= 0 ? 'text-green-400/70' : 'text-red-400/70'}`}>
+                    {result.priceGainKRW >= 0 ? '+' : ''}{formatKRW(result.priceGainKRW)}
+                  </span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-dim">환율 변동분</span>
+                  <span className={`tabular-nums ${result.fxGainKRW >= 0 ? 'text-green-400/70' : 'text-red-400/70'}`}>
+                    {result.fxGainKRW >= 0 ? '+' : ''}{formatKRW(result.fxGainKRW)}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <div className="h-px bg-white/[0.04]" />
+
+            {/* 해외주식: 공제 정보 */}
+            {selected?.market === 'US' && (
+              <>
+                <div className="flex items-center justify-between">
+                  <span className="text-[12px] text-sub">연간 공제 한도</span>
+                  <span className="text-[12px] text-dim tabular-nums">{formatKRW(FOREIGN_STOCK_DEDUCTION)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-[12px] text-sub">기존 실현 손익 (YTD)</span>
+                  <span className={`text-[12px] tabular-nums ${
+                    ytdForeignGain >= 0 ? 'text-muted' : 'text-red-400/70'
+                  }`}>
+                    {ytdForeignGain >= 0 ? '+' : ''}{formatKRW(ytdForeignGain)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-[12px] text-sub">매도 후 공제 잔여</span>
+                  <span className="text-[12px] text-muted tabular-nums">{formatKRW(result.deductionRemaining)}</span>
+                </div>
+              </>
+            )}
+
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] text-sub">과세 대상</span>
+              <span className="text-[12px] text-muted tabular-nums">
+                {formatKRW(result.taxableAmount)}
+                <span className="text-dim ml-1">× {(result.taxRate * 100).toFixed(0)}%</span>
+              </span>
+            </div>
+
+            <div className="h-px bg-white/[0.06]" />
+            <div className="flex items-center justify-between">
+              <span className="text-[13px] font-bold text-sub">예상 세금</span>
+              <span className={`text-[17px] font-bold tabular-nums ${
+                result.estimatedTax > 0 ? 'text-bright' : 'text-muted'
+              }`}>
+                {formatKRW(result.estimatedTax)}
+              </span>
+            </div>
+
+            {result.realizedGainKRW > 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] text-dim">세후 순이익 예상</span>
+                <span className="text-[12px] text-muted tabular-nums">
+                  {formatKRW(result.realizedGainKRW - result.estimatedTax)}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 손실 시 안내 */}
+      {result && result.realizedGainKRW < 0 && selected?.market === 'US' && (
+        <div className="bg-blue-500/5 border border-blue-500/10 rounded-lg px-4 py-2.5">
+          <span className="text-[11px] text-blue-400/70">
+            해외주식 간 손익통산이 가능합니다. 이 매도 손실은 같은 해 다른 해외주식 이익에서 공제할 수 있습니다.
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/tax/sell-simulator.ts
+++ b/src/lib/tax/sell-simulator.ts
@@ -1,0 +1,132 @@
+/**
+ * 매도 전 세금 미리보기 계산
+ *
+ * 보유 종목 매도 시 예상 양도소득세를 사전에 계산한다.
+ * - 해외주식(US): 250만 공제 후 22%
+ * - 국내 ETF(KR): 매매차익 15.4%
+ */
+
+import {
+  FOREIGN_STOCK_DEDUCTION,
+  FOREIGN_STOCK_TAX_RATE,
+  KR_ETF_TAX_RATE,
+} from './capital-gains-tax'
+
+export interface SellSimulationInput {
+  /** 시장 */
+  market: string
+  /** 통화 */
+  currency: string
+  /** 매도 수량 */
+  sellShares: number
+  /** 매도 단가 (원본 통화) */
+  sellPrice: number
+  /** 매도 환율 (USD 종목만) */
+  sellFxRate: number | null
+  /** 보유 평균단가 (KRW 기준) */
+  avgPrice: number
+  /** 보유 평균단가 (USD 원본 — USD 종목만) */
+  avgPriceFx: number | null
+  /** 보유 평균환율 (USD 종목만) */
+  avgFxRate: number | null
+  /** 올해 이미 실현된 해외주식 손익 (공제 잔여분 계산용) */
+  ytdForeignGain: number
+}
+
+export interface SellSimulationResult {
+  /** 매도 총액 (KRW) */
+  proceedsKRW: number
+  /** 매입 원가 (KRW) */
+  costBasisKRW: number
+  /** 실현 손익 (KRW) */
+  realizedGainKRW: number
+  /** 환율 변동 손익 (USD 종목만) */
+  fxGainKRW: number | null
+  /** 주가 변동 손익 (USD 종목만) */
+  priceGainKRW: number | null
+  /** 기본공제 적용 후 과세대상 (해외주식만) */
+  taxableAmount: number
+  /** 적용 세율 */
+  taxRate: number
+  /** 예상 세금 */
+  estimatedTax: number
+  /** 공제 잔여분 (해외주식만) */
+  deductionRemaining: number
+}
+
+/**
+ * 매도 시뮬레이션 계산
+ */
+export function simulateSellTax(input: SellSimulationInput): SellSimulationResult {
+  const {
+    market, currency, sellShares, sellPrice, sellFxRate,
+    avgPrice, avgPriceFx, avgFxRate, ytdForeignGain,
+  } = input
+
+  // USD 종목은 환율 필수
+  if (currency === 'USD' && (sellFxRate == null || sellFxRate <= 0)) {
+    return {
+      proceedsKRW: 0, costBasisKRW: 0, realizedGainKRW: 0,
+      fxGainKRW: null, priceGainKRW: null,
+      taxableAmount: 0, taxRate: 0, estimatedTax: 0, deductionRemaining: 0,
+    }
+  }
+
+  // 매도 총액 (KRW)
+  const proceedsKRW = currency === 'USD' && sellFxRate != null
+    ? Math.round(sellPrice * sellShares * sellFxRate)
+    : Math.round(sellPrice * sellShares)
+
+  // 매입 원가 (KRW)
+  const costBasisKRW = Math.round(avgPrice * sellShares)
+
+  // 실현 손익
+  const realizedGainKRW = proceedsKRW - costBasisKRW
+
+  // USD 종목: 주가분 / 환율분 분리
+  let fxGainKRW: number | null = null
+  let priceGainKRW: number | null = null
+
+  if (currency === 'USD' && avgPriceFx != null && avgFxRate != null && sellFxRate != null) {
+    // 주가 변동분 = (매도가 - 평균단가) × 수량 × 매수환율
+    priceGainKRW = Math.round((sellPrice - avgPriceFx) * sellShares * avgFxRate)
+    // 환율 변동분 = 평균단가(USD) × 수량 × (매도환율 - 매수환율)
+    fxGainKRW = Math.round(avgPriceFx * sellShares * (sellFxRate - avgFxRate))
+  }
+
+  // 세금 계산
+  let taxableAmount = 0
+  let taxRate = 0
+  let estimatedTax = 0
+  let deductionRemaining = 0
+
+  if (market === 'US') {
+    taxRate = FOREIGN_STOCK_TAX_RATE
+    // 연간 누적 손익에 이번 매도 합산
+    const totalYtdGain = ytdForeignGain + realizedGainKRW
+    // 공제 후 과세대상 (기존 + 이번)
+    const totalTaxable = Math.max(0, totalYtdGain - FOREIGN_STOCK_DEDUCTION)
+    // 이미 과세된 부분 차감 → 이번 매도의 추가 세금
+    const existingTaxable = Math.max(0, ytdForeignGain - FOREIGN_STOCK_DEDUCTION)
+    taxableAmount = totalTaxable - existingTaxable
+    estimatedTax = Math.round(taxableAmount * taxRate)
+    deductionRemaining = Math.max(0, FOREIGN_STOCK_DEDUCTION - Math.max(0, totalYtdGain))
+  } else if (market === 'KR') {
+    taxRate = KR_ETF_TAX_RATE
+    taxableAmount = Math.max(0, realizedGainKRW)
+    estimatedTax = Math.round(taxableAmount * taxRate)
+    deductionRemaining = 0
+  }
+
+  return {
+    proceedsKRW,
+    costBasisKRW,
+    realizedGainKRW,
+    fxGainKRW,
+    priceGainKRW,
+    taxableAmount,
+    taxRate,
+    estimatedTax,
+    deductionRemaining,
+  }
+}


### PR DESCRIPTION
## Summary
- 보유 종목 매도 시 예상 세금 사전 계산 시뮬레이터
- 해외주식: 양도소득세 22% (연간 250만 공제 잔여분 반영)
- 국내 ETF: 배당소득세 15.4%
- USD 종목: 주가 변동분 / 환율 변동분 분리 표시
- 현재가 + 환율 자동 세팅, 전량 매도 버튼
- 현재 연도에서만 시뮬레이터 표시

Closes #23

## Checklist
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` — 컴파일 성공 (DB 미연결로 prerender만 실패)
- [x] 코드 리뷰 2회 (P1: 4건 → 0건, P2: 0건)

## Code Review
- 1차: P1 4건 (USD 환율 null 방어, parseInt→Number 검증, 라벨 수정, 연도 혼재)
- 2차: P1/P2 0건 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)