### PR TITLE
[Phase 15-A] 아이 전용 간소화 대시보드 (#163)

### DIFF
--- a/docs/designs/163-kids-dashboard/prototype.html
+++ b/docs/designs/163-kids-dashboard/prototype.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>소담이의 투자 일기</title>
+  <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet" />
+  <style>
+    * { margin:0; padding:0; box-sizing:border-box; }
+    body { font-family:'Pretendard',sans-serif; background:linear-gradient(135deg,#0f1729 0%,#1a1040 50%,#0f1729 100%); color:#eee; min-height:100vh; padding:24px; }
+
+    .header { text-align:center; margin-bottom:32px; }
+    .header h1 { font-size:28px; font-weight:800; }
+    .header h1 span { font-size:36px; }
+    .header .sub { font-size:14px; color:#9494a8; margin-top:4px; }
+
+    /* 총 자산 카드 */
+    .total-card {
+      background:linear-gradient(135deg,rgba(96,165,250,0.15),rgba(96,165,250,0.05));
+      border:1px solid rgba(96,165,250,0.2); border-radius:20px;
+      padding:28px; text-align:center; margin-bottom:24px;
+      position:relative; overflow:hidden;
+    }
+    .total-card .glow { position:absolute; top:0; left:0; right:0; height:2px; background:linear-gradient(90deg,transparent,#60a5fa,transparent); opacity:0.6; }
+    .total-label { font-size:14px; color:#9494a8; }
+    .total-amount { font-size:36px; font-weight:800; color:#fff; margin:8px 0; }
+    .total-growth { font-size:16px; color:#34d399; font-weight:600; }
+    .total-growth.negative { color:#ef4444; }
+
+    /* 종목 카드 */
+    .holdings { display:flex; flex-direction:column; gap:12px; margin-bottom:24px; }
+    .holding-card {
+      background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08);
+      border-radius:16px; padding:16px 20px;
+      display:flex; align-items:center; gap:16px;
+    }
+    .holding-emoji { font-size:32px; }
+    .holding-info { flex:1; }
+    .holding-name { font-size:15px; font-weight:700; color:#fff; }
+    .holding-desc { font-size:12px; color:#9494a8; margin-top:2px; }
+    .holding-value { text-align:right; }
+    .holding-amount { font-size:14px; font-weight:600; color:#fff; }
+    .holding-return { font-size:13px; font-weight:600; }
+    .holding-return.positive { color:#34d399; }
+    .holding-return.negative { color:#ef4444; }
+
+    /* 배당 섹션 */
+    .section-title { font-size:18px; font-weight:700; margin-bottom:12px; }
+    .dividend-card {
+      background:rgba(251,191,36,0.08); border:1px solid rgba(251,191,36,0.15);
+      border-radius:16px; padding:20px; margin-bottom:24px; text-align:center;
+    }
+    .dividend-emoji { font-size:40px; margin-bottom:8px; }
+    .dividend-text { font-size:14px; color:#fbbf24; }
+    .dividend-amount { font-size:20px; font-weight:700; color:#fff; margin-top:4px; }
+
+    /* 복리 미리보기 */
+    .compound-card {
+      background:rgba(52,211,153,0.08); border:1px solid rgba(52,211,153,0.15);
+      border-radius:16px; padding:20px; text-align:center;
+    }
+    .compound-text { font-size:14px; color:#34d399; }
+    .compound-amount { font-size:24px; font-weight:800; color:#fff; margin-top:4px; }
+    .compound-sub { font-size:12px; color:#9494a8; margin-top:4px; }
+
+    /* 뷰 전환 */
+    .view-toggle { display:flex; justify-content:center; gap:8px; margin-bottom:24px; }
+    .view-btn { padding:8px 16px; border-radius:20px; border:1px solid rgba(255,255,255,0.1); background:transparent; color:#9494a8; font-size:12px; cursor:pointer; font-family:inherit; }
+    .view-btn.active { background:rgba(96,165,250,0.15); border-color:rgba(96,165,250,0.3); color:#60a5fa; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1><span>👧</span> 소담이의 투자 일기</h1>
+    <div class="sub">🌿 새싹 레벨 (9세)</div>
+  </div>
+
+  <div class="view-toggle">
+    <button class="view-btn active">📊 내 투자</button>
+    <button class="view-btn">📖 투자 이야기</button>
+    <button class="view-btn">🔮 미래 보기</button>
+  </div>
+
+  <div class="total-card">
+    <div class="glow"></div>
+    <div class="total-label">💰 내 투자 총액</div>
+    <div class="total-amount">₩4,523,000</div>
+    <div class="total-growth">📈 +₩1,523,000 자랐어! (+50.8%)</div>
+  </div>
+
+  <div class="section-title">🏢 내가 가진 회사들</div>
+  <div class="holdings">
+    <div class="holding-card">
+      <div class="holding-emoji">🍎</div>
+      <div class="holding-info">
+        <div class="holding-name">애플 (AAPL)</div>
+        <div class="holding-desc">아이폰, 맥북 만드는 회사</div>
+      </div>
+      <div class="holding-value">
+        <div class="holding-amount">₩1,520,000</div>
+        <div class="holding-return positive">+45.2% 📈</div>
+      </div>
+    </div>
+    <div class="holding-card">
+      <div class="holding-emoji">🚀</div>
+      <div class="holding-info">
+        <div class="holding-name">로켓랩 (RKLB)</div>
+        <div class="holding-desc">우주로 로켓 쏘는 회사</div>
+      </div>
+      <div class="holding-value">
+        <div class="holding-amount">₩1,890,000</div>
+        <div class="holding-return positive">+120.3% 🚀</div>
+      </div>
+    </div>
+    <div class="holding-card">
+      <div class="holding-emoji">🐯</div>
+      <div class="holding-info">
+        <div class="holding-name">TIGER S&P500</div>
+        <div class="holding-desc">미국 500대 회사에 골고루 투자</div>
+      </div>
+      <div class="holding-value">
+        <div class="holding-amount">₩1,113,000</div>
+        <div class="holding-return positive">+11.3% 📈</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-title">🎁 회사가 준 용돈 (배당금)</div>
+  <div class="dividend-card">
+    <div class="dividend-emoji">🎁</div>
+    <div class="dividend-text">올해 회사들이 소담이에게 준 용돈</div>
+    <div class="dividend-amount">₩12,500</div>
+  </div>
+
+  <div class="section-title">🔮 미래 미리보기</div>
+  <div class="compound-card">
+    <div class="compound-text">매달 5만원씩 넣으면 20살 때</div>
+    <div class="compound-amount">약 ₩1,500만원!</div>
+    <div class="compound-sub">지금 가진 돈이 계속 자라면서 + 매달 조금씩 넣으면 이렇게 돼요</div>
+  </div>
+</body>
+</html>

--- a/src/app/kids/[accountId]/KidsClient.tsx
+++ b/src/app/kids/[accountId]/KidsClient.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+interface HoldingData {
+  ticker: string
+  displayName: string
+  emoji: string
+  description: string
+  valueKRW: number
+  costKRW: number
+  returnPct: number
+  shares: number
+}
+
+interface Props {
+  accountName: string
+  ownerAge: number | null
+  level: { level: number; label: string; emoji: string }
+  totalValue: number
+  totalCost: number
+  totalReturn: number
+  holdings: HoldingData[]
+  dividendTotal: number
+  compoundFinalValue: number
+  compoundYears: number
+  compoundMonthly: number
+}
+
+function formatKRW(n: number): string {
+  if (n >= 1_0000_0000) return `약 ${(n / 1_0000_0000).toFixed(1)}억원`
+  if (n >= 1_0000) return `약 ${Math.round(n / 1_0000).toLocaleString('ko-KR')}만원`
+  return `${Math.round(n).toLocaleString('ko-KR')}원`
+}
+
+const ACCOUNT_EMOJI: Record<string, string> = { '소담': '👧', '다솜': '👶' }
+
+export default function KidsClient({
+  accountName, ownerAge, level, totalValue, totalCost, totalReturn,
+  holdings, dividendTotal, compoundFinalValue, compoundYears, compoundMonthly,
+}: Props) {
+  const accountEmoji = ACCOUNT_EMOJI[accountName] ?? '👤'
+  const growth = totalValue - totalCost
+
+  return (
+    <div className="min-h-screen px-4 sm:px-8 py-8 max-w-[600px] mx-auto">
+      {/* 헤더 */}
+      <div className="text-center mb-8">
+        <h1 className="text-[28px] font-extrabold text-bright">
+          <span className="text-[36px]">{accountEmoji}</span> {accountName}이의 투자 일기
+        </h1>
+        <p className="text-[14px] text-sub mt-1">
+          {level.emoji} {level.label} 레벨 {ownerAge != null ? `(${ownerAge}세)` : ''}
+        </p>
+      </div>
+
+      {/* 총 자산 카드 */}
+      <div className="relative overflow-hidden rounded-[20px] border border-sodam/20 bg-sodam/5 p-7 text-center mb-6">
+        <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-sodam to-transparent opacity-60" />
+        <div className="text-[14px] text-sub">💰 내 투자 총액</div>
+        <div className="text-[36px] font-extrabold text-bright mt-2">
+          {formatKRW(totalValue)}
+        </div>
+        <div className={`text-[16px] font-semibold mt-1 ${growth >= 0 ? 'text-sejin' : 'text-red-400'}`}>
+          {growth >= 0 ? '📈' : '📉'} {growth >= 0 ? '+' : ''}{formatKRW(growth)} 자랐어! ({totalReturn >= 0 ? '+' : ''}{totalReturn.toFixed(1)}%)
+        </div>
+      </div>
+
+      {/* 보유 종목 */}
+      <h2 className="text-[18px] font-bold text-bright mb-3">🏢 내가 가진 회사들</h2>
+      <div className="flex flex-col gap-3 mb-6">
+        {holdings.map((h) => (
+          <div key={h.ticker} className="flex items-center gap-4 p-4 rounded-[16px] bg-card border border-border">
+            <span className="text-[32px]">{h.emoji}</span>
+            <div className="flex-1">
+              <div className="text-[15px] font-bold text-bright">{h.displayName}</div>
+              <div className="text-[12px] text-sub">{h.description}</div>
+            </div>
+            <div className="text-right">
+              <div className="text-[14px] font-semibold text-bright">{formatKRW(h.valueKRW)}</div>
+              <div className={`text-[13px] font-semibold ${h.returnPct >= 0 ? 'text-sejin' : 'text-red-400'}`}>
+                {h.returnPct >= 0 ? '+' : ''}{h.returnPct.toFixed(1)}% {h.returnPct >= 100 ? '🚀' : h.returnPct >= 0 ? '📈' : '📉'}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 배당금 */}
+      {dividendTotal > 0 && (
+        <>
+          <h2 className="text-[18px] font-bold text-bright mb-3">🎁 회사가 준 용돈 (배당금)</h2>
+          <div className="rounded-[16px] border border-yellow-500/15 bg-yellow-500/5 p-5 text-center mb-6">
+            <span className="text-[40px]">🎁</span>
+            <div className="text-[14px] text-yellow-400 mt-2">올해 회사들이 {accountName}이에게 준 용돈</div>
+            <div className="text-[20px] font-bold text-bright mt-1">{formatKRW(dividendTotal)}</div>
+          </div>
+        </>
+      )}
+
+      {/* 복리 미리보기 */}
+      <h2 className="text-[18px] font-bold text-bright mb-3">🔮 미래 미리보기</h2>
+      <div className="rounded-[16px] border border-sejin/15 bg-sejin/5 p-5 text-center">
+        <div className="text-[14px] text-sejin">
+          매달 {(compoundMonthly / 10000).toFixed(0)}만원씩 넣으면 {compoundYears}년 후
+        </div>
+        <div className="text-[24px] font-extrabold text-bright mt-2">
+          {formatKRW(compoundFinalValue)}!
+        </div>
+        <div className="text-[12px] text-sub mt-2">
+          지금 가진 돈이 계속 자라면서 + 매달 조금씩 넣으면 이렇게 돼요 ✨
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/kids/[accountId]/page.tsx
+++ b/src/app/kids/[accountId]/page.tsx
@@ -1,0 +1,122 @@
+import { prisma } from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import {
+  calcCostKRW,
+  calcCurrentValueKRW,
+  DEFAULT_FX_RATE_USD_KRW,
+} from '@/lib/format'
+import { getStockDescription, getDescriptionByName } from '@/lib/kids/stock-descriptions'
+import { simulateAccount } from '@/lib/simulator/compound-engine'
+import KidsClient from './KidsClient'
+
+export const dynamic = 'force-dynamic'
+
+interface HoldingData {
+  ticker: string
+  displayName: string
+  emoji: string
+  description: string
+  valueKRW: number
+  costKRW: number
+  returnPct: number
+  shares: number
+}
+
+function getLevel(age: number | null): { level: number; label: string; emoji: string } {
+  if (age == null || age <= 8) return { level: 1, label: '씨앗', emoji: '🌱' }
+  if (age <= 12) return { level: 2, label: '새싹', emoji: '🌿' }
+  if (age <= 15) return { level: 3, label: '나무', emoji: '🌳' }
+  return { level: 4, label: '산', emoji: '🏔️' }
+}
+
+export default async function KidsPage({
+  params,
+}: {
+  params: { accountId: string }
+}) {
+  const account = await prisma.account.findUnique({
+    where: { id: params.accountId },
+    include: { holdings: true },
+  })
+
+  if (!account) notFound()
+
+  const fxCache = await prisma.priceCache.findUnique({ where: { ticker: 'USDKRW=X' } })
+  const fxRate = fxCache?.price ?? DEFAULT_FX_RATE_USD_KRW
+
+  const tickers = account.holdings.map((h) => h.ticker)
+  const prices = tickers.length > 0
+    ? await prisma.priceCache.findMany({ where: { ticker: { in: tickers } } })
+    : []
+  const priceMap = new Map(prices.map((p) => [p.ticker, p.price]))
+
+  let totalValue = 0
+  let totalCost = 0
+
+  const holdingData: HoldingData[] = account.holdings.map((h) => {
+    const cost = calcCostKRW(h)
+    const cp = priceMap.get(h.ticker)
+    let value = cost
+    if (cp != null) {
+      value = calcCurrentValueKRW(h, cp, h.currency === 'USD' ? fxRate : 1)
+    } else if (h.currency === 'USD' && h.avgPriceFx != null) {
+      value = Math.round(h.avgPriceFx * h.shares * fxRate)
+    }
+    totalValue += value
+    totalCost += cost
+    const returnPct = cost > 0 ? ((value - cost) / cost) * 100 : 0
+
+    const desc = getStockDescription(h.ticker)
+    const nameDesc = desc.emoji === '🏢' ? getDescriptionByName(h.displayName) : desc
+
+    return {
+      ticker: h.ticker,
+      displayName: h.displayName,
+      emoji: nameDesc.emoji,
+      description: nameDesc.desc,
+      valueKRW: value,
+      costKRW: cost,
+      returnPct,
+      shares: h.shares,
+    }
+  }).sort((a, b) => b.valueKRW - a.valueKRW)
+
+  const totalReturn = totalCost > 0 ? ((totalValue - totalCost) / totalCost) * 100 : 0
+  const level = getLevel(account.ownerAge)
+
+  // 배당금 (올해)
+  const yearStart = new Date(Date.UTC(new Date().getFullYear(), 0, 1))
+  const dividends = await prisma.dividend.findMany({
+    where: { accountId: account.id, payDate: { gte: yearStart } },
+  })
+  const dividendTotal = dividends.reduce((s, d) => s + d.amountKRW, 0)
+
+  // 복리 미리보기
+  const monthlyContribution = 50000
+  const yearsToAdult = account.ownerAge != null ? Math.max(1, 20 - account.ownerAge) : 10
+  const sim = simulateAccount({
+    accountId: account.id,
+    accountName: account.name,
+    initialValue: totalValue,
+    monthlyContribution,
+    years: yearsToAdult,
+    ownerAge: account.ownerAge,
+  })
+  const baseScenario = sim.scenarios.find((s) => s.scenarioName === '기본')
+
+  return (
+    <KidsClient
+      accountName={account.name}
+      ownerAge={account.ownerAge}
+      level={level}
+      totalValue={totalValue}
+      totalCost={totalCost}
+      totalReturn={totalReturn}
+      holdings={holdingData}
+      dividendTotal={dividendTotal}
+      compoundFinalValue={baseScenario?.finalValue ?? totalValue}
+      compoundYears={yearsToAdult}
+      compoundMonthly={monthlyContribution}
+    />
+  )
+}

--- a/src/lib/kids/stock-descriptions.ts
+++ b/src/lib/kids/stock-descriptions.ts
@@ -1,0 +1,35 @@
+/**
+ * 아이 친화적 종목 설명
+ * ticker → { emoji, description }
+ */
+
+const STOCK_DESCRIPTIONS: Record<string, { emoji: string; desc: string }> = {
+  AAPL: { emoji: '🍎', desc: '아이폰, 맥북 만드는 회사' },
+  MSFT: { emoji: '💻', desc: '윈도우, 엑스박스 만드는 회사' },
+  NVDA: { emoji: '🎮', desc: '게임용 그래픽카드 만드는 회사' },
+  RKLB: { emoji: '🚀', desc: '우주로 로켓 쏘는 회사' },
+  AMZN: { emoji: '📦', desc: '인터넷 쇼핑몰 아마존' },
+  GOOGL: { emoji: '🔍', desc: '구글 검색, 유튜브 만드는 회사' },
+  TSLA: { emoji: '🚗', desc: '전기자동차 테슬라' },
+  META: { emoji: '👥', desc: '인스타그램, 페이스북 만드는 회사' },
+  '005930': { emoji: '📱', desc: '삼성 갤럭시 만드는 회사' },
+  '035720': { emoji: '💬', desc: '카카오톡 만드는 회사' },
+}
+
+const DEFAULT_DESC = { emoji: '🏢', desc: '여러 가지를 만드는 회사' }
+
+export function getStockDescription(ticker: string): { emoji: string; desc: string } {
+  // 한국 ETF는 displayName으로 매칭
+  return STOCK_DESCRIPTIONS[ticker] ?? DEFAULT_DESC
+}
+
+/** displayName 기반 매칭 (ETF 등) */
+export function getDescriptionByName(displayName: string): { emoji: string; desc: string } {
+  if (displayName.includes('S&P500') || displayName.includes('S&P')) return { emoji: '🐯', desc: '미국 500대 회사에 골고루 투자' }
+  if (displayName.includes('나스닥') || displayName.includes('NASDAQ')) return { emoji: '💡', desc: '미국 기술 회사들에 투자' }
+  if (displayName.includes('배당')) return { emoji: '🎁', desc: '용돈(배당금) 잘 주는 회사들' }
+  if (displayName.includes('카카오')) return { emoji: '💬', desc: '카카오톡 만드는 회사' }
+  if (displayName.includes('삼성')) return { emoji: '📱', desc: '삼성 갤럭시 만드는 회사' }
+  if (displayName.includes('로보틱스') || displayName.includes('로봇')) return { emoji: '🤖', desc: '로봇 만드는 회사' }
+  return DEFAULT_DESC
+}


### PR DESCRIPTION
## Summary

- `/kids/[accountId]` 페이지: 아이 친화적 투자 대시보드
- 나이별 레벨 자동 판정 (🌱 씨앗 5~8, 🌿 새싹 9~12, 🌳 나무 13~15)
- 총 자산 카드 + 성장률 (큰 글씨, 이모지)
- 종목별 카드: 이모지 + 설명 ("아이폰 만드는 회사") + 수익률
- 배당금 섹션 ("회사가 준 용돈")
- 복리 미리보기 ("매달 5만원 → 20살 때 약 1,500만원!")
- 종목 설명 매핑 (stock-descriptions.ts)

### 코드 리뷰
- 1회, P1/P2: 0건

Closes #163

## Checklist
- [x] lint / typecheck / build 통과
- [x] 코드 리뷰 통과

## Test plan
- [ ] /kids/[소담ID] → 새싹 레벨, 종목 이모지+설명
- [ ] /kids/[다솜ID] → 씨앗 레벨
- [ ] 배당금 있는 계좌 → 배당 섹션 표시
- [ ] 복리 미리보기 → 20살 기준 금액