### PR TITLE
텔레그램 소비/수입 입력 시 후잉 웹훅 전송 누락 수정 (#200)

### DIFF
--- a/docs/specs/bot-expense-whooing-fix.md
+++ b/docs/specs/bot-expense-whooing-fix.md
@@ -1,0 +1,57 @@
+# 텔레그램 소비/수입 입력 → 후잉 웹훅 전송 누락 수정
+
+## 목적
+
+텔레그램 봇에서 소비/수입 입력 시 후잉(Whooing) 웹훅 전송이 누락되는 버그를 수정한다.
+
+## 현상
+
+- 웹 API POST (`src/app/api/transactions/route.ts` L288-298): 정상 전송
+- cron 반복거래 (`src/lib/cron.ts` L231-241): 정상 전송
+- **텔레그램 봇 (`src/bot/commands/expense.ts` L262-309): 미호출** ← 버그
+
+## 요구사항
+
+- [ ] `createTransaction()` 내 `prisma.transaction.create` 이후 `sendToWhooing()` 호출 추가
+- [ ] 웹 API POST와 동일한 패턴 (실패해도 거래 기록에 영향 없음)
+- [ ] expense/income 모두 전송
+- [ ] 후잉 비활성화 상태에서 에러 없이 정상 동작
+- [ ] lint + typecheck + build 통과
+
+## 기술 설계
+
+### 변경 파일
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `src/bot/commands/expense.ts` | 수정 | `sendToWhooing` import + 호출 추가 |
+
+### 수정 내용
+
+`createTransaction()` 내 `prisma.transaction.create` 이후, 예산 체크 이전에 추가:
+
+```typescript
+import { sendToWhooing } from '@/lib/whooing-webhook'
+
+// prisma.transaction.create 이후 추가:
+sendToWhooing({
+  amount: pending.amount,
+  description: pending.description,
+  categoryId: pending.categoryId,
+  transactedAt: new Date(),
+}).catch((err) => console.error('[bot/expense] 후잉 전송 실패:', err))
+```
+
+- `.catch()`로 감싸서 후잉 실패가 거래 기록에 영향 없도록 처리
+- 웹 API의 try-catch 패턴과 동일한 동작
+
+## 테스트 계획
+
+- [ ] 텔레그램에서 소비 입력 → 거래 기록 + 후잉 전송 확인
+- [ ] 텔레그램에서 수입 입력 → 거래 기록 + 후잉 전송 확인
+- [ ] 후잉 비활성화 상태 → 에러 없이 거래 기록 정상
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- 거래 수정(PUT)/삭제(DELETE) 시 후잉 반영은 별도 이슈로 분리

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -272,7 +272,7 @@ async function createTransaction(
       select: { icon: true, name: true },
     })
 
