### PR TITLE
[Phase 5-A] 스톡옵션 모델 + 시드 데이터 (#31)

### DIFF
--- a/prisma/migrations/20260310050111_add_stock_option_models/migration.sql
+++ b/prisma/migrations/20260310050111_add_stock_option_models/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "StockOption" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "ticker" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "grantDate" TIMESTAMP(3) NOT NULL,
+    "expiryDate" TIMESTAMP(3) NOT NULL,
+    "strikePrice" DOUBLE PRECISION NOT NULL,
+    "totalShares" INTEGER NOT NULL,
+    "cancelledShares" INTEGER NOT NULL DEFAULT 0,
+    "exercisedShares" INTEGER NOT NULL DEFAULT 0,
+    "adjustedShares" INTEGER NOT NULL DEFAULT 0,
+    "remainingShares" INTEGER NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StockOption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StockOptionVesting" (
+    "id" TEXT NOT NULL,
+    "stockOptionId" TEXT NOT NULL,
+    "vestingDate" TIMESTAMP(3) NOT NULL,
+    "shares" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "exercisedAt" TIMESTAMP(3),
+    "note" TEXT,
+
+    CONSTRAINT "StockOptionVesting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "StockOption_accountId_idx" ON "StockOption"("accountId");
+
+-- CreateIndex
+CREATE INDEX "StockOptionVesting_stockOptionId_idx" ON "StockOptionVesting"("stockOptionId");
+
+-- CreateIndex
+CREATE INDEX "StockOptionVesting_vestingDate_idx" ON "StockOptionVesting"("vestingDate");
+
+-- AddForeignKey
+ALTER TABLE "StockOption" ADD CONSTRAINT "StockOption_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StockOptionVesting" ADD CONSTRAINT "StockOptionVesting_stockOptionId_fkey" FOREIGN KEY ("stockOptionId") REFERENCES "StockOption"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260310050435_add_stock_option_indexes/migration.sql
+++ b/prisma/migrations/20260310050435_add_stock_option_indexes/migration.sql
@@ -1,0 +1,14 @@
+-- DropIndex
+DROP INDEX "StockOption_accountId_idx";
+
+-- DropIndex
+DROP INDEX "StockOptionVesting_stockOptionId_idx";
+
+-- DropIndex
+DROP INDEX "StockOptionVesting_vestingDate_idx";
+
+-- CreateIndex
+CREATE INDEX "StockOption_accountId_grantDate_idx" ON "StockOption"("accountId", "grantDate");
+
+-- CreateIndex
+CREATE INDEX "StockOptionVesting_stockOptionId_vestingDate_idx" ON "StockOptionVesting"("stockOptionId", "vestingDate");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Account {
   trades       Trade[]
   deposits     Deposit[]
   rsuSchedules RSUSchedule[]
+  stockOptions StockOption[]
   dividends    Dividend[]
 }
 
@@ -92,6 +93,40 @@ model RSUSchedule {
   keepShares  Int?
   note        String?
   vestedAt    DateTime?
+}
+
+model StockOption {
+  id              String               @id @default(cuid())
+  accountId       String
+  account         Account              @relation(fields: [accountId], references: [id])
+  ticker          String
+  displayName     String
+  grantDate       DateTime             // 부여일
+  expiryDate      DateTime             // 만료일
+  strikePrice     Float                // 행사가격
+  totalShares     Int                  // 총부여수량
+  cancelledShares Int      @default(0) // 취소수량
+  exercisedShares Int      @default(0) // 행사수량
+  adjustedShares  Int      @default(0) // 조정수량
+  remainingShares Int                  // 잔여수량
+  note            String?
+  createdAt       DateTime             @default(now())
+  vestings        StockOptionVesting[]
+
+  @@index([accountId, grantDate])
+}
+
+model StockOptionVesting {
+  id            String      @id @default(cuid())
+  stockOptionId String
+  stockOption   StockOption @relation(fields: [stockOptionId], references: [id])
+  vestingDate   DateTime    // 행사 가능일
+  shares        Int         // 행사 가능 수량
+  status        String      @default("pending") // pending | exercisable | exercised | expired
+  exercisedAt   DateTime?
+  note          String?
+
+  @@index([stockOptionId, vestingDate])
 }
 
 model Dividend {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -102,6 +102,8 @@ async function main() {
   // === 삭제 + 생성을 단일 트랜잭션으로 실행 (all-or-nothing) ===
   await prisma.$transaction(async (tx) => {
     // 기존 데이터 정리
+    await tx.stockOptionVesting.deleteMany()
+    await tx.stockOption.deleteMany()
     await tx.deposit.deleteMany()
     await tx.trade.deleteMany()
     await tx.holding.deleteMany()
@@ -196,6 +198,90 @@ async function main() {
         },
       ],
     })
+    // 스톡옵션 (세진 계좌 — 카카오)
+    const soGrants = [
+      {
+        ticker: '035720.KS',
+        displayName: '카카오',
+        grantDate: '2021-05-04',
+        expiryDate: '2028-05-04',
+        strikePrice: 116449,
+        totalShares: 200,
+        adjustedShares: -5,
+        remainingShares: 195,
+        // 전량 행사 가능 (2년 경과)
+        vestings: [
+          { vestingDate: '2023-05-04', shares: 195, status: 'exercisable' },
+        ],
+      },
+      {
+        ticker: '035720.KS',
+        displayName: '카카오',
+        grantDate: '2022-03-29',
+        expiryDate: '2029-03-29',
+        strikePrice: 103359,
+        totalShares: 200,
+        adjustedShares: -5,
+        remainingShares: 195,
+        // 전량 행사 가능 (2년 경과)
+        vestings: [
+          { vestingDate: '2024-03-29', shares: 195, status: 'exercisable' },
+        ],
+      },
+      {
+        ticker: '035720.KS',
+        displayName: '카카오',
+        grantDate: '2023-03-28',
+        expiryDate: '2030-03-28',
+        strikePrice: 62760,
+        totalShares: 200,
+        adjustedShares: -3,
+        remainingShares: 197,
+        vestings: [
+          { vestingDate: '2025-03-28', shares: 99, status: 'exercisable' },
+          { vestingDate: '2026-03-28', shares: 98, status: 'pending' },
+        ],
+      },
+      {
+        ticker: '035720.KS',
+        displayName: '카카오',
+        grantDate: '2024-03-28',
+        expiryDate: '2031-03-28',
+        strikePrice: 54943,
+        totalShares: 200,
+        adjustedShares: -2,
+        remainingShares: 198,
+        vestings: [
+          { vestingDate: '2026-03-28', shares: 99, status: 'pending' },
+          { vestingDate: '2027-03-28', shares: 99, status: 'pending' },
+        ],
+      },
+    ]
+
+    for (const grant of soGrants) {
+      const so = await tx.stockOption.create({
+        data: {
+          accountId: sejin.id,
+          ticker: grant.ticker,
+          displayName: grant.displayName,
+          grantDate: new Date(grant.grantDate),
+          expiryDate: new Date(grant.expiryDate),
+          strikePrice: grant.strikePrice,
+          totalShares: grant.totalShares,
+          adjustedShares: grant.adjustedShares,
+          remainingShares: grant.remainingShares,
+        },
+      })
+
+      await tx.stockOptionVesting.createMany({
+        data: grant.vestings.map((v) => ({
+          stockOptionId: so.id,
+          vestingDate: new Date(v.vestingDate),
+          shares: v.shares,
+          status: v.status,
+        })),
+      })
+    }
   })
 
   const totalHoldings = sejinHoldings.length + sodamHoldings.length + dasomHoldings.length
