### PR TITLE
카테고리 추천 기능 (#198)

### DIFF
--- a/docs/designs/198-category-suggestion/design-notes.md
+++ b/docs/designs/198-category-suggestion/design-notes.md
@@ -1,0 +1,37 @@
+# 카테고리 추천 칩 디자인
+
+## 위치
+
+TransactionForm에서 "내용" 입력 필드와 "카테고리" select 사이.
+카테고리 label 바로 아래, select 바로 위에 추천 칩 영역 배치.
+
+## 칩 스타일
+
+기존 프로젝트 뱃지 패턴 (`rounded-full`, `text-[11px]~[12px]`, `font-semibold`, `border`) 준수.
+
+### 기본 상태 (미선택)
+```
+bg-surface border-border text-sub hover:text-bright hover:border-border-hover
+rounded-full px-2.5 py-1 text-[12px] font-medium
+```
+
+### 선택 상태
+```
+bg-sodam/15 border-sodam/30 text-sodam
+```
+
+## 칩 내용
+
+- 아이콘 + 카테고리명: `🍽️ 외식`
+- 히스토리 소스는 건수 표시: `🥬 식료품 (15건)` — 건수는 `text-dim text-[11px]`
+
+## 동작
+
+- 추천이 없으면 칩 영역 자체를 숨김 (공간 차지 안 함)
+- 칩 클릭 시 카테고리 자동 선택 + 칩 영역 사라짐
+- `flex flex-wrap gap-1.5 mb-2`로 여러 줄 대응
+
+## 참고
+
+- 다크 테마 기본 (기존 TransactionForm과 동일)
+- 모바일 반응형: flex-wrap으로 자연스럽게 줄바꿈

--- a/docs/specs/category-suggestion.md
+++ b/docs/specs/category-suggestion.md
@@ -1,0 +1,75 @@
+# 카테고리 추천 기능
+
+## 목적
+
+웹 가계부(TransactionForm)에서 내역 추가 시 40개+ 카테고리를 수동 선택해야 하는 불편함 개선.
+내용(description) 입력 시 키워드 매칭 + 과거 거래 히스토리 기반으로 카테고리를 자동 추천한다.
+
+## 요구사항
+
+- [ ] 추천 API (`GET /api/transactions/suggest?q=...`) 구현
+  - [ ] q 파라미터 필수, 2글자 이상
+  - [ ] `matchCategory()` 키워드 매칭 재사용 (source: "keyword")
+  - [ ] Transaction description ILIKE → categoryId별 GROUP BY count (source: "history")
+  - [ ] 중복 제거 (keyword 우선), 최대 5개 반환
+- [ ] TransactionForm 추천 칩 UI
+  - [ ] description onChange → 300ms 디바운스 → suggest API 호출
+  - [ ] AbortController로 이전 요청 취소
+  - [ ] 카테고리 select 위에 추천 칩 렌더링
+  - [ ] 칩 클릭 → setCategoryId 자동 설정
+  - [ ] 추천 없으면 칩 영역 숨김
+  - [ ] 수정 모드(edit)에서도 description 변경 시 동작
+
+## 기술 설계
+
+### 추천 API
+
+**엔드포인트**: `GET /api/transactions/suggest?q=점심`
+
+**응답 형태**:
+```json
+{
+  "suggestions": [
+    { "categoryId": "xxx", "categoryName": "외식", "categoryIcon": "🍽️", "source": "keyword" },
+    { "categoryId": "yyy", "categoryName": "식료품", "categoryIcon": "🥬", "source": "history", "count": 15 }
+  ]
+}
+```
+
+**로직**:
+1. `matchCategory(q, 'expense')` + `matchCategory(q, 'income')` 호출
+2. Prisma `transaction.groupBy({ by: ['categoryId'], where: { description: { contains: q, mode: 'insensitive' } } })`
+3. keyword 매칭 결과 우선, 히스토리에서 중복 제거, 최대 5개
+
+### TransactionForm UI
+
+- 상태: `suggestions` 배열
+- 디바운스: 300ms setTimeout + clearTimeout
+- AbortController: 이전 fetch 취소
+- 칩 스타일: `bg-surface border-border rounded-full` (기존 뱃지 패턴)
+- 선택된 칩: `bg-sodam/15 border-sodam/30 text-sodam`
+
+## 변경 파일
+
+### 신규
+- `src/app/api/transactions/suggest/route.ts`
+
+### 수정
+- `src/components/expense/TransactionForm.tsx`
+
+### 재사용 (변경 없음)
+- `src/lib/category-matcher.ts`
+
+## 테스트 계획
+
+- "점심" 입력 → 외식/식료품 추천 칩 표시
+- 칩 클릭 → 카테고리 자동 선택
+- "asdf" 입력 → 추천 없음 (칩 숨김)
+- 빠른 타이핑 → 디바운스로 마지막 요청만 실행
+- lint + typecheck + build 통과
+
+## 제외 사항
+
+- DB 스키마 변경 없음
+- 텔레그램 봇 측 변경 없음
+- 새 패키지 추가 없음

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -34,10 +34,11 @@ export async function GET(request: NextRequest) {
     }
 
     const rawType = sp.get('type')
+    if (rawType && !VALID_TYPES.has(rawType)) {
+      return NextResponse.json({ error: 'type은 expense 또는 income이어야 합니다.' }, { status: 400 })
+    }
     const types: Array<'expense' | 'income'> =
-      rawType && VALID_TYPES.has(rawType)
-        ? [rawType as 'expense' | 'income']
-        : ['expense', 'income']
+      rawType ? [rawType as 'expense' | 'income'] : ['expense', 'income']
 
     // 1. 키워드 매칭
     const keywordMatchResults = await Promise.all(

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { matchCategory } from '@/lib/category-matcher'
+
+export const dynamic = 'force-dynamic'
+
+interface Suggestion {
+  categoryId: string
+  categoryName: string
+  categoryIcon: string | null
+  source: 'keyword' | 'history'
+  count?: number
+}
+
+const MAX_SUGGESTIONS = 5
+
+/**
+ * GET /api/transactions/suggest?q=점심
+ *
+ * description 기반 카테고리 추천.
+ * 1. 키워드 매칭 (category-matcher.ts 재사용)
+ * 2. 과거 거래 히스토리 (description ILIKE → categoryId별 count)
+ * 3. 중복 제거 (keyword 우선), 최대 5개
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const q = request.nextUrl.searchParams.get('q')?.trim()
+    if (!q || q.length < 2) {
+      return NextResponse.json({ suggestions: [] })
+    }
+
+    // 1. 키워드 매칭
+    const [expenseMatches, incomeMatches] = await Promise.all([
+      matchCategory(q, 'expense'),
+      matchCategory(q, 'income'),
+    ])
+
+    const keywordSuggestions: Suggestion[] = [...expenseMatches, ...incomeMatches].map((m) => ({
+      categoryId: m.id,
+      categoryName: m.name,
+      categoryIcon: m.icon,
+      source: 'keyword' as const,
+    }))
+
+    // 2. 히스토리 매칭: 과거 거래에서 description 유사 → categoryId별 count
+    const historyRows = await prisma.transaction.groupBy({
+      by: ['categoryId'],
+      where: {
+        description: { contains: q, mode: 'insensitive' },
+      },
+      _count: { categoryId: true },
+      orderBy: { _count: { categoryId: 'desc' } },
+      take: MAX_SUGGESTIONS,
+    })
+
+    const keywordCategoryIds = new Set(keywordSuggestions.map((s) => s.categoryId))
+
+    let historySuggestions: Suggestion[] = []
+    if (historyRows.length > 0) {
+      const categoryIds = historyRows
+        .filter((r) => !keywordCategoryIds.has(r.categoryId))
+        .map((r) => r.categoryId)
+
+      if (categoryIds.length > 0) {
+        const categories = await prisma.category.findMany({
+          where: { id: { in: categoryIds } },
+          select: { id: true, name: true, icon: true },
+        })
+        const catMap = new Map(categories.map((c) => [c.id, c]))
+
+        historySuggestions = historyRows
+          .filter((r) => !keywordCategoryIds.has(r.categoryId))
+          .reduce<Suggestion[]>((acc, r) => {
+            const cat = catMap.get(r.categoryId)
+            if (cat) {
+              acc.push({
+                categoryId: r.categoryId,
+                categoryName: cat.name,
+                categoryIcon: cat.icon,
+                source: 'history',
+                count: r._count.categoryId,
+              })
+            }
+            return acc
+          }, [])
+      }
+    }
+
+    const suggestions = [...keywordSuggestions, ...historySuggestions].slice(0, MAX_SUGGESTIONS)
+
+    return NextResponse.json({ suggestions })
+  } catch (error) {
+    console.error('[suggest] error:', error)
+    return NextResponse.json({ error: '추천 조회에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -60,6 +60,7 @@ export async function GET(request: NextRequest) {
       where: {
         description: { contains: q, mode: 'insensitive' },
         transactedAt: { gte: sixMonthsAgo },
+        ...(types.length === 1 ? { category: { type: types[0] } } : {}),
       },
       _count: { categoryId: true },
       orderBy: { _count: { categoryId: 'desc' } },

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -14,8 +14,11 @@ interface Suggestion {
 
 const MAX_SUGGESTIONS = 5
 
+const VALID_TYPES = new Set(['expense', 'income'])
+const MAX_QUERY_LENGTH = 100
+
 /**
- * GET /api/transactions/suggest?q=점심
+ * GET /api/transactions/suggest?q=점심&type=expense
  *
  * description 기반 카테고리 추천.
  * 1. 키워드 매칭 (category-matcher.ts 재사용)
@@ -24,18 +27,24 @@ const MAX_SUGGESTIONS = 5
  */
 export async function GET(request: NextRequest) {
   try {
-    const q = request.nextUrl.searchParams.get('q')?.trim()
+    const sp = request.nextUrl.searchParams
+    const q = sp.get('q')?.trim()?.slice(0, MAX_QUERY_LENGTH)
     if (!q || q.length < 2) {
       return NextResponse.json({ suggestions: [] })
     }
 
-    // 1. 키워드 매칭
-    const [expenseMatches, incomeMatches] = await Promise.all([
-      matchCategory(q, 'expense'),
-      matchCategory(q, 'income'),
-    ])
+    const rawType = sp.get('type')
+    const types: Array<'expense' | 'income'> =
+      rawType && VALID_TYPES.has(rawType)
+        ? [rawType as 'expense' | 'income']
+        : ['expense', 'income']
 
-    const keywordSuggestions: Suggestion[] = [...expenseMatches, ...incomeMatches].map((m) => ({
+    // 1. 키워드 매칭
+    const keywordMatchResults = await Promise.all(
+      types.map((t) => matchCategory(q, t))
+    )
+
+    const keywordSuggestions: Suggestion[] = keywordMatchResults.flat().map((m) => ({
       categoryId: m.id,
       categoryName: m.name,
       categoryIcon: m.icon,

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -42,15 +42,19 @@ export async function GET(request: NextRequest) {
       source: 'keyword' as const,
     }))
 
-    // 2. 히스토리 매칭: 과거 거래에서 description 유사 → categoryId별 count
+    // 2. 히스토리 매칭: 최근 6개월 거래에서 description 유사 → categoryId별 count
+    const sixMonthsAgo = new Date()
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+
     const historyRows = await prisma.transaction.groupBy({
       by: ['categoryId'],
       where: {
         description: { contains: q, mode: 'insensitive' },
+        transactedAt: { gte: sixMonthsAgo },
       },
       _count: { categoryId: true },
       orderBy: { _count: { categoryId: 'desc' } },
-      take: MAX_SUGGESTIONS,
+      take: MAX_SUGGESTIONS * 3,
     })
 
     const keywordCategoryIds = new Set(keywordSuggestions.map((s) => s.categoryId))

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -287,6 +287,8 @@ export default function TransactionForm({
                     key={s.categoryId}
                     type="button"
                     onClick={() => {
+                      if (timerRef.current) clearTimeout(timerRef.current)
+                      if (abortRef.current) abortRef.current.abort()
                       setCategoryId(s.categoryId)
                       setSuggestions([])
                     }}

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -84,7 +84,7 @@ export default function TransactionForm({
   const abortRef = useRef<AbortController | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const fetchSuggestions = useCallback((query: string) => {
+  const fetchSuggestions = useCallback((query: string, type: TxType) => {
     if (timerRef.current) clearTimeout(timerRef.current)
     if (abortRef.current) abortRef.current.abort()
 
@@ -93,12 +93,14 @@ export default function TransactionForm({
       return
     }
 
+    const catType = type === 'income' ? 'income' : 'expense'
+
     timerRef.current = setTimeout(async () => {
       const controller = new AbortController()
       abortRef.current = controller
       try {
         const res = await fetch(
-          `/api/transactions/suggest?q=${encodeURIComponent(query.trim())}`,
+          `/api/transactions/suggest?q=${encodeURIComponent(query.trim())}&type=${catType}`,
           { signal: controller.signal }
         )
         if (res.ok) {
@@ -260,7 +262,7 @@ export default function TransactionForm({
               value={description}
               onChange={(e) => {
                 setDescription(e.target.value)
-                fetchSuggestions(e.target.value)
+                fetchSuggestions(e.target.value, txType)
               }}
               placeholder="점심, 택시, 월급 등"
               maxLength={200}

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+interface CategorySuggestion {
+  categoryId: string
+  categoryName: string
+  categoryIcon: string | null
+  source: 'keyword' | 'history'
+  count?: number
+}
 
 interface CategoryOption {
   id: string
@@ -71,6 +79,44 @@ export default function TransactionForm({
   const [categoryId, setCategoryId] = useState(transaction?.categoryId ?? '')
   const [linkedAssetId, setLinkedAssetId] = useState(transaction?.linkedAssetId ?? '')
   const [transactedAt, setTransactedAt] = useState(toDateInputValue(transaction?.transactedAt))
+
+  const [suggestions, setSuggestions] = useState<CategorySuggestion[]>([])
+  const abortRef = useRef<AbortController | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchSuggestions = useCallback((query: string) => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (abortRef.current) abortRef.current.abort()
+
+    if (query.trim().length < 2) {
+      setSuggestions([])
+      return
+    }
+
+    timerRef.current = setTimeout(async () => {
+      const controller = new AbortController()
+      abortRef.current = controller
+      try {
+        const res = await fetch(
+          `/api/transactions/suggest?q=${encodeURIComponent(query.trim())}`,
+          { signal: controller.signal }
+        )
+        if (res.ok) {
+          const data = await res.json()
+          setSuggestions(data.suggestions ?? [])
+        }
+      } catch {
+        // AbortError or network error — ignore
+      }
+    }, 300)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [])
 
   const isTransfer = txType === 'transfer_out' || txType === 'transfer_in'
   const selectedAsset = assets.find((a) => a.id === linkedAssetId)
@@ -209,7 +255,10 @@ export default function TransactionForm({
             <input
               type="text"
               value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              onChange={(e) => {
+                setDescription(e.target.value)
+                fetchSuggestions(e.target.value)
+              }}
               placeholder="점심, 택시, 월급 등"
               maxLength={200}
               className={inputClasses}
@@ -219,6 +268,31 @@ export default function TransactionForm({
           {/* 카테고리 */}
           <div>
             <label className={labelClasses}>카테고리</label>
+            {suggestions.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {suggestions.map((s) => (
+                  <button
+                    key={s.categoryId}
+                    type="button"
+                    onClick={() => {
+                      setCategoryId(s.categoryId)
+                      setSuggestions([])
+                    }}
+                    className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[12px] font-medium border transition-all ${
+                      categoryId === s.categoryId
+                        ? 'bg-sodam/15 border-sodam/30 text-sodam'
+                        : 'bg-surface border-border text-sub hover:text-bright hover:border-border-hover'
+                    }`}
+                  >
+                    {s.categoryIcon && <span>{s.categoryIcon}</span>}
+                    <span>{s.categoryName}</span>
+                    {s.source === 'history' && s.count && (
+                      <span className="text-dim text-[11px]">({s.count}건)</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
             <select
               value={categoryId}
               onChange={(e) => setCategoryId(e.target.value)}

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -104,9 +104,12 @@ export default function TransactionForm({
         if (res.ok) {
           const data = await res.json()
           setSuggestions(data.suggestions ?? [])
+        } else {
+          setSuggestions([])
         }
-      } catch {
-        // AbortError or network error — ignore
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setSuggestions([])
       }
     }, 300)
   }, [])

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -229,7 +229,14 @@ export default function TransactionForm({
                 <button
                   key={t.value}
                   type="button"
-                  onClick={() => setTxType(t.value)}
+                  onClick={() => {
+                    setTxType(t.value)
+                    if (description.trim().length >= 2) {
+                      fetchSuggestions(description, t.value)
+                    } else {
+                      setSuggestions([])
+                    }
+                  }}
                   className={`flex-1 py-2 rounded-md text-[12px] font-semibold transition-all ${
                     txType === t.value ? t.activeClass : 'text-sub'
                   }`}


### PR DESCRIPTION
## Summary

- 추천 API (`GET /api/transactions/suggest?q=...&type=expense`) 신규
  - 키워드 매칭(`category-matcher.ts` 재사용) + 과거 거래 히스토리 groupBy 결합
  - type 필터, 최근 6개월, q 길이 상한 100자, 최대 5개 반환
- TransactionForm에 추천 칩 UI 추가
  - 300ms 디바운스 + AbortController 이전 요청 취소
  - 카테고리 select 위 추천 칩, 클릭 시 자동 선택
  - txType 변경 시 추천 재조회

Closes #198

## Checklist

- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (4회, P1/P2: 0건)

## Code Review

- 리뷰 횟수: 4회
- P0: 2건 (타입 중복 정의, 매직넘버 — 선택 반영)
- P1: 0건
- P2: 0건

## Design

- `docs/designs/198-category-suggestion/design-notes.md` 참조

🤖 Generated with [Claude Code](https://claude.com/claude-code)