### PR TITLE
[Phase 4-F] 배당소득세 추적 (#24)

### DIFF
--- a/src/app/tax/page.tsx
+++ b/src/app/tax/page.tsx
@@ -5,9 +5,11 @@ import CapitalGainsSummary from '@/components/tax/CapitalGainsSummary'
 import RealizedGainsTable from '@/components/tax/RealizedGainsTable'
 import RSUTaxCard from '@/components/tax/RSUTaxCard'
 import SellTaxSimulator from '@/components/tax/SellTaxSimulator'
+import DividendTaxCard from '@/components/tax/DividendTaxCard'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
 import { calcRealizedGains, calcCapitalGainsSummary } from '@/lib/tax/capital-gains-tax'
 import { calcRSUTaxSummary } from '@/lib/tax/income-tax'
+import { calcDividendTaxSummary } from '@/lib/tax/dividend-tax'
 
 export const dynamic = 'force-dynamic'
 
@@ -142,6 +144,29 @@ export default async function TaxPage({ searchParams }: TaxPageProps) {
     currentFxRate: h.currency === 'USD' ? currentFxRate : null,
   }))
 
+  // 배당소득세 데이터
+  const dividends = await prisma.dividend.findMany({
+    where: {
+      payDate: {
+        gte: new Date(`${year}-01-01`),
+        lt: new Date(`${year + 1}-01-01`),
+      },
+    },
+    select: {
+      ticker: true,
+      displayName: true,
+      currency: true,
+      amountGross: true,
+      amountNet: true,
+      taxAmount: true,
+      fxRate: true,
+      amountKRW: true,
+    },
+    orderBy: { payDate: 'asc' },
+  })
+
+  const dividendTaxSummary = calcDividendTaxSummary(dividends)
+
   // 연도 선택 옵션
   const years = [currentYear, currentYear - 1, currentYear - 2]
 
@@ -266,11 +291,10 @@ export default async function TaxPage({ searchParams }: TaxPageProps) {
         )}
       </div>
 
-      {/* Placeholder */}
-      <div className="mb-6">
-        <div className="relative overflow-hidden rounded-[14px] border border-white/[0.04] bg-white/[0.015] px-5 py-4">
-          <span className="text-[13px] text-dim">배당소득세 추적 — Phase 4-F에서 추가 예정</span>
-        </div>
+      {/* 배당소득세 섹션 */}
+      <div className="mb-8">
+        <h2 className="text-[14px] font-bold text-bright mb-3">배당소득세 ({year}년)</h2>
+        <DividendTaxCard summary={dividendTaxSummary} year={year} />
       </div>
 
       <p className="text-[11px] text-dim">