@@ -205,6 +291,7 @@ async function main() {
   console.log(`  Trades: ${totalHoldings} (초기 보유분)`)
   console.log('  RSU Schedules: 2')
   console.log('  Deposits: 4')
+  console.log('  Stock Options: 4 (카카오, 베스팅 7건)')
 }
 
 main()

--- a/src/app/api/stock-options/route.ts
+++ b/src/app/api/stock-options/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/stock-options — 스톡옵션 목록 조회
+ * Query: accountId (optional)
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const accountId = searchParams.get('accountId')
+
+    const where = accountId ? { accountId } : {}
+
+    const stockOptions = await prisma.stockOption.findMany({
+      where,
+      include: {
+        vestings: {
+          orderBy: { vestingDate: 'asc' },
+        },
+        account: {
+          select: { name: true },
+        },
+      },
+      orderBy: { grantDate: 'asc' },
+    })
+
+    return NextResponse.json({ stockOptions })
+  } catch (err) {
+    console.error('GET /api/stock-options error:', err)
+    return NextResponse.json({ error: '스톡옵션 조회 실패' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- StockOption + StockOptionVesting Prisma 모델 추가
- 카카오 스톡옵션 4건 시드 데이터 (2021~2024, 총 785주, 베스팅 7건)
  - 2021: 행사가 116,449원 / 195주 (전량 행사 가능)
  - 2022: 행사가 103,359원 / 195주 (전량 행사 가능)
  - 2023: 행사가 62,760원 / 197주 (99주 2025.3 + 98주 2026.3)
  - 2024: 행사가 54,943원 / 198주 (99주 2026.3 + 99주 2027.3)
- 복합 인덱스: [accountId, grantDate], [stockOptionId, vestingDate]
- GET /api/stock-options 조회 API

Closes #31

## Checklist
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npx prisma db seed` 성공
- [x] 코드 리뷰 3회 (P1: 5건→0건, P2: 1건→0건)

## Code Review
- 1차: P1 5건 (파생값 무결성, enum, 페이징, 인덱스 2건)
- 2차: P2 1건 (dynamic 선언 누락)
- 3차: P1/P2 0건 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)