### PR TITLE
[Phase 17] 17-B: RSU 스케줄 CRUD (#179)

### DIFF
--- a/docs/designs/179-rsu-crud/design-notes.md
+++ b/docs/designs/179-rsu-crud/design-notes.md
@@ -1,0 +1,41 @@
+# RSU 스케줄 CRUD 디자인 노트 — #179
+
+## 디자인 방향
+
+기존 RSUDashboard에 추가/수정/삭제 기능을 확장. 기존 CRUD 패턴(슬라이드 폼 + 삭제 모달) 재사용.
+
+## 변경 영역
+
+### RSUDashboard 확장
+- 헤더에 "+ RSU 추가" 버튼 (sodam 색상)
+- 각 스케줄 카드에 수정(연필) / 삭제(휴지통) 아이콘 추가
+- vested 상태: 수정/삭제 비활성화 (opacity 0.3)
+- pending 상태만 수정/삭제 가능
+
+### RSUForm (슬라이드 패널)
+- 기존 CategoryForm 패턴 (420px 우측 슬라이드)
+- 필드:
+  - 계좌: select (세진/소담/다솜)
+  - 베스팅일: date input
+  - 수량: number
+  - 기준금액: number (원)
+  - 기준일: date (optional)
+  - 매도 예정 수량: number (optional)
+  - 보유 예정 수량: number (optional)
+  - 메모: text (optional)
+- 수정 모드: 기존값 prefill
+
+### RSUDeleteModal
+- 기존 CategoryDeleteModal 패턴 (중앙 모달)
+- 정보 카드: 베스팅일, 수량, 기준금액
+- pending 상태만 삭제 가능
+- "삭제된 RSU 스케줄은 복구할 수 없습니다."
+
+## UI 컴포넌트
+
+| 요소 | 구현 방식 |
+|------|----------|
+| 추가 버튼 | sodam 색상, 헤더 우측 |
+| 폼 | 우측 슬라이드 패널 420px |
+| 삭제 확인 | 중앙 모달 |
+| 액션 버튼 | 연필 + 휴지통 아이콘 (vested 비활성) |

--- a/docs/implementation_plans/179-rsu-crud.md
+++ b/docs/implementation_plans/179-rsu-crud.md
@@ -1,0 +1,38 @@
+# 17-B: RSU 스케줄 CRUD — 구현 계획
+
+## 변경 파일 목록
+
+### 신규
+- `src/app/api/rsu/[id]/route.ts` — PUT, DELETE
+- `src/components/rsu/RSUForm.tsx` — 추가/수정 슬라이드 패널
+- `src/components/rsu/RSUDeleteModal.tsx` — 삭제 확인 모달
+
+### 수정
+- `src/app/api/rsu/route.ts` — POST 추가
+- `src/components/rsu/RSUDashboard.tsx` — 추가 버튼, 수정/삭제 아이콘, 폼/모달 통합
+- `src/app/rsu/page.tsx` — 계좌 목록 전달 (폼 select용)
+
+## 패키지 추가
+없음
+
+## DB 마이그레이션
+없음
+
+## 구현 순서
+
+### Step 1: POST /api/rsu + PUT/DELETE /api/rsu/[id]
+- POST: 스케줄 생성 (accountId, vestingDate, shares, basisValue 등)
+- PUT: pending 상태만 수정 가능
+- DELETE: pending 상태만 삭제 가능
+
+### Step 2: RSUForm (슬라이드 패널)
+- 기존 슬라이드 패널 패턴
+- 필드: 계좌, 베스팅일, 수량, 기준금액, 기준일, 매도/보유 예정, 메모
+
+### Step 3: RSUDeleteModal
+- 기존 삭제 모달 패턴
+
+### Step 4: RSUDashboard 확장
+- "+ RSU 추가" 버튼
+- 카드별 수정/삭제 아이콘 (pending만)
+- 폼/모달 상태 관리 + refetch

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -207,7 +207,7 @@
 
 ## Phase 17: 설정/관리 페이지 (Admin Center)
 
-- [ ] **17-A**: 계좌 관리 (PATCH API + AccountEditor)
+- [x] **17-A**: 계좌 관리 (PATCH API + AccountEditor)
 - [ ] **17-B**: RSU 스케줄 CRUD (추가/수정/삭제 API + UI)
 - [ ] **17-C**: 스톡옵션 CRUD (옵션 + 행사 스케줄 관리)
 - [ ] **17-D**: 관심종목 웹 관리 (API + /watchlist 페이지)

--- a/src/app/api/rsu/[id]/route.ts
+++ b/src/app/api/rsu/[id]/route.ts
@@ -19,14 +19,6 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
     }
 