--- a/src/components/tax/DividendTaxCard.tsx
+++ b/src/components/tax/DividendTaxCard.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { formatKRW, formatUSD } from '@/lib/format'
+import type { DividendTaxSummary } from '@/lib/tax/dividend-tax'
+
+interface DividendTaxCardProps {
+  summary: DividendTaxSummary
+  year: number
+}
+
+export default function DividendTaxCard({ summary, year }: DividendTaxCardProps) {
+  if (summary.totalCount === 0) {
+    return (
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card p-8 text-center">
+        <div className="text-[13px] text-sub">{year}년 배당 수령 내역이 없습니다</div>
+      </div>
+    )
+  }
+
+  const gaugePercent = Math.min(summary.usageRate * 100, 100)
+  const formatByCurrency = (amount: number, currency: string) =>
+    currency === 'USD' ? formatUSD(amount) : formatKRW(amount)
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 요약 카드 */}
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+        <div className="px-5 py-4">
+          {/* 3열 요약 */}
+          <div className="grid grid-cols-3 gap-4 mb-4">
+            <div>
+              <div className="text-[11px] text-dim mb-0.5">세전 배당 (YTD)</div>
+              <div className="text-[15px] font-bold text-bright tabular-nums">
+                {formatKRW(summary.totalGrossKRW)}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] text-dim mb-0.5">원천징수 합계</div>
+              <div className="text-[15px] font-bold text-muted tabular-nums">
+                {formatKRW(summary.totalTaxKRW)}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] text-dim mb-0.5">세후 수령 합계</div>
+              <div className="text-[15px] font-bold text-green-400 tabular-nums">
+                {formatKRW(summary.totalNetKRW)}
+              </div>
+            </div>
+          </div>
+
+          {/* 금융소득종합과세 게이지 */}
+          <div className="mb-2">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-[11px] text-sub">금융소득종합과세 기준선 (배당소득 기준)</span>
+              <span className="text-[11px] text-dim tabular-nums">
+                {formatKRW(summary.totalGrossKRW)} / {formatKRW(summary.threshold)}
+              </span>
+            </div>
+            <div className="w-full h-2 rounded-full bg-white/[0.04] overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  summary.exceeded
+                    ? 'bg-red-400'
+                    : summary.usageRate > 0.8
+                      ? 'bg-yellow-400'
+                      : 'bg-green-400'
+                }`}
+                style={{ width: `${gaugePercent}%` }}
+              />
+            </div>
+            <div className="flex items-center justify-between mt-1">
+              <span className={`text-[10px] font-bold ${
+                summary.exceeded
+                  ? 'text-red-400'
+                  : summary.usageRate > 0.8
+                    ? 'text-yellow-400'
+                    : 'text-green-400/70'
+              }`}>
+                {(summary.usageRate * 100).toFixed(1)}%
+              </span>
+              {summary.exceeded ? (
+                <span className="text-[10px] text-red-400">
+                  기준선 초과 — 종합과세 대상
+                </span>
+              ) : (
+                <span className="text-[10px] text-dim">
+                  잔여 {formatKRW(summary.remaining)}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 종목별 배당소득세 내역 */}
+      {summary.byTicker.length > 0 && (
+        <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+          <div className="px-5 py-3.5 border-b border-border flex justify-between items-center">
+            <div className="text-[13px] font-bold text-bright">종목별 배당소득</div>
+            <div className="text-[12px] text-sub">{summary.totalCount}건</div>
+          </div>
+
+          <div className="divide-y divide-white/[0.025]">
+            {summary.byTicker.map((t) => (
+              <div key={`${t.ticker}:${t.currency}`} className="px-5 py-3 hover:bg-white/[0.015]">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[13px] font-bold text-bright">{t.displayName}</span>
+                    <span className="text-[10px] text-dim px-1 py-0.5 rounded bg-white/[0.04]">
+                      {t.currency === 'USD' ? 'USD' : 'KRW'}
+                    </span>
+                  </div>
+                  <span className="text-[13px] font-semibold text-green-400 tabular-nums">
+                    {formatKRW(t.totalNetKRW)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-[11px] text-dim">
+                  <span className="tabular-nums">
+                    세전 {formatByCurrency(t.totalGross, t.currency)} · 세금 {formatByCurrency(t.totalTax, t.currency)} · {t.count}건
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {summary.exceeded && (
+        <div className="bg-red-500/5 border border-red-500/10 rounded-lg px-4 py-2.5">
+          <span className="text-[11px] text-red-400/70">
+            연간 금융소득이 2,000만원을 초과하면 종합소득세 신고 대상입니다. 세무사 상담을 권장합니다.
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/tax/dividend-tax.ts
+++ b/src/lib/tax/dividend-tax.ts
@@ -1,0 +1,127 @@
+/**
+ * 배당소득세 추적 유틸리티
+ *
+ * - 미국주 배당: 원천징수 15% (Dividend.taxAmount에 기록됨)
+ * - 국내 ETF 배당: 배당소득세 15.4% (Dividend.taxAmount에 기록됨)
+ * - 금융소득종합과세: 연간 금융소득 2,000만원 초과 시 종합과세 대상
+ */
+
+/** 금융소득종합과세 기준선 */
+export const FINANCIAL_INCOME_THRESHOLD = 20_000_000
+
+interface DividendRecord {
+  ticker: string
+  displayName: string
+  currency: string
+  amountGross: number
+  amountNet: number
+  taxAmount: number | null
+  fxRate: number | null
+  amountKRW: number
+}
+
+export interface DividendTaxByTicker {
+  ticker: string
+  displayName: string
+  currency: string
+  /** 세전 배당 합계 (원본 통화) */
+  totalGross: number
+  /** 세후 배당 합계 (원본 통화) */
+  totalNet: number
+  /** 원천징수 합계 (원본 통화) */
+  totalTax: number
+  /** 세후 배당 합계 (KRW) */
+  totalNetKRW: number
+  /** 건수 */
+  count: number
+}
+
+export interface DividendTaxSummary {
+  /** 세전 배당 합계 (KRW 환산) */
+  totalGrossKRW: number
+  /** 세후 배당 합계 (KRW) */
+  totalNetKRW: number
+  /** 원천징수 합계 (KRW 환산) */
+  totalTaxKRW: number
+  /** 금융소득종합과세 기준선 */
+  threshold: number
+  /** 기준선 대비 사용률 (0~1+) */
+  usageRate: number
+  /** 기준선 잔여 */
+  remaining: number
+  /** 기준선 초과 여부 */
+  exceeded: boolean
+  /** 종목별 합산 */
+  byTicker: DividendTaxByTicker[]
+  /** 총 배당 건수 */
+  totalCount: number
+}
+
+/**
+ * 연간 배당소득세 요약 계산
+ */
+export function calcDividendTaxSummary(dividends: DividendRecord[]): DividendTaxSummary {
+  // 종목별 집계
+  const tickerMap = new Map<string, DividendTaxByTicker>()
+
+  let totalGrossKRW = 0
+  let totalNetKRW = 0
+  let totalTaxKRW = 0
+
+  for (const d of dividends) {
+    const tax = d.taxAmount ?? 0
+    // amountKRW는 서버에서 정확히 계산된 세후 원화 금액
+    // grossKRW: amountNet > 0이면 비율 역산, 아니면 amountKRW 사용
+    const grossKRW = d.amountNet > 0
+      ? Math.round(d.amountKRW * (d.amountGross / d.amountNet))
+      : d.amountKRW
+    const taxKRW = grossKRW - d.amountKRW
+
+    totalGrossKRW += grossKRW
+    totalNetKRW += d.amountKRW
+    totalTaxKRW += taxKRW
+
+    const key = `${d.ticker}:${d.currency}`
+    const existing = tickerMap.get(key)
+    if (existing) {
+      tickerMap.set(key, {
+        ...existing,
+        totalGross: existing.totalGross + d.amountGross,
+        totalNet: existing.totalNet + d.amountNet,
+        totalTax: existing.totalTax + tax,
+        totalNetKRW: existing.totalNetKRW + d.amountKRW,
+        count: existing.count + 1,
+      })
+    } else {
+      tickerMap.set(key, {
+        ticker: d.ticker,
+        displayName: d.displayName,
+        currency: d.currency,
+        totalGross: d.amountGross,
+        totalNet: d.amountNet,
+        totalTax: tax,
+        totalNetKRW: d.amountKRW,
+        count: 1,
+      })
+    }
+  }
+
+  const byTicker = Array.from(tickerMap.values())
+    .sort((a, b) => b.totalNetKRW - a.totalNetKRW)
+
+  const usageRate = FINANCIAL_INCOME_THRESHOLD > 0
+    ? totalGrossKRW / FINANCIAL_INCOME_THRESHOLD
+    : 0
+
+  return {
+    totalGrossKRW,
+    totalNetKRW,
+    totalTaxKRW,
+    threshold: FINANCIAL_INCOME_THRESHOLD,
+    usageRate,
+    remaining: Math.max(0, FINANCIAL_INCOME_THRESHOLD - totalGrossKRW),
+    exceeded: totalGrossKRW > FINANCIAL_INCOME_THRESHOLD,
+    byTicker,
+    totalCount: dividends.length,
+  }
+}


### PR DESCRIPTION
## Summary
- 연간 배당소득 집계 유틸리티 (`dividend-tax.ts`): 종목별 세전/세후/원천징수 합산
- 배당소득세 YTD 카드 (`DividendTaxCard.tsx`): 3열 요약 + 금융소득종합과세 2,000만원 게이지
- 종목별 배당소득 내역 (ticker:currency 복합키로 정확한 분류)
- `/tax` 페이지에 배당소득세 섹션 통합 (placeholder 교체)

Closes #24

## Checklist
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` — 컴파일 성공 (DB 미연결로 prerender만 실패)
- [x] 코드 리뷰 3회 (P1: 3건→0건, P2: 1건→0건)

## Code Review
- 1차: P1 3건 (fxRate fallback, ticker 키 충돌, 금융소득 문구), P0 2건
- 2차: P2 1건 (React key 충돌)
- 3차: P1/P2 0건 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)