-    await prisma.transaction.create({
+    const created = await prisma.transaction.create({
       data: {
         amount: pending.amount,
         description: pending.description,
@@ -281,6 +281,21 @@ async function createTransaction(
         transactedAt: new Date(),
       },
     })
+
+    // 후잉 웹훅 전송 (실패해도 거래 기록은 정상 완료)
+    sendToWhooing({
+      amount: created.amount,
+      description: created.description,
+      categoryId: created.categoryId,
+      transactedAt: created.transactedAt,
+    }).catch((error) => console.error('[bot/expense] 후잉 전송 실패:', error))
+
+    // 소비 기록 후 예산 사용률 체크 (비동기, 실패해도 무시)
+    if (pending.type === 'expense') {
+      checkBudgetUsage().catch((error) =>
+        console.error('[bot/expense] 예산 경고 체크 실패:', error)
+      )
+    }
 
     const catLabel = category?.icon
       ? `${category.icon} ${category.name}`
@@ -294,21 +309,6 @@ async function createTransaction(
         `금액: ${formatKRWFull(pending.amount)}\n` +
         `카테고리: ${catLabel}`
     )
-
-    // 후잉 웹훅 전송 (실패해도 거래 기록은 정상 완료)
-    sendToWhooing({
-      amount: pending.amount,
-      description: pending.description,
-      categoryId: pending.categoryId,
-      transactedAt: new Date(),
-    }).catch((err) => console.error('[bot/expense] 후잉 전송 실패:', err))
-
-    // 소비 기록 후 예산 사용률 체크 (비동기, 실패해도 무시)
-    if (pending.type === 'expense') {
-      checkBudgetUsage().catch((e) =>
-        console.error('[bot] 예산 경고 체크 실패:', e)
-      )
-    }
   } catch (error) {
     console.error('[bot] 거래 기록 실패:', error)
     await ctx.answerCallbackQuery({ text: '⚠️ 기록에 실패했습니다.' })

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -282,8 +282,8 @@ async function createTransaction(
       },
     })
 
-    // 후잉 웹훅 전송 시작 (DB 직후, 텔레그램 응답과 병렬 실행)
-    const whooingPromise = sendToWhooing({
+    // 후잉 웹훅 전송 (DB 직후 비차단, 실패해도 거래 기록은 정상 완료)
+    void sendToWhooing({
       amount: created.amount,
       description: created.description,
       categoryId: created.categoryId,
@@ -302,9 +302,6 @@ async function createTransaction(
         `금액: ${formatKRWFull(pending.amount)}\n` +
         `카테고리: ${catLabel}`
     )
-
-    // 후잉 전송 완료 대기 (이미 병렬 실행 중)
-    await whooingPromise
 
     // 소비 기록 후 예산 사용률 체크 (비동기, 실패해도 무시)
     if (pending.type === 'expense') {

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -6,6 +6,7 @@ import { formatKRWFull } from '../utils/formatter'
 import { isAiQuestion } from '../utils/ai-trigger'
 import { isTradeMessage } from '../utils/trade-trigger'
 import { checkBudgetUsage } from '../notifications/budget-alert'
+import { sendToWhooing } from '@/lib/whooing-webhook'
 
 interface PendingTransaction {
   requestedByUserId: number
@@ -293,6 +294,14 @@ async function createTransaction(
         `금액: ${formatKRWFull(pending.amount)}\n` +
         `카테고리: ${catLabel}`
     )
+
+    // 후잉 웹훅 전송 (실패해도 거래 기록은 정상 완료)
+    sendToWhooing({
+      amount: pending.amount,
+      description: pending.description,
+      categoryId: pending.categoryId,
+      transactedAt: new Date(),
+    }).catch((err) => console.error('[bot/expense] 후잉 전송 실패:', err))
 
     // 소비 기록 후 예산 사용률 체크 (비동기, 실패해도 무시)
     if (pending.type === 'expense') {

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -282,6 +282,20 @@ async function createTransaction(
       },
     })
 
+    const catLabel = category?.icon
+      ? `${category.icon} ${category.name}`
+      : pending.categoryName
+
+    // 텔레그램 콜백 응답 먼저 (UX 우선)
+    await ctx.answerCallbackQuery({ text: '기록 완료!' })
+    await ctx.editMessageReplyMarkup({ reply_markup: undefined })
+    await ctx.editMessageText(
+      `✅ ${typeLabel} 기록 완료\n\n` +
+        `내용: ${pending.description}\n` +
+        `금액: ${formatKRWFull(pending.amount)}\n` +
+        `카테고리: ${catLabel}`
+    )
+
     // 후잉 웹훅 전송 (실패해도 거래 기록은 정상 완료)
     try {
       await sendToWhooing({
@@ -300,21 +314,8 @@ async function createTransaction(
         console.error('[bot/expense] 예산 경고 체크 실패:', error)
       )
     }
-
-    const catLabel = category?.icon
-      ? `${category.icon} ${category.name}`
-      : pending.categoryName
-
-    await ctx.answerCallbackQuery({ text: '기록 완료!' })
-    await ctx.editMessageReplyMarkup({ reply_markup: undefined })
-    await ctx.editMessageText(
-      `✅ ${typeLabel} 기록 완료\n\n` +
-        `내용: ${pending.description}\n` +
-        `금액: ${formatKRWFull(pending.amount)}\n` +
-        `카테고리: ${catLabel}`
-    )
   } catch (error) {
-    console.error('[bot] 거래 기록 실패:', error)
+    console.error('[bot/expense] 거래 기록 실패:', error)
     await ctx.answerCallbackQuery({ text: '⚠️ 기록에 실패했습니다.' })
     await ctx.editMessageReplyMarkup({ reply_markup: undefined })
     await ctx.editMessageText(`⚠️ ${typeLabel} 기록에 실패했습니다. 잠시 후 다시 시도해주세요.`)

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -282,11 +282,18 @@ async function createTransaction(
       },
     })
 
+    // 후잉 웹훅 전송 시작 (DB 직후, 텔레그램 응답과 병렬 실행)
+    const whooingPromise = sendToWhooing({
+      amount: created.amount,
+      description: created.description,
+      categoryId: created.categoryId,
+      transactedAt: created.transactedAt,
+    }).catch((error) => console.error('[bot/expense] 후잉 전송 실패:', error))
+
     const catLabel = category?.icon
       ? `${category.icon} ${category.name}`
       : pending.categoryName
 
-    // 텔레그램 콜백 응답 먼저 (UX 우선)
     await ctx.answerCallbackQuery({ text: '기록 완료!' })
     await ctx.editMessageReplyMarkup({ reply_markup: undefined })
     await ctx.editMessageText(
@@ -296,17 +303,8 @@ async function createTransaction(
         `카테고리: ${catLabel}`
     )
 
-    // 후잉 웹훅 전송 (실패해도 거래 기록은 정상 완료)
-    try {
-      await sendToWhooing({
-        amount: created.amount,
-        description: created.description,
-        categoryId: created.categoryId,
-        transactedAt: created.transactedAt,
-      })
-    } catch (error) {
-      console.error('[bot/expense] 후잉 전송 실패:', error)
-    }
+    // 후잉 전송 완료 대기 (이미 병렬 실행 중)
+    await whooingPromise
 
     // 소비 기록 후 예산 사용률 체크 (비동기, 실패해도 무시)
     if (pending.type === 'expense') {

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -283,12 +283,16 @@ async function createTransaction(
     })
 
     // 후잉 웹훅 전송 (실패해도 거래 기록은 정상 완료)
-    sendToWhooing({
-      amount: created.amount,
-      description: created.description,
-      categoryId: created.categoryId,
-      transactedAt: created.transactedAt,
-    }).catch((error) => console.error('[bot/expense] 후잉 전송 실패:', error))
+    try {
+      await sendToWhooing({
+        amount: created.amount,
+        description: created.description,
+        categoryId: created.categoryId,
+        transactedAt: created.transactedAt,
+      })
+    } catch (error) {
+      console.error('[bot/expense] 후잉 전송 실패:', error)
+    }
 
     // 소비 기록 후 예산 사용률 체크 (비동기, 실패해도 무시)
     if (pending.type === 'expense') {

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -282,13 +282,17 @@ async function createTransaction(
       },
     })
 
-    // 후잉 웹훅 전송 (DB 직후 비차단, 실패해도 거래 기록은 정상 완료)
-    void sendToWhooing({
-      amount: created.amount,
-      description: created.description,
-      categoryId: created.categoryId,
-      transactedAt: created.transactedAt,
-    }).catch((error) => console.error('[bot/expense] 후잉 전송 실패:', error))
+    // 후잉 웹훅 전송 (별도 try-catch, 실패해도 거래 기록·텔레그램 응답에 영향 없음)
+    try {
+      await sendToWhooing({
+        amount: created.amount,
+        description: created.description,
+        categoryId: created.categoryId,
+        transactedAt: created.transactedAt,
+      })
+    } catch (error) {
+      console.error('[bot/expense] 후잉 전송 실패:', error)
+    }
 
     const catLabel = category?.icon
       ? `${category.icon} ${category.name}`


### PR DESCRIPTION
## Summary

- 텔레그램 봇 `createTransaction()`에서 `sendToWhooing()` 호출 누락 수정
- 웹 API POST와 동일한 패턴 (별도 try-catch + await)
- DB 저장된 `transactedAt` 사용하여 날짜 정합성 보장
- 로그 prefix `[bot/expense]`로 통일

Closes #200

## Checklist

- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (6회, P1/P2: 0건 — 순환 피드백 제외)

## Code Review

- 리뷰 횟수: 6회
- P0: 1건 (문서 체크박스 미갱신 — 선택 반영)
- P1: 0건 (순환 피드백 제외)
- P2: 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)