### PR TITLE
[Phase 10-C] 급등락 / 환율 변동 알림 (#112)

### DIFF
--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -45,11 +45,16 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       key: { in: ['price_drop_pct', 'price_surge_pct', 'fx_change_krw'] },
     },
   })
-  const configMap = new Map(configs.map((c) => [c.key, parseFloat(c.value)]))
+  const configMap = new Map(configs.map((c) => [c.key, c.value]))
 
-  const dropThreshold = configMap.get('price_drop_pct') ?? -5
-  const surgeThreshold = configMap.get('price_surge_pct') ?? 5
-  const fxThreshold = configMap.get('fx_change_krw') ?? 50
+  const parseOrDefault = (key: string, fallback: number): number => {
+    const raw = parseFloat(configMap.get(key) ?? '')
+    return Number.isFinite(raw) ? raw : fallback
+  }
+
+  const dropThreshold = parseOrDefault('price_drop_pct', -5)
+  const surgeThreshold = parseOrDefault('price_surge_pct', 5)
+  const fxThreshold = parseOrDefault('fx_change_krw', 50)
 
   // 보유 종목만 조회 (전체 PriceCache가 아니라)
   const holdings = await prisma.holding.findMany({

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -107,11 +107,13 @@ export function schedulePriceUpdates(): void {
 
       if (isMarketHours || isTopOfHour) {
         try {
-          await refreshPrices()
-          // 갱신 후 급등락/환율 변동 알림 체크
-          const chatIds = getAllowedChatIds()
-          if (chatIds.length > 0) {
-            await checkPriceAlerts(chatIds)
+          const result = await refreshPrices()
+          // 실제 갱신이 발생한 경우에만 알림 체크
+          if (result.success > 0) {
+            const chatIds = getAllowedChatIds()
+            if (chatIds.length > 0) {
+              await checkPriceAlerts(chatIds)
+            }
           }
         } catch (error) {
           console.error('[cron] Price refresh failed:', error)


### PR DESCRIPTION
## Summary

- 주가 갱신(refreshPrices) 후 보유 종목 급등/급락 + 환율 변동 감지
- AlertConfig 임계값 초과 시 텔레그램 알림 자동 발송
- 중복 방지: 동일 종목/환율 당일 1회만 (인메모리 Map, KST 자정 리셋)
- 실제 갱신 발생 시에만 알림 체크 (mutex 스킵 시 건너뛰기)

### 파일 변경
- `src/bot/notifications/price-alert.ts` (신규)
- `src/lib/cron.ts` (수정) — refreshPrices 후 checkPriceAlerts 연동

### 코드 리뷰
- 2회 반복, P1/P2: 0건

Closes #112

## Checklist
- [x] lint / typecheck / build 통과
- [x] 코드 리뷰 통과

## Test plan
- [ ] `알림설정 급락 -3` → 임계값 변경
- [ ] 보유 종목 -3% 이상 하락 시 텔레그램 알림 수신
- [ ] 환율 ±50원 이상 변동 시 알림 수신
- [ ] 동일 종목 당일 재알림 안 됨