-    const existing = await prisma.rSUSchedule.findUnique({ where: { id } })
-    if (!existing) {
-      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
-    }
-    if (existing.status !== 'pending') {
-      return NextResponse.json({ error: '베스팅 완료된 스케줄은 수정할 수 없습니다.' }, { status: 400 })
-    }
-
     if (typeof body.shares === 'number' && (!Number.isInteger(body.shares) || body.shares <= 0)) {
       return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
     }
@@ -44,14 +36,24 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (body.keepShares !== undefined) data.keepShares = typeof body.keepShares === 'number' ? body.keepShares : null
     if (body.note !== undefined) data.note = typeof body.note === 'string' ? body.note.trim() || null : null
 
-    const updated = await prisma.rSUSchedule.update({
-      where: { id },
-      data,
-      include: { account: { select: { id: true, name: true } } },
-    })
+    // 트랜잭션: pending 체크 + update 원자적 처리
+    const updated = await prisma.$transaction(async (tx) => {
+      const existing = await tx.rSUSchedule.findUnique({ where: { id } })
+      if (!existing) throw new Error('NOT_FOUND')
+      if (existing.status !== 'pending') throw new Error('NOT_PENDING')
+      return tx.rSUSchedule.update({
+        where: { id },
+        data,
+        include: { account: { select: { id: true, name: true } } },
+      })
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
     return NextResponse.json(updated)
   } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'NOT_FOUND') return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+      if (error.message === 'NOT_PENDING') return NextResponse.json({ error: '베스팅 완료된 스케줄은 수정할 수 없습니다.' }, { status: 400 })
+    }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
     }
@@ -67,17 +69,20 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
 
-    const existing = await prisma.rSUSchedule.findUnique({ where: { id } })
-    if (!existing) {
-      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
-    }
-    if (existing.status !== 'pending') {
-      return NextResponse.json({ error: '베스팅 완료된 스케줄은 삭제할 수 없습니다.' }, { status: 400 })
-    }
+    // 트랜잭션: pending 체크 + delete 원자적 처리
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.rSUSchedule.findUnique({ where: { id } })
+      if (!existing) throw new Error('NOT_FOUND')
+      if (existing.status !== 'pending') throw new Error('NOT_PENDING')
+      await tx.rSUSchedule.delete({ where: { id } })
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    await prisma.rSUSchedule.delete({ where: { id } })
     return new NextResponse(null, { status: 204 })
   } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'NOT_FOUND') return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+      if (error.message === 'NOT_PENDING') return NextResponse.json({ error: '베스팅 완료된 스케줄은 삭제할 수 없습니다.' }, { status: 400 })
+    }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
     }

