### PR TITLE
[Phase 11-E] 모닝 브리핑 (#128)

### DIFF
--- a/src/bot/commands/briefing.ts
+++ b/src/bot/commands/briefing.ts
@@ -1,0 +1,49 @@
+import { Bot, Context } from 'grammy'
+import { sendBriefing } from '@/bot/notifications/briefing'
+
+function getChatId(ctx: Context): number | null {
+  return ctx.chat?.id ?? null
+}
+
+/**
+ * /브리핑 — 수동 모닝 브리핑 트리거
+ * /브리핑 한국 — 한국장 브리핑
+ * /브리핑 미국 — 미국장 브리핑
+ * /브리핑 (기본) — 현재 시간 기준 자동 판단
+ */
+async function handleBriefing(ctx: Context): Promise<void> {
+  const text = ctx.message?.text ?? ''
+  const args = text.replace(/^(\/briefing(?:@\w+)?|브리핑)\s*/i, '').trim()
+
+  const chatId = getChatId(ctx)
+  if (!chatId) {
+    await ctx.reply('⚠️ 채팅 정보를 확인할 수 없습니다.')
+    return
+  }
+
+  await ctx.reply('📊 브리핑 생성 중... (1~2분 소요)')
+  await ctx.replyWithChatAction('typing')
+
+  let session: 'KR' | 'US'
+
+  if (args === '한국' || args === 'kr' || args === 'KR') {
+    session = 'KR'
+  } else if (args === '미국' || args === 'us' || args === 'US') {
+    session = 'US'
+  } else {
+    // 시간 기준 자동 판단: KST 6~15시 → 한국장, 그 외 → 미국장
+    const now = new Date()
+    const kstHour = (now.getUTCHours() + 9) % 24
+    session = kstHour >= 6 && kstHour < 15 ? 'KR' : 'US'
+  }
+
+  // fire-and-forget (비동기, webhook 타임아웃 방지)
+  sendBriefing([chatId], session).catch((e) =>
+    console.error('[bot] 브리핑 발송 실패:', e)
+  )
+}
+
+export function registerBriefingCommands(bot: Bot): void {
+  bot.command('briefing', handleBriefing)
+  bot.hears(/^브리핑(?:\s+.*)?$/, handleBriefing)
+}

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -347,7 +347,7 @@ export function registerExpenseFallback(bot: Bot): void {
     // 기존 커맨드 패턴은 무시 (이미 다른 핸들러에서 처리됨)
     // 커맨드 단어 뒤에 공백 또는 문자열 끝이어야 매칭 (예: "매수수수료"는 통과)
     // "수입 ..."은 expense 핸들러가 처리, "소비"/"수입" 단독은 budget 핸들러가 처리
-    if (/^(현황|계좌|주가|환율|매수|매도|수입|예산설정|알림설정|전략|전략목록|관심|관심삭제|관심목록|분석)(\s|$)/i.test(text)) return next()
+    if (/^(현황|계좌|주가|환율|매수|매도|수입|예산설정|알림설정|전략|전략목록|관심|관심삭제|관심목록|분석|브리핑)(\s|$)/i.test(text)) return next()
     if (/^(소비|예산)\s*$/i.test(text)) return next()
 
     // 숫자 미포함 → 다음 핸들러(AI fallback)로 전달

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -36,7 +36,10 @@ const COMMANDS_HELP =
   `관심삭제 [종목] — 관심종목 제거\n` +
   `관심목록 — 관심종목 현황 + 현재가\n\n` +
   `기술적 분석:\n` +
-  `분석 [종목] — TA 리포트 (RSI, MACD, BB, SMA, 시그널)`
+  `분석 [종목] — TA 리포트 (RSI, MACD, BB, SMA, 시그널)\n\n` +
+  `모닝 브리핑:\n` +
+  `브리핑 — 모닝 브리핑 수동 발송\n` +
+  `브리핑 한국/미국 — 특정 시장 브리핑`
 
 export function registerCommands(bot: Bot): void {
   bot.command('start', async (ctx) => {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -10,6 +10,7 @@ import { registerAlertCommands } from './commands/alert'
 import { registerStrategyCommands } from './commands/strategy'
 import { registerWatchlistCommands } from './commands/watchlist'
 import { registerAnalysisCommands } from './commands/analysis'
+import { registerBriefingCommands } from './commands/briefing'
 import { authMiddleware } from './middleware/auth'
 
 let bot: Bot | null = null
@@ -37,6 +38,7 @@ function createBot(): Bot {
   registerStrategyCommands(instance)
   registerWatchlistCommands(instance)
   registerAnalysisCommands(instance)
+  registerBriefingCommands(instance)
 
   // fallback 순서: 소비 입력 → AI 질문 (질문형 키워드 포함 시)
   registerExpenseFallback(instance)

--- a/src/bot/notifications/briefing.ts
+++ b/src/bot/notifications/briefing.ts
@@ -1,0 +1,89 @@
+/**
+ * 모닝 브리핑 생성 + 텔레그램 발송
+ *
+ * AI(askAdvisor)로 보유 종목 전략별 맞춤 브리핑 생성.
+ * 한국장 08:30 KST / 미국장 23:00 KST 자동 발송.
+ */
+
+import { getBot } from '@/bot/index'
+import { askAdvisor } from '@/lib/ai/claude-advisor'
+import { splitMessage } from '@/bot/utils/formatter'
+import { markdownToTelegramHtml } from '@/bot/utils/markdown'
+
+type MarketSession = 'KR' | 'US'
+
+function buildBriefingPrompt(session: MarketSession): string {
+  const sessionLabel = session === 'KR' ? '🇰🇷 한국장' : '🇺🇸 미국장'
+
+  return [
+    `${sessionLabel} 모닝 브리핑을 작성해줘.\n`,
+    '다음 단계로 진행해:',
+    '1. get_all_strategies로 전체 종목 전략 확인',
+    '2. get_portfolio(전체)로 현재 보유 현황 확인',
+    session === 'US'
+      ? '3. 미국주(USD) 종목 중 스윙/모멘텀/단타 전략은 get_technical_analysis로 TA 확인'
+      : '3. 한국주(KRW) 종목 중 스윙/모멘텀/단타 전략은 get_technical_analysis로 TA 확인',
+    '4. firecrawl_search로 보유 종목 관련 최신 뉴스 검색',
+    '',
+    '브리핑 구성:',
+    '- 시장 동향 요약 (주요 지수, 이슈)',
+    '- 장기보유 종목: 간략 (뉴스 요약만, 특이사항 있을 때만)',
+    '- 스윙/모멘텀 종목: TA 기반 매수/매도 타이밍 + 목표가/손절 대비',
+    '- 감시 종목: 점검 기준 대비 현재 상태',
+    '- 오늘 주목 이벤트 (실적, FOMC, 점검일 등)',
+    '',
+    '계좌별로 섹션 분리 (소담/다솜 장기 vs 세진 능동).',
+  ].join('\n')
+}
+
+export async function sendBriefing(
+  chatIds: number[],
+  session: MarketSession
+): Promise<void> {
+  const bot = getBot()
+  const prompt = buildBriefingPrompt(session)
+
+  try {
+    const result = await askAdvisor(prompt, {
+      model: 'sonnet',
+      timeout: 300_000,
+      maxBudgetUsd: 1.0,
+    })
+
+    const html = markdownToTelegramHtml(result.response)
+
+    for (const chatId of chatIds) {
+      try {
+        if (html.length <= 4096) {
+          try {
+            await bot.api.sendMessage(chatId, html, { parse_mode: 'HTML' })
+          } catch {
+            await bot.api.sendMessage(chatId, result.response)
+          }
+        } else {
+          const chunks = splitMessage(result.response)
+          for (const chunk of chunks) {
+            await bot.api.sendMessage(chatId, chunk)
+          }
+        }
+      } catch (error) {
+        console.error(`[briefing] 발송 실패 (chatId: ${chatId}):`, error)
+      }
+    }
+
+    const label = session === 'KR' ? '한국장' : '미국장'
+    console.log(`[briefing] ${label} 모닝 브리핑 발송 완료`)
+  } catch (error) {
+    console.error('[briefing] 브리핑 생성 실패:', error)
+
+    const label = session === 'KR' ? '🇰🇷 한국장' : '🇺🇸 미국장'
+    const fallback = `📊 ${label} 모닝 브리핑 생성에 실패했습니다.\n/ai 에서 직접 질문해주세요.`
+    for (const chatId of chatIds) {
+      try {
+        await bot.api.sendMessage(chatId, fallback)
+      } catch {
+        // 무시
+      }
+    }
+  }
+}

--- a/src/bot/notifications/scheduler.ts
+++ b/src/bot/notifications/scheduler.ts
@@ -10,6 +10,7 @@ import { sendRSUReminders } from './rsu'
 import { sendMonthlyReminder } from './monthly'
 import { sendDailySummary } from './daily'
 import { sendMonthlyReport } from './monthly-report'
+import { sendBriefing } from './briefing'
 
 function getAllowedChatIds(): number[] {
   return (process.env.TELEGRAM_ALLOWED_CHAT_IDS ?? '')
@@ -125,8 +126,34 @@ export function scheduleNotifications(): void {
       { timezone: 'Asia/Seoul' }
     )
 
+    // 모닝 브리핑: 한국장 08:30 KST (월~금)
+    cron.schedule(
+      '30 8 * * 1-5',
+      async () => {
+        try {
+          await sendBriefing(chatIds, 'KR')
+        } catch (error) {
+          console.error('[notification] 한국장 브리핑 실패:', error)
+        }
+      },
+      { timezone: 'Asia/Seoul' }
+    )
+
+    // 모닝 브리핑: 미국장 23:00 KST (월~금)
+    cron.schedule(
+      '0 23 * * 1-5',
+      async () => {
+        try {
+          await sendBriefing(chatIds, 'US')
+        } catch (error) {
+          console.error('[notification] 미국장 브리핑 실패:', error)
+        }
+      },
+      { timezone: 'Asia/Seoul' }
+    )
+
     scheduled = true
-    console.log('[notification] 알림 스케줄러 등록 (일일요약 + 분기점검 + RSU D-7/D-1 + 월적립 + 월간리포트)')
+    console.log('[notification] 알림 스케줄러 등록 (일일요약 + 브리핑 + 분기점검 + RSU + 월적립 + 월간리포트)')
   } catch (error) {
     console.error('[notification] 알림 스케줄러 등록 실패:', error)
   }


### PR DESCRIPTION
## Summary

- 한국장 08:30 KST + 미국장 23:00 KST 자동 모닝 브리핑 (월~금)
- askAdvisor(sonnet)로 전략별 맞춤 브리핑 생성
  - 전체 전략 확인 → 포트폴리오 현황 → TA(스윙/모멘텀) → 뉴스 검색
  - 계좌별 섹션 분리 (장기 vs 능동 관리)
- `브리핑` 커맨드: 수동 트리거 (한국/미국 선택 가능, 시간 기준 자동 판단)
- 텔레그램 HTML 포맷 + 4096자 초과 시 plain text fallback

### 파일 변경
- `src/bot/notifications/briefing.ts` (신규) — 브리핑 생성 + 발송
- `src/bot/commands/briefing.ts` (신규) — /브리핑 커맨드
- `src/bot/notifications/scheduler.ts` — 크론 추가
- `src/bot/index.ts`, `start.ts`, `expense.ts` — 등록/도움말/패턴

### 코드 리뷰
- 1회, P1/P2: 0건

Closes #128

## Checklist
- [x] lint / typecheck / build 통과
- [x] 코드 리뷰 통과

## Test plan
- [ ] `브리핑` → 현재 시간 기준 한국/미국 브리핑 수동 발송
- [ ] `브리핑 한국` → 한국장 브리핑
- [ ] `브리핑 미국` → 미국장 브리핑
- [ ] 08:30 KST → 한국장 자동 브리핑 수신 (월~금)
- [ ] 23:00 KST → 미국장 자동 브리핑 수신 (월~금)