### PR TITLE
[Phase 15-B] 내 투자 이야기 타임라인 (#165)

### DIFF
--- a/src/app/kids/[accountId]/KidsClient.tsx
+++ b/src/app/kids/[accountId]/KidsClient.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Link from 'next/link'
+
 interface HoldingData {
   ticker: string
   displayName: string
@@ -12,6 +14,7 @@ interface HoldingData {
 }
 
 interface Props {
+  accountId: string
   accountName: string
   ownerAge: number | null
   level: { level: number; label: string; emoji: string }
@@ -34,7 +37,7 @@ function formatKRW(n: number): string {
 const ACCOUNT_EMOJI: Record<string, string> = { '소담': '👧', '다솜': '👶' }
 
 export default function KidsClient({
-  accountName, ownerAge, level, totalValue, totalCost, totalReturn,
+  accountId, accountName, ownerAge, level, totalValue, totalCost, totalReturn,
   holdings, dividendTotal, compoundFinalValue, compoundYears, compoundMonthly,
 }: Props) {
   const accountEmoji = ACCOUNT_EMOJI[accountName] ?? '👤'
@@ -109,6 +112,17 @@ export default function KidsClient({
           지금 가진 돈이 계속 자라면서 + 매달 조금씩 넣으면 이렇게 돼요 ✨
         </div>
       </div>
+
+      {/* 타임라인 링크 */}
+      <Link
+        href={`/kids/${accountId}/timeline`}
+        className="block mt-6 rounded-[16px] border border-border bg-card p-5 text-center
+          hover:bg-card-hover hover:border-border-hover transition-all"
+      >
+        <span className="text-[24px]">📖</span>
+        <div className="text-[14px] font-bold text-bright mt-2">내 투자 이야기 보기</div>
+        <div className="text-[12px] text-sub mt-1">투자를 시작한 날부터 지금까지</div>
+      </Link>
     </div>
   )
 }

--- a/src/app/kids/[accountId]/page.tsx
+++ b/src/app/kids/[accountId]/page.tsx
@@ -106,6 +106,7 @@ export default async function KidsPage({
 
   return (
     <KidsClient
+      accountId={account.id}
       accountName={account.name}
       ownerAge={account.ownerAge}
       level={level}

--- a/src/app/kids/[accountId]/timeline/TimelineClient.tsx
+++ b/src/app/kids/[accountId]/timeline/TimelineClient.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import Link from 'next/link'
+
+interface TimelineEvent {
+  date: string
+  emoji: string
+  title: string
+  description: string
+}
+
+interface Props {
+  accountName: string
+  events: TimelineEvent[]
+  accountId: string
+}
+
+const ACCOUNT_EMOJI: Record<string, string> = { '소담': '👧', '다솜': '👶' }
+
+export default function TimelineClient({ accountName, events, accountId }: Props) {
+  const accountEmoji = ACCOUNT_EMOJI[accountName] ?? '👤'
+
+  return (
+    <div className="min-h-screen px-4 sm:px-8 py-8 max-w-[600px] mx-auto">
+      {/* 헤더 */}
+      <div className="text-center mb-8">
+        <h1 className="text-[28px] font-extrabold text-bright">
+          📖 {accountName}이의 투자 이야기
+        </h1>
+        <p className="text-[14px] text-sub mt-1">
+          {accountEmoji} 투자를 시작한 날부터 지금까지
+        </p>
+        <Link
+          href={`/kids/${accountId}`}
+          className="inline-block mt-3 text-[12px] text-sodam hover:text-sodam/80 transition-colors"
+        >
+          ← 대시보드로 돌아가기
+        </Link>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="text-center text-sub py-12">
+          <span className="text-[48px]">📭</span>
+          <p className="mt-4 text-[14px]">아직 투자 이야기가 없어요!</p>
+          <p className="text-[12px] text-dim mt-1">첫 투자를 하면 여기에 기록돼요</p>
+        </div>
+      ) : (
+        <div className="relative">
+          {/* 타임라인 세로선 */}
+          <div className="absolute left-6 top-0 bottom-0 w-px bg-border" />
+
+          <div className="flex flex-col gap-0">
+            {events.map((event, i) => {
+              // 연도 구분
+              const year = event.date.slice(0, 4)
+              const prevYear = i > 0 ? events[i - 1].date.slice(0, 4) : ''
+              const showYear = year !== prevYear
+
+              return (
+                <div key={`${event.date}-${i}`}>
+                  {showYear && (
+                    <div className="relative pl-14 py-3">
+                      <div className="absolute left-[18px] w-3 h-3 rounded-full bg-sodam border-2 border-bg" />
+                      <div className="text-[16px] font-bold text-sodam">{year}년</div>
+                    </div>
+                  )}
+                  <div className="relative pl-14 py-3">
+                    <div className="absolute left-[21px] w-[7px] h-[7px] rounded-full bg-dim" />
+                    <div className="bg-card border border-border rounded-[14px] p-4">
+                      <div className="flex items-start gap-3">
+                        <span className="text-[24px] flex-shrink-0">{event.emoji}</span>
+                        <div className="flex-1">
+                          <div className="text-[14px] font-bold text-bright">{event.title}</div>
+                          <div className="text-[12px] text-sub mt-1">{event.description}</div>
+                          <div className="text-[11px] text-dim mt-2">{event.date}</div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {/* 현재 */}
+          <div className="relative pl-14 py-3">
+            <div className="absolute left-[18px] w-3 h-3 rounded-full bg-sejin border-2 border-bg animate-pulse" />
+            <div className="text-[14px] font-bold text-sejin">
+              지금! 계속 자라는 중 🌱
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/kids/[accountId]/timeline/page.tsx
+++ b/src/app/kids/[accountId]/timeline/page.tsx
@@ -1,0 +1,29 @@
+import { prisma } from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import { collectTimeline } from '@/lib/kids/timeline'
+import TimelineClient from './TimelineClient'
+
+export const dynamic = 'force-dynamic'
+
+export default async function TimelinePage({
+  params,
+}: {
+  params: { accountId: string }
+}) {
+  const account = await prisma.account.findUnique({
+    where: { id: params.accountId },
+    select: { id: true, name: true, ownerAge: true },
+  })
+
+  if (!account) notFound()
+
+  const events = await collectTimeline(account.id)
+
+  return (
+    <TimelineClient
+      accountName={account.name}
+      events={events}
+      accountId={account.id}
+    />
+  )
+}

--- a/src/lib/kids/timeline.ts
+++ b/src/lib/kids/timeline.ts
@@ -1,0 +1,86 @@
+/**
+ * "내 투자 이야기" 타임라인 이벤트 수집
+ *
+ * 거래, 배당, 증여 등 주요 이벤트를 아이 친화적 텍스트로 변환.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { getStockDescription, getDescriptionByName } from './stock-descriptions'
+
+export interface TimelineEvent {
+  date: string
+  emoji: string
+  title: string
+  description: string
+}
+
+export async function collectTimeline(accountId: string): Promise<TimelineEvent[]> {
+  const events: TimelineEvent[] = []
+
+  // 거래 내역
+  const trades = await prisma.trade.findMany({
+    where: { accountId },
+    orderBy: { tradedAt: 'asc' },
+    select: { ticker: true, displayName: true, type: true, shares: true, tradedAt: true },
+  })
+
+  const firstTrade = trades[0]
+  if (firstTrade) {
+    events.push({
+      date: firstTrade.tradedAt.toISOString().slice(0, 10),
+      emoji: '🎉',
+      title: '투자 시작!',
+      description: `첫 번째 주식을 샀어!`,
+    })
+  }
+
+  // 매수 이벤트 (첫 거래 제외)
+  for (const t of trades.slice(1)) {
+    if (t.type !== 'BUY') continue
+    const desc = getStockDescription(t.ticker)
+    const nameDesc = desc.emoji === '🏢' ? getDescriptionByName(t.displayName) : desc
+    events.push({
+      date: t.tradedAt.toISOString().slice(0, 10),
+      emoji: nameDesc.emoji,
+      title: `${t.displayName} ${t.shares}주 매수`,
+      description: `${nameDesc.desc}의 주인이 되었어!`,
+    })
+  }
+
+  // 배당금
+  const dividends = await prisma.dividend.findMany({
+    where: { accountId },
+    orderBy: { payDate: 'asc' },
+    select: { displayName: true, amountKRW: true, payDate: true },
+  })
+
+  for (const d of dividends) {
+    events.push({
+      date: d.payDate.toISOString().slice(0, 10),
+      emoji: '🎁',
+      title: '배당금 받았어!',
+      description: `${d.displayName}에서 ${Math.round(d.amountKRW).toLocaleString('ko-KR')}원 용돈이 왔어`,
+    })
+  }
+
+  // 증여 입금
+  const deposits = await prisma.deposit.findMany({
+    where: { accountId, source: { in: ['증여', 'gift'] } },
+    orderBy: { depositedAt: 'asc' },
+    select: { amount: true, depositedAt: true },
+  })
+
+  for (const d of deposits) {
+    events.push({
+      date: d.depositedAt.toISOString().slice(0, 10),
+      emoji: '💝',
+      title: '투자금 선물 받았어!',
+      description: `${Math.round(d.amount).toLocaleString('ko-KR')}원이 들어왔어`,
+    })
+  }
+
+  // 날짜순 정렬
+  events.sort((a, b) => a.date.localeCompare(b.date))
+
+  return events
+}


### PR DESCRIPTION
## Summary

- /kids/[accountId]/timeline: 투자 이야기 타임라인
- 거래/배당/증여 이벤트 수집 → 아이 친화적 텍스트 변환
- 연도별 구분 + 세로 타임라인 UI + "지금! 계속 자라는 중" 현재 마커
- KidsClient에 타임라인 링크 추가

### 코드 리뷰: 1회, P1/P2: 0건

Closes #165

## Checklist
- [x] lint / typecheck / build 통과
- [x] 코드 리뷰 통과