--- a/src/app/api/rsu/[id]/route.ts
+++ b/src/app/api/rsu/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { Prisma } from '@prisma/client'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * PUT /api/rsu/[id] — pending 상태만 수정 가능
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params
+    let body: Record<string, unknown>
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+    }
+
+    const existing = await prisma.rSUSchedule.findUnique({ where: { id } })
+    if (!existing) {
+      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+    }
+    if (existing.status !== 'pending') {
+      return NextResponse.json({ error: '베스팅 완료된 스케줄은 수정할 수 없습니다.' }, { status: 400 })
+    }
+
+    if (typeof body.shares === 'number' && (!Number.isInteger(body.shares) || body.shares <= 0)) {
+      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+    }
+    if (typeof body.basisValue === 'number' && body.basisValue < 0) {
+      return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
+    }
+
+    const data: Record<string, unknown> = {}
+    if (body.vestingDate && typeof body.vestingDate === 'string') data.vestingDate = new Date(body.vestingDate)
+    if (typeof body.shares === 'number') data.shares = body.shares
+    if (typeof body.basisValue === 'number') data.basisValue = body.basisValue
+    if (body.basisDate !== undefined) data.basisDate = body.basisDate ? new Date(body.basisDate as string) : null
+    if (body.basisPrice !== undefined) data.basisPrice = typeof body.basisPrice === 'number' ? body.basisPrice : null
+    if (body.sellShares !== undefined) data.sellShares = typeof body.sellShares === 'number' ? body.sellShares : null
+    if (body.keepShares !== undefined) data.keepShares = typeof body.keepShares === 'number' ? body.keepShares : null
+    if (body.note !== undefined) data.note = typeof body.note === 'string' ? body.note.trim() || null : null
+
+    const updated = await prisma.rSUSchedule.update({
+      where: { id },
+      data,
+      include: { account: { select: { id: true, name: true } } },
+    })
+
+    return NextResponse.json(updated)
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+    }
+    console.error('PUT /api/rsu/[id] error:', error)
+    return NextResponse.json({ error: 'RSU 스케줄 수정에 실패했습니다.' }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/rsu/[id] — pending 상태만 삭제 가능
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params
+
+    const existing = await prisma.rSUSchedule.findUnique({ where: { id } })
+    if (!existing) {
+      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+    }
+    if (existing.status !== 'pending') {
+      return NextResponse.json({ error: '베스팅 완료된 스케줄은 삭제할 수 없습니다.' }, { status: 400 })
+    }
+
+    await prisma.rSUSchedule.delete({ where: { id } })
+    return new NextResponse(null, { status: 204 })
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+    }
+    console.error('DELETE /api/rsu/[id] error:', error)
+    return NextResponse.json({ error: 'RSU 스케줄 삭제에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/rsu/route.ts
+++ b/src/app/api/rsu/route.ts
@@ -46,6 +46,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
     }
 
+    const shares = body.shares as number
+    if (typeof body.sellShares === 'number' && (body.sellShares < 0 || body.sellShares > shares)) {
+      return NextResponse.json({ error: '매도 예정 수량은 0 이상, 총 수량 이하여야 합니다.' }, { status: 400 })
+    }
+    if (typeof body.keepShares === 'number' && (body.keepShares < 0 || body.keepShares > shares)) {
+      return NextResponse.json({ error: '보유 예정 수량은 0 이상, 총 수량 이하여야 합니다.' }, { status: 400 })
+    }
+
     const schedule = await prisma.rSUSchedule.create({
       data: {
         accountId: body.accountId as string,

--- a/src/app/api/rsu/route.ts
+++ b/src/app/api/rsu/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { Prisma } from '@prisma/client'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,5 +18,55 @@ export async function GET() {
       { error: 'RSU 스케줄을 불러올 수 없습니다.' },
       { status: 500 }
     )
+  }
+}
+
+/**
+ * POST /api/rsu — RSU 스케줄 추가
+ */
+export async function POST(request: NextRequest) {
+  try {
+    let body: Record<string, unknown>
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+    }
+
+    if (!body.accountId || typeof body.accountId !== 'string') {
+      return NextResponse.json({ error: '계좌를 선택해주세요.' }, { status: 400 })
+    }
+    if (!body.vestingDate || typeof body.vestingDate !== 'string') {
+      return NextResponse.json({ error: '베스팅일을 입력해주세요.' }, { status: 400 })
+    }
+    if (typeof body.shares !== 'number' || !Number.isInteger(body.shares) || body.shares <= 0) {
+      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+    }
+    if (typeof body.basisValue !== 'number' || body.basisValue < 0) {
+      return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
+    }
+
+    const schedule = await prisma.rSUSchedule.create({
+      data: {
+        accountId: body.accountId as string,
+        vestingDate: new Date(body.vestingDate as string),
+        shares: body.shares as number,
+        basisValue: body.basisValue as number,
+        basisDate: body.basisDate ? new Date(body.basisDate as string) : null,
+        basisPrice: typeof body.basisPrice === 'number' ? body.basisPrice : null,
+        sellShares: typeof body.sellShares === 'number' ? body.sellShares : null,
+        keepShares: typeof body.keepShares === 'number' ? body.keepShares : null,
+        note: typeof body.note === 'string' ? body.note.trim() || null : null,
+      },
+      include: { account: { select: { id: true, name: true } } },
+    })
+
+    return NextResponse.json(schedule, { status: 201 })
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
+      return NextResponse.json({ error: '존재하지 않는 계좌입니다.' }, { status: 400 })
+    }
+    console.error('POST /api/rsu error:', error)
+    return NextResponse.json({ error: 'RSU 스케줄 생성에 실패했습니다.' }, { status: 500 })
   }
 }

