### PR TITLE
[Phase 8-A] DB 스키마 + 기본 카테고리 시드 (#73)

### DIFF
--- a/prisma/migrations/20260312080147_add_expense_income_models/migration.sql
+++ b/prisma/migrations/20260312080147_add_expense_income_models/migration.sql
@@ -1,0 +1,68 @@
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "icon" TEXT,
+    "keywords" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "userId" TEXT,
+    "transactedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Budget" (
+    "id" TEXT NOT NULL,
+    "categoryId" TEXT,
+    "year" INTEGER NOT NULL,
+    "month" INTEGER NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Budget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_slug_key" ON "Category"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_name_key" ON "Category"("name");
+
+-- CreateIndex
+CREATE INDEX "Transaction_transactedAt_idx" ON "Transaction"("transactedAt");
+
+-- CreateIndex
+CREATE INDEX "Transaction_categoryId_idx" ON "Transaction"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Transaction_userId_idx" ON "Transaction"("userId");
+
+-- CreateIndex
+CREATE INDEX "Budget_year_month_idx" ON "Budget"("year", "month");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Budget_categoryId_year_month_key" ON "Budget"("categoryId", "year", "month");
+
+-- Partial unique index: enforce single overall budget (categoryId IS NULL) per year/month
+CREATE UNIQUE INDEX "Budget_overall_year_month_key" ON "Budget"("year", "month") WHERE "categoryId" IS NULL;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Budget" ADD CONSTRAINT "Budget_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,6 +195,47 @@ model HoldingSnapshot {
   @@index([portfolioSnapshotId])
 }
 
+model Category {
+  id           String        @id @default(cuid())
+  slug         String        @unique // 변경 불가 식별자 ("food", "transport" 등)
+  name         String        @unique // 표시명 ("식비", "교통" 등)
+  type         String        // "expense" | "income"
+  icon         String?
+  keywords     String[]      @default([])
+  sortOrder    Int           @default(0)
+  createdAt    DateTime      @default(now())
+  transactions Transaction[]
+  budgets      Budget[]
+}
+
+model Transaction {
+  id           String   @id @default(cuid())
+  amount       Int
+  description  String
+  categoryId   String
+  category     Category @relation(fields: [categoryId], references: [id])
+  userId       String?
+  transactedAt DateTime @default(now())
+  createdAt    DateTime @default(now())
+
+  @@index([transactedAt])
+  @@index([categoryId])
+  @@index([userId])
+}
+
+model Budget {
+  id         String    @id @default(cuid())
+  categoryId String?
+  category   Category? @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  year       Int
+  month      Int
+  amount     Int
+  createdAt  DateTime  @default(now())
+
+  @@unique([categoryId, year, month])
+  @@index([year, month])
+}
+
 model BenchmarkPrice {
   id        String   @id @default(cuid())
   ticker    String

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -101,7 +101,10 @@ async function main() {
 
   // === 삭제 + 생성을 단일 트랜잭션으로 실행 (all-or-nothing) ===
   await prisma.$transaction(async (tx) => {
-    // 기존 데이터 정리
+    // 기존 데이터 정리 (FK 순서)
+    await tx.transaction.deleteMany()
+    await tx.budget.deleteMany()
+    await tx.category.deleteMany()
     await tx.holdingSnapshot.deleteMany()
     await tx.portfolioSnapshot.deleteMany()
     await tx.benchmarkPrice.deleteMany()
@@ -285,6 +288,26 @@ async function main() {
         })),
       })
     }
+
+    // === 카테고리 시드 ===
+    const categories = [
+      // 소비
+      { slug: 'food', name: '식비', type: 'expense', icon: '🍚', keywords: ['점심', '저녁', '아침', '커피', '카페', '배달', '식사', '간식', '음료', '밥'], sortOrder: 1 },
+      { slug: 'transport', name: '교통', type: 'expense', icon: '🚗', keywords: ['택시', '버스', '지하철', '주유', '기름', '톨비', '주차', '교통'], sortOrder: 2 },
+      { slug: 'living', name: '생활', type: 'expense', icon: '🏠', keywords: ['마트', '생필품', '세탁', '관리비', '공과금', '전기', '수도', '가스'], sortOrder: 3 },
+      { slug: 'medical', name: '의료', type: 'expense', icon: '🏥', keywords: ['병원', '약국', '치과', '안과', '건강검진', '약'], sortOrder: 4 },
+      { slug: 'education', name: '교육', type: 'expense', icon: '📚', keywords: ['학원', '교재', '학비', '수업', '강의', '책'], sortOrder: 5 },
+      { slug: 'shopping', name: '쇼핑', type: 'expense', icon: '🛍️', keywords: ['쇼핑', '옷', '신발', '가전', '전자기기'], sortOrder: 6 },
+      { slug: 'leisure', name: '여가', type: 'expense', icon: '🎮', keywords: ['영화', '게임', '여행', '숙소', '운동', '헬스', '넷플릭스'], sortOrder: 7 },
+      { slug: 'social', name: '경조사', type: 'expense', icon: '💐', keywords: ['축의금', '조의금', '선물', '생일', '꽃'], sortOrder: 8 },
+      { slug: 'etc-expense', name: '기타', type: 'expense', icon: '📦', keywords: [], sortOrder: 99 },
+      // 수입
+      { slug: 'salary', name: '월급', type: 'income', icon: '💰', keywords: ['월급', '급여', '보너스', '상여', '성과급'], sortOrder: 1 },
+      { slug: 'side-income', name: '부수입', type: 'income', icon: '💵', keywords: ['부수입', '알바', '프리랜서', '용돈'], sortOrder: 2 },
+      { slug: 'etc-income', name: '기타수입', type: 'income', icon: '📥', keywords: [], sortOrder: 99 },
+    ]
+
+    await tx.category.createMany({ data: categories })
   })
 
   const totalHoldings = sejinHoldings.length + sodamHoldings.length + dasomHoldings.length
@@ -295,6 +318,7 @@ async function main() {
   console.log('  RSU Schedules: 2')
   console.log('  Deposits: 4')
   console.log('  Stock Options: 4 (카카오, 베스팅 7건)')
+  console.log('  Categories: 12 (소비 9 + 수입 3)')
 }
 
 main()


### PR DESCRIPTION
## Summary
- Category, Transaction, Budget 모델 추가 (소비/수입 관리 기반)
- Category: slug(불변 식별자) + name + type + keywords(자동 분류용)
- Transaction: type을 Category에서 파생 (데이터 정합성)
- Budget: 월별 예산, onDelete Restrict, year/month 인덱스
- Budget: partial unique index로 전체 예산 중복 방지 (categoryId IS NULL)
- 기본 카테고리 12개 시드 (소비 9 + 수입 3)

Closes #73

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (P1/P2: 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)