### PR TITLE
fix(krx): KRX HTML 파서 컬럼 인덱스 복원 (#82)

### DIFF
--- a/src/lib/krx-stocks.ts
+++ b/src/lib/krx-stocks.ts
@@ -18,9 +18,10 @@ interface KrxStockEntry {
 
 /**
  * KRX HTML 테이블을 파싱하여 종목 리스트를 반환한다.
- * 컬럼 순서: 회사명(0), 종목코드(1), 업종(2), ...
+ * 컬럼 순서: 회사명(0), 시장구분(1), 종목코드(2), 업종(3), ...
+ * 시장구분 값에 줄바꿈/공백이 많으므로 HTML 태그 제거 + 공백 정리 필수.
  */
-function parseKrxHtml(html: string, market: string, suffix: string): KrxStockEntry[] {
+function parseKrxHtml(html: string): KrxStockEntry[] {
   const entries: KrxStockEntry[] = []
   const rowRegex = /<tr>([\s\S]*?)<\/tr>/g
   let match: RegExpExecArray | null
@@ -36,19 +37,26 @@ function parseKrxHtml(html: string, market: string, suffix: string): KrxStockEnt
     const cells: string[] = []
     let cellMatch: RegExpExecArray | null
     while ((cellMatch = cellRegex.exec(match[1])) !== null) {
-      cells.push(cellMatch[1].trim())
+      // HTML 태그 제거 + 공백 정리
+      cells.push(cellMatch[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim())
     }
 
-    if (cells.length < 2) continue
+    if (cells.length < 3) continue
 
-    const name = cells[0].trim()
-    const code = cells[1].trim()
+    const name = cells[0]
+    const marketRaw = cells[1]
+    const code = cells[2]
 
     // 6자리 숫자 종목코드만 처리
     if (!/^\d{6}$/.test(code)) continue
     if (!name) continue
 
+    const marketMap: Record<string, string> = { '유가': 'KOSPI', '코스닥': 'KOSDAQ' }
+    const market = marketMap[marketRaw]
+    if (!market) continue
+    const suffix = market === 'KOSPI' ? '.KS' : '.KQ'
     const yahooTicker = `${code}${suffix}`
+
     entries.push({ code, name, market, yahooTicker })
   }
 
@@ -56,11 +64,11 @@ function parseKrxHtml(html: string, market: string, suffix: string): KrxStockEnt
 }
 
 /**
- * KRX에서 시장별 종목 리스트를 다운로드한다.
+ * KRX에서 시장별 종목 리스트 HTML을 다운로드한다.
  */
-async function fetchKrxMarket(marketType: string): Promise<string> {
+async function fetchKrxHtml(marketType: string): Promise<string> {
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
+  const timeout = setTimeout(() => controller.abort(), 15_000)
 
   const url = `${KRX_BASE_URL}&marketType=${marketType}`
   const res = await fetch(url, {
@@ -77,18 +85,15 @@ async function fetchKrxMarket(marketType: string): Promise<string> {
 }
 
 /**
- * KOSPI + KOSDAQ 종목 리스트를 합쳐서 반환한다.
+ * KOSPI + KOSDAQ 종목 리스트를 병렬로 가져와 합친다.
  */
 async function fetchKrxStockList(): Promise<KrxStockEntry[]> {
   const [kospiHtml, kosdaqHtml] = await Promise.all([
-    fetchKrxMarket('stockMkt'),
-    fetchKrxMarket('kosdaqMkt'),
+    fetchKrxHtml('stockMkt'),
+    fetchKrxHtml('kosdaqMkt'),
   ])
 
-  const kospi = parseKrxHtml(kospiHtml, 'KOSPI', '.KS')
-  const kosdaq = parseKrxHtml(kosdaqHtml, 'KOSDAQ', '.KQ')
-
-  return [...kospi, ...kosdaq]
+  return [...parseKrxHtml(kospiHtml), ...parseKrxHtml(kosdaqHtml)]
 }
 
 /**


### PR DESCRIPTION
## Summary
- KRX 종목 리스트 파서가 잘못된 컬럼 인덱스를 사용하여 0개 종목 파싱되는 프로덕션 버그 수정
- 실제 KRX HTML 컬럼: 회사명(0), 시장구분(1), 종목코드(2) — 코드 리뷰에서 cells[1]을 종목코드로 잘못 변경한 것이 원인
- 시장구분 컬럼의 HTML 태그/공백 정리 추가, 파서를 순수 함수로 리팩토링

Closes #82

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 로컬 파싱 테스트 (KOSPI 838개 확인)