--- a/src/app/rsu/page.tsx
+++ b/src/app/rsu/page.tsx
@@ -5,10 +5,13 @@ import RSUDashboard from '@/components/rsu/RSUDashboard'
 export const dynamic = 'force-dynamic'
 
 export default async function RSUPage() {
-  const schedules = await prisma.rSUSchedule.findMany({
-    orderBy: { vestingDate: 'asc' },
-    include: { account: { select: { id: true, name: true } } },
-  })
+  const [schedules, accounts] = await Promise.all([
+    prisma.rSUSchedule.findMany({
+      orderBy: { vestingDate: 'asc' },
+      include: { account: { select: { id: true, name: true } } },
+    }),
+    prisma.account.findMany({ select: { id: true, name: true } }),
+  ])
 
   const serialized = schedules.map((s) => ({
     ...s,
@@ -28,7 +31,7 @@ export default async function RSUPage() {
       />
 
       <div className="mt-5">
-        <RSUDashboard schedules={serialized} />
+        <RSUDashboard schedules={serialized} accounts={accounts} />
       </div>
     </div>
   )

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import Card from '@/components/ui/Card'
 import { formatKRW, formatDate } from '@/lib/format'
+import RSUForm from './RSUForm'
+import RSUDeleteModal from './RSUDeleteModal'
 
 interface RSUSchedule {
   id: string
@@ -21,15 +23,31 @@ interface RSUSchedule {
 
 interface RSUDashboardProps {
   schedules: RSUSchedule[]
+  accounts?: { id: string; name: string }[]
 }
 
-export default function RSUDashboard({ schedules: initialSchedules }: RSUDashboardProps) {
+export default function RSUDashboard({ schedules: initialSchedules, accounts = [] }: RSUDashboardProps) {
   const [schedules, setSchedules] = useState(initialSchedules)
   const [vestingId, setVestingId] = useState<string | null>(null)
   const [vestPrice, setVestPrice] = useState('')
   const [autoSell, setAutoSell] = useState(true)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // CRUD 상태
+  const [showForm, setShowForm] = useState(false)
+  const [editingItem, setEditingItem] = useState<RSUSchedule | null>(null)
+  const [deletingItem, setDeletingItem] = useState<RSUSchedule | null>(null)
+
+  const refreshSchedules = async () => {
+    try {
+      const res = await fetch('/api/rsu')
+      if (res.ok) {
+        const data = await res.json()
+        setSchedules(data.schedules ?? [])
+      }
+    } catch {}
+  }
 
   const handleVest = async (id: string) => {
     const price = parseFloat(vestPrice)
@@ -89,6 +107,16 @@ export default function RSUDashboard({ schedules: initialSchedules }: RSUDashboa
 
   return (
     <div className="space-y-4">
+      {/* 추가 버튼 */}
+      <div className="flex justify-end">
+        <button
+          onClick={() => setShowForm(true)}
+          className="inline-flex items-center gap-1.5 px-3 sm:px-4 py-2 rounded-lg bg-sodam/15 text-sodam text-[12px] sm:text-[13px] font-semibold border border-sodam/25 hover:bg-sodam/25 transition-all"
+        >
+          + RSU 추가
+        </button>
+      </div>
+
       {schedules.map((schedule) => (
         <Card key={schedule.id}>
           <div className="flex items-start justify-between gap-4">
@@ -131,25 +159,43 @@ export default function RSUDashboard({ schedules: initialSchedules }: RSUDashboa
               )}
             </div>
 
-            {schedule.status === 'pending' && (
-              <div className="flex-shrink-0">
-                {vestingId === schedule.id ? (
-                  <button
-                    onClick={() => { setVestingId(null); setError(null) }}
-                    className="text-[12px] text-sub hover:text-muted"
-                  >
-                    취소
-                  </button>
-                ) : (
-                  <button
-                    onClick={() => setVestingId(schedule.id)}
-                    className="px-3 py-1.5 rounded-lg bg-sejin/15 text-sejin text-[12px] font-semibold border border-sejin/25 hover:bg-sejin/25 transition-all"
-                  >
-                    베스팅 처리
-                  </button>
-                )}
-              </div>
-            )}
+            <div className="flex-shrink-0 flex items-center gap-1.5">
+              {schedule.status === 'pending' && (
+                <>
+                  {vestingId === schedule.id ? (
+                    <button
+                      onClick={() => { setVestingId(null); setError(null) }}
+                      className="text-[12px] text-sub hover:text-muted"
+                    >
+                      취소
+                    </button>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => setVestingId(schedule.id)}
+                        className="px-3 py-1.5 rounded-lg bg-sejin/15 text-sejin text-[12px] font-semibold border border-sejin/25 hover:bg-sejin/25 transition-all"
+                      >
+                        베스팅
+                      </button>
+                      <button
+                        onClick={() => setEditingItem(schedule)}
+                        className="p-1.5 rounded-md text-dim hover:text-text hover:bg-surface transition-all"
+                        title="수정"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" /></svg>
+                      </button>
+                      <button
+                        onClick={() => setDeletingItem(schedule)}
+                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
+                        title="삭제"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" /></svg>
+                      </button>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
           </div>
 
           {/* 인라인 베스팅 폼 */}
@@ -220,6 +266,37 @@ export default function RSUDashboard({ schedules: initialSchedules }: RSUDashboa
       <div className="text-[11px] text-dim mt-4 px-1">
         RSU 근로소득세는 회사에서 원천징수됩니다. 이 계산은 참고용이며 법적 조언이 아닙니다.
       </div>
+
+      {/* RSU 추가/수정 폼 */}
+      {showForm && (
+        <RSUForm mode="create" accounts={accounts} onClose={() => setShowForm(false)} onSaved={refreshSchedules} />
+      )}
+      {editingItem && (
+        <RSUForm
+          mode="edit"
+          item={{
+            id: editingItem.id,
+            accountId: editingItem.accountId,
+            vestingDate: editingItem.vestingDate,
+            shares: editingItem.shares,
+            basisValue: editingItem.basisValue,
+            basisDate: null,
+            sellShares: editingItem.sellShares,
+            keepShares: editingItem.keepShares,
+            note: editingItem.note,
+          }}
+          accounts={accounts}
+          onClose={() => setEditingItem(null)}
+          onSaved={refreshSchedules}
+        />
+      )}
+      {deletingItem && (
+        <RSUDeleteModal
+          item={{ id: deletingItem.id, vestingDate: deletingItem.vestingDate, shares: deletingItem.shares, basisValue: deletingItem.basisValue }}
+          onClose={() => setDeletingItem(null)}
+          onDeleted={refreshSchedules}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -12,6 +12,7 @@ interface RSUSchedule {
   vestingDate: string
   shares: number
   basisValue: number
+  basisDate: string | null
   vestPrice: number | null
   status: string
   sellShares: number | null
@@ -280,7 +281,7 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
             vestingDate: editingItem.vestingDate,
             shares: editingItem.shares,
             basisValue: editingItem.basisValue,
-            basisDate: null,
+            basisDate: editingItem.basisDate,
             sellShares: editingItem.sellShares,
             keepShares: editingItem.keepShares,
             note: editingItem.note,

--- a/src/components/rsu/RSUDeleteModal.tsx
+++ b/src/components/rsu/RSUDeleteModal.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { formatKRW, formatDate } from '@/lib/format'
+
+interface RSUDeleteModalProps {
+  item: { id: string; vestingDate: string; shares: number; basisValue: number }
+  onClose: () => void
+  onDeleted: () => void
+}
+
+export default function RSUDeleteModal({ item, onClose, onDeleted }: RSUDeleteModalProps) {
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleDelete = async () => {
+    setError(null)
+    setIsDeleting(true)
+    try {
+      const res = await fetch(`/api/rsu/${item.id}`, { method: 'DELETE' })
+      if (!res.ok && res.status !== 204) {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '삭제에 실패했습니다.')
+        return
+      }
+      onDeleted()
+      onClose()
+    } catch {
+      setError('네트워크 오류가 발생했습니다.')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" onClick={onClose} />
+      <div className="fixed inset-0 flex items-center justify-center z-50 px-4">
+        <div className="w-full max-w-[380px] bg-bg-raised border border-border rounded-[14px] overflow-hidden">
+          <div className="px-6 py-5">
+            <h2 className="text-[15px] font-bold text-bright mb-4">RSU 스케줄 삭제</h2>
+            <div className="bg-card border border-border rounded-lg px-4 py-3 mb-4 flex flex-col gap-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] text-dim">베스팅일</span>
+                <span className="text-[13px] text-bright">{formatDate(item.vestingDate)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] text-dim">수량</span>
+                <span className="text-[13px] text-bright tabular-nums">{item.shares}주</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] text-dim">기준금액</span>
+                <span className="text-[13px] text-bright tabular-nums">{formatKRW(item.basisValue)}</span>
+              </div>
+            </div>
+            <p className="text-[12px] text-red-400/80 leading-relaxed">삭제된 RSU 스케줄은 복구할 수 없습니다.</p>
+            {error && <div className="mt-3 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400">{error}</div>}
+          </div>
+          <div className="px-6 py-4 border-t border-border flex gap-3">
+            <button onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-border hover:bg-surface-dim transition-all">취소</button>
+            <button onClick={handleDelete} disabled={isDeleting} className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-red-500/15 text-red-400 border border-red-500/25 hover:bg-red-500/25 disabled:opacity-40 transition-all">
+              {isDeleting ? '삭제 중...' : '삭제'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/rsu/RSUForm.tsx
+++ b/src/components/rsu/RSUForm.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface AccountOption {
+  id: string
+  name: string
+}
+
+interface RSUData {
+  id: string
+  accountId: string
+  vestingDate: string
+  shares: number
+  basisValue: number
+  basisDate: string | null
+  sellShares: number | null
+  keepShares: number | null
+  note: string | null
+}
+
+interface RSUFormProps {
+  mode: 'create' | 'edit'
+  item?: RSUData
+  accounts: AccountOption[]
+  onClose: () => void
+  onSaved: () => void
+}
+
+export default function RSUForm({ mode, item, accounts, onClose, onSaved }: RSUFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [accountId, setAccountId] = useState(item?.accountId ?? accounts[0]?.id ?? '')
+  const [vestingDate, setVestingDate] = useState(item?.vestingDate?.slice(0, 10) ?? '')
+  const [shares, setShares] = useState(item ? String(item.shares) : '')
+  const [basisValue, setBasisValue] = useState(item ? String(item.basisValue) : '')
+  const [basisDate, setBasisDate] = useState(item?.basisDate?.slice(0, 10) ?? '')
+  const [sellShares, setSellShares] = useState(item?.sellShares !== null ? String(item?.sellShares) : '')
+  const [keepShares, setKeepShares] = useState(item?.keepShares !== null ? String(item?.keepShares) : '')
+  const [note, setNote] = useState(item?.note ?? '')
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    if (!vestingDate) { setError('베스팅일을 입력해주세요.'); setIsSubmitting(false); return }
+    const parsedShares = parseInt(shares)
+    if (!parsedShares || parsedShares <= 0) { setError('수량을 입력해주세요.'); setIsSubmitting(false); return }
+    const parsedBasis = parseFloat(basisValue)
+    if (isNaN(parsedBasis) || parsedBasis < 0) { setError('기준금액을 입력해주세요.'); setIsSubmitting(false); return }
+
+    const body: Record<string, unknown> = {
+      accountId,
+      vestingDate: `${vestingDate}T00:00:00.000Z`,
+      shares: parsedShares,
+      basisValue: parsedBasis,
+      basisDate: basisDate ? `${basisDate}T00:00:00.000Z` : null,
+      sellShares: sellShares ? parseInt(sellShares) : null,
+      keepShares: keepShares ? parseInt(keepShares) : null,
+      note: note.trim() || null,
+    }
+
+    try {
+      const url = mode === 'edit' ? `/api/rsu/${item!.id}` : '/api/rsu'
+      const method = mode === 'edit' ? 'PUT' : 'POST'
+      const res = await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '저장에 실패했습니다.')
+        return
+      }
+      onSaved()
+      onClose()
+    } catch {
+      setError('네트워크 오류가 발생했습니다.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const inputClasses = 'w-full bg-surface-dim border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-bright placeholder-dim focus:outline-none focus:bg-surface focus:border-border-hover transition-colors'
+  const labelClasses = 'block text-[12px] font-semibold text-sub mb-1.5'
+  const isEdit = mode === 'edit'
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" onClick={onClose} />
+      <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
+        <div className="px-6 py-5 border-b border-border flex items-center justify-between">
+          <h2 className="text-[15px] font-bold text-bright">{isEdit ? 'RSU 수정' : 'RSU 추가'}</h2>
+          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">
+          <div>
+            <label className={labelClasses}>계좌</label>
+            <select value={accountId} onChange={(e) => setAccountId(e.target.value)}
+              className={`${inputClasses} appearance-none cursor-pointer`}
+              style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 14px center' }}
+              disabled={isEdit}>
+              {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className={labelClasses}>베스팅일</label>
+            <input type="date" value={vestingDate} onChange={(e) => setVestingDate(e.target.value)} className={inputClasses} />
+          </div>
+          <div>
+            <label className={labelClasses}>수량 (주)</label>
+            <input type="number" value={shares} onChange={(e) => setShares(e.target.value)} placeholder="0" className={inputClasses} />
+          </div>
+          <div>
+            <label className={labelClasses}>기준금액 (원)</label>
+            <input type="number" value={basisValue} onChange={(e) => setBasisValue(e.target.value)} placeholder="0" className={inputClasses} />
+          </div>
+          <div>
+            <label className={labelClasses}>기준일 (선택)</label>
+            <input type="date" value={basisDate} onChange={(e) => setBasisDate(e.target.value)} className={inputClasses} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClasses}>매도 예정</label>
+              <input type="number" value={sellShares} onChange={(e) => setSellShares(e.target.value)} placeholder="주" className={inputClasses} />
+            </div>
+            <div>
+              <label className={labelClasses}>보유 예정</label>
+              <input type="number" value={keepShares} onChange={(e) => setKeepShares(e.target.value)} placeholder="주" className={inputClasses} />
+            </div>
+          </div>
+          <div>
+            <label className={labelClasses}>메모 (선택)</label>
+            <input type="text" value={note} onChange={(e) => setNote(e.target.value)} placeholder="메모" className={inputClasses} />
+          </div>
+
+          {error && <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400">{error}</div>}
+
+          <div className="flex gap-3">
+            <button type="button" onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-border hover:bg-surface-dim transition-all">취소</button>
+            <button type="submit" disabled={isSubmitting} className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-sodam/15 text-sodam border border-sodam/25 hover:bg-sodam/25 disabled:opacity-40 transition-all">
+              {isSubmitting ? '저장 중...' : isEdit ? '수정' : '추가'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <style jsx>{`
+        @keyframes slideIn { from { transform: translateX(100%); } to { transform: translateX(0); } }
+        .animate-slide-in { animation: slideIn 0.2s ease-out; }
+      `}</style>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- **POST /api/rsu**: RSU 스케줄 추가 (sellShares/keepShares 범위 검증)
- **PUT /api/rsu/[id]**: pending 상태만 수정 (Serializable 트랜잭션)
- **DELETE /api/rsu/[id]**: pending 상태만 삭제 (Serializable 트랜잭션)
- **RSUForm**: 슬라이드 패널 (계좌, 베스팅일, 수량, 기준금액 등)
- **RSUDeleteModal**: 삭제 확인 모달
- **RSUDashboard**: + RSU 추가 버튼, 수정/삭제 아이콘 (pending만)

Closes #179

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과

## Code Review
- 1차: P1 1건 (basisDate 유실) + P2 2건 (sellShares 검증, 트랜잭션) → 수정

## Test Plan
- [ ] RSU 추가 (계좌, 베스팅일, 수량, 기준금액)
- [ ] RSU 수정 (pending 상태만)
- [ ] RSU 삭제 (pending 상태만)
- [ ] vested 상태 수정/삭제 비활성 확인
- [ ] 기존 베스팅 기능 정상 동작 확인