### PR TITLE
카테고리 정렬 변경 기능 — ↑/↓ 버튼 (#204)

### DIFF
--- a/docs/implementation_plans/204-category-reorder.md
+++ b/docs/implementation_plans/204-category-reorder.md
@@ -1,0 +1,24 @@
+# 구현 계획: 카테고리 정렬 변경 기능 (#204)
+
+## 변경 파일
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `src/app/api/categories/reorder/route.ts` | 신규 | 일괄 정렬 업데이트 API |
+| `src/components/category/CategoryTable.tsx` | 수정 | ↑/↓ 버튼 + handleReorder 로직 |
+
+## 구현 순서
+
+1. `src/app/api/categories/reorder/route.ts` 신규 생성
+2. `CategoryTable.tsx`에 handleReorder 함수 추가
+3. `CategoryRowDesktop`에 ↑/↓ 버튼 추가 (props로 콜백 + isFirst/isLast 전달)
+4. 모바일 카드에 ↑/↓ 버튼 추가
+5. expense 그룹 내 이동 + income 플랫 이동 분기
+
+## 패키지 추가
+
+없음
+
+## DB 마이그레이션
+
+없음 (sortOrder 필드 이미 존재)

--- a/docs/specs/204-category-reorder.md
+++ b/docs/specs/204-category-reorder.md
@@ -1,0 +1,62 @@
+# 카테고리 정렬 변경 기능
+
+## 목적
+
+카테고리 관리 페이지에서 정렬 순서를 직관적으로 변경할 수 있도록 ↑/↓ 버튼을 추가한다.
+현재는 수정 패널에서 sortOrder 숫자를 수동 입력해야 하며, 직관적이지 않다.
+
+## 요구사항
+
+- [ ] `POST /api/categories/reorder` 일괄 정렬 업데이트 API
+- [ ] CategoryTable 데스크톱: 액션 열에 ↑/↓ 버튼 추가
+- [ ] CategoryTable 모바일 카드: ↑/↓ 버튼 추가
+- [ ] expense 탭: 그룹 내에서 이동 (같은 그룹 내 인접 항목 스왑)
+- [ ] income 탭: 플랫 리스트에서 이동
+- [ ] 첫 번째 항목 ↑ 비활성화, 마지막 항목 ↓ 비활성화
+- [ ] lint + typecheck + build 통과
+
+## 기술 설계
+
+### 변경 파일
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `src/app/api/categories/reorder/route.ts` | 신규 | 일괄 정렬 업데이트 API |
+| `src/components/category/CategoryTable.tsx` | 수정 | ↑/↓ 버튼 추가 (데스크톱 + 모바일) |
+
+### Reorder API
+
+`POST /api/categories/reorder`
+
+요청:
+```json
+{ "items": [{ "id": "abc", "sortOrder": 1 }, { "id": "def", "sortOrder": 2 }] }
+```
+
+- items 배열 필수, 각 항목 id(string) + sortOrder(0-999 정수)
+- `prisma.$transaction`으로 원자적 업데이트
+- DB 마이그레이션 불필요 (sortOrder 필드 이미 존재)
+
+### CategoryTable UI
+
+**handleReorder(categoryId, direction):**
+- 인접 항목과 sortOrder 스왑
+- reorder API 호출
+- `router.refresh()`로 화면 갱신
+
+**expense 탭:** 그룹 내에서만 이동 (같은 groupId 내 인접 항목 스왑)
+**income 탭:** 플랫 리스트에서 이동
+
+## 테스트 계획
+
+- [ ] 카테고리 ↑ 클릭 → sortOrder 스왑, 화면 갱신, DB 반영
+- [ ] 첫 항목 ↑ 비활성화, 마지막 항목 ↓ 비활성화
+- [ ] expense 그룹 내 이동 정상
+- [ ] income 플랫 리스트 이동 정상
+- [ ] 모바일에서도 ↑/↓ 동작
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- 드래그앤드롭 (패키지 추가 불필요, 카테고리 수 30개 미만)
+- 그룹 간 이동 (그룹 변경은 수정 패널에서 처리)

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -47,6 +47,12 @@ export async function POST(request: NextRequest) {
       validItems.push({ id: (item as ReorderItem).id, sortOrder: (item as ReorderItem).sortOrder })
     }
 
+    // id 유니크 검증
+    const uniqueIds = new Set(validItems.map((item) => item.id))
+    if (uniqueIds.size !== validItems.length) {
+      return NextResponse.json({ error: '중복된 카테고리 ID가 있습니다.' }, { status: 400 })
+    }
+
     await prisma.$transaction(
       validItems.map((item) =>
         prisma.category.update({

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+interface ReorderItem {
+  id: string
+  sortOrder: number
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+    }
+
+    const { items } = body as { items?: unknown }
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: 'items 배열이 필요합니다.' }, { status: 400 })
+    }
+
+    const validItems: ReorderItem[] = []
+    for (const item of items) {
+      if (
+        !item ||
+        typeof item !== 'object' ||
+        typeof (item as ReorderItem).id !== 'string' ||
+        typeof (item as ReorderItem).sortOrder !== 'number' ||
+        (item as ReorderItem).sortOrder < 0 ||
+        (item as ReorderItem).sortOrder > 999 ||
+        !Number.isInteger((item as ReorderItem).sortOrder)
+      ) {
+        return NextResponse.json(
+          { error: '각 항목은 id(string)와 sortOrder(0-999 정수)가 필요합니다.' },
+          { status: 400 }
+        )
+      }
+      validItems.push({ id: (item as ReorderItem).id, sortOrder: (item as ReorderItem).sortOrder })
+    }
+
+    await prisma.$transaction(
+      validItems.map((item) =>
+        prisma.category.update({
+          where: { id: item.id },
+          data: { sortOrder: item.sortOrder },
+        })
+      )
+    )
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('POST /api/categories/reorder error:', error)
+    return NextResponse.json(
+      { error: '정렬 순서 변경에 실패했습니다.' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 
 export const dynamic = 'force-dynamic'
@@ -57,6 +58,12 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true })
   } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      return NextResponse.json(
+        { error: '존재하지 않는 카테고리가 포함되어 있습니다.' },
+        { status: 404 }
+      )
+    }
     console.error('POST /api/categories/reorder error:', error)
     return NextResponse.json(
       { error: '정렬 순서 변경에 실패했습니다.' },

--- a/src/components/category/CategoryTable.tsx
+++ b/src/components/category/CategoryTable.tsx
@@ -176,12 +176,19 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
       const swapIdx = direction === 'up' ? idx - 1 : idx + 1
       if (swapIdx < 0 || swapIdx >= list.length) return
 
-      // 스왑 후 전체 리스트 재인덱싱 (sortOrder 중복 방지)
-      const reordered = [...list]
-      const [moved] = reordered.splice(idx, 1)
-      reordered.splice(swapIdx, 0, moved)
+      const current = list[idx]
+      const target = list[swapIdx]
 
-      const items = reordered.map((c, i) => ({ id: c.id, sortOrder: i }))
+      // sortOrder가 같으면 강제 분리 (인접 스왑)
+      const currentOrder = current.sortOrder
+      const targetOrder = target.sortOrder !== currentOrder
+        ? target.sortOrder
+        : direction === 'up' ? currentOrder - 1 : currentOrder + 1
+
+      const items = [
+        { id: current.id, sortOrder: targetOrder },
+        { id: target.id, sortOrder: currentOrder },
+      ]
 
       const res = await fetch('/api/categories/reorder', {
         method: 'POST',

--- a/src/components/category/CategoryTable.tsx
+++ b/src/components/category/CategoryTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import CategoryEditPanel from './CategoryEditPanel'
 import CategoryDeleteModal from './CategoryDeleteModal'
 
@@ -23,7 +24,33 @@ interface CategoryTableProps {
   onTabChange: (tab: 'expense' | 'income') => void
 }
 
-function CategoryRowDesktop({ c, onEdit, onDelete }: { c: CategoryRow; onEdit: (c: CategoryRow) => void; onDelete: (c: CategoryRow) => void }) {
+function ArrowUpIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M8 13V3M4 7l4-4 4 4" />
+    </svg>
+  )
+}
+
+function ArrowDownIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M8 3v10M4 9l4 4 4-4" />
+    </svg>
+  )
+}
+
+function CategoryRowDesktop({
+  c, isFirst, isLast, onMoveUp, onMoveDown, onEdit, onDelete,
+}: {
+  c: CategoryRow
+  isFirst: boolean
+  isLast: boolean
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onEdit: (c: CategoryRow) => void
+  onDelete: (c: CategoryRow) => void
+}) {
   return (
     <tr className="hover:bg-card">
       <td className="pl-4 px-3 py-3 text-[13px] text-dim border-b border-border text-center tabular-nums">
@@ -51,6 +78,22 @@ function CategoryRowDesktop({ c, onEdit, onDelete }: { c: CategoryRow; onEdit: (
       </td>
       <td className="pr-4 px-3 py-3 border-b border-border">
         <div className="flex items-center gap-1">
+          <button
+            onClick={onMoveUp}
+            disabled={isFirst}
+            className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+            title="위로"
+          >
+            <ArrowUpIcon />
+          </button>
+          <button
+            onClick={onMoveDown}
+            disabled={isLast}
+            className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+            title="아래로"
+          >
+            <ArrowDownIcon />
+          </button>
           <button onClick={() => onEdit(c)} className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all" title="수정">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" /></svg>
           </button>
@@ -84,7 +127,6 @@ function groupCategories(cats: CategoryRow[]): GroupedCategories[] {
     }
     groups.get(gId)!.categories.push(c)
   }
-  // 그룹 있는 것 먼저, 미분류(null) 마지막
   const result = Array.from(groups.values())
   result.sort((a, b) => {
     if (a.groupId === null) return 1
@@ -95,9 +137,11 @@ function groupCategories(cats: CategoryRow[]): GroupedCategories[] {
 }
 
 export default function CategoryTable({ categories, activeTab, onTabChange }: CategoryTableProps) {
+  const router = useRouter()
   const [editItem, setEditItem] = useState<CategoryRow | null>(null)
   const [deleteItem, setDeleteItem] = useState<CategoryRow | null>(null)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string | null>>(new Set())
+  const [reordering, setReordering] = useState(false)
 
   const filtered = categories.filter((c) => c.type === activeTab)
   const grouped = activeTab === 'expense' ? groupCategories(filtered) : null
@@ -109,6 +153,48 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
       else next.add(gId)
       return next
     })
+  }
+
+  async function handleReorder(categoryId: string, direction: 'up' | 'down') {
+    if (reordering) return
+    setReordering(true)
+
+    try {
+      // expense: 그룹 내 이동, income: 플랫 리스트 이동
+      let list: CategoryRow[]
+      if (grouped) {
+        const group = grouped.find((g) => g.categories.some((c) => c.id === categoryId))
+        list = group?.categories ?? []
+      } else {
+        list = filtered
+      }
+
+      const idx = list.findIndex((c) => c.id === categoryId)
+      if (idx < 0) return
+
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1
+      if (swapIdx < 0 || swapIdx >= list.length) return
+
+      const current = list[idx]
+      const target = list[swapIdx]
+
+      await fetch('/api/categories/reorder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: [
+            { id: current.id, sortOrder: target.sortOrder },
+            { id: target.id, sortOrder: current.sortOrder },
+          ],
+        }),
+      })
+
+      router.refresh()
+    } catch (error) {
+      console.error('카테고리 정렬 실패:', error)
+    } finally {
+      setReordering(false)
+    }
   }
 
   return (
@@ -154,7 +240,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                         key={i}
                         className={`px-3 py-2.5 text-[11px] font-semibold text-sub tracking-wide uppercase border-b border-border bg-card ${
                           i === 0 || i === 4 ? 'text-center' : 'text-left'
-                        } ${i === 0 ? 'pl-4 w-16' : ''} ${i === 5 ? 'pr-4 w-16' : ''}`}
+                        } ${i === 0 ? 'pl-4 w-16' : ''} ${i === 5 ? 'pr-4 w-28' : ''}`}
                       >
                         {col}
                       </th>
@@ -166,7 +252,6 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                     const isCollapsed = collapsedGroups.has(g.groupId)
                     return (
                       <React.Fragment key={g.groupId ?? '_ungrouped'}>
-                        {/* 그룹 헤더 */}
                         <tr
                           className="cursor-pointer hover:bg-white/[0.02]"
                           onClick={() => toggleGroup(g.groupId)}
@@ -185,14 +270,31 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                             </div>
                           </td>
                         </tr>
-                        {/* 그룹 내 카테고리 */}
-                        {!isCollapsed && g.categories.map((c) => (
-                          <CategoryRowDesktop key={c.id} c={c} onEdit={setEditItem} onDelete={setDeleteItem} />
+                        {!isCollapsed && g.categories.map((c, idx) => (
+                          <CategoryRowDesktop
+                            key={c.id}
+                            c={c}
+                            isFirst={idx === 0}
+                            isLast={idx === g.categories.length - 1}
+                            onMoveUp={() => handleReorder(c.id, 'up')}
+                            onMoveDown={() => handleReorder(c.id, 'down')}
+                            onEdit={setEditItem}
+                            onDelete={setDeleteItem}
+                          />
                         ))}
                       </React.Fragment>
                     )
-                  }) : filtered.map((c) => (
-                    <CategoryRowDesktop key={c.id} c={c} onEdit={setEditItem} onDelete={setDeleteItem} />
+                  }) : filtered.map((c, idx) => (
+                    <CategoryRowDesktop
+                      key={c.id}
+                      c={c}
+                      isFirst={idx === 0}
+                      isLast={idx === filtered.length - 1}
+                      onMoveUp={() => handleReorder(c.id, 'up')}
+                      onMoveDown={() => handleReorder(c.id, 'down')}
+                      onEdit={setEditItem}
+                      onDelete={setDeleteItem}
+                    />
                   ))}
                 </tbody>
               </table>
@@ -200,7 +302,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
 
             {/* Mobile card view */}
             <div className="sm:hidden divide-y divide-border">
-              {filtered.map((c) => (
+              {filtered.map((c, idx) => (
                 <div key={c.id} className="px-4 py-3.5 hover:bg-card">
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-2">
@@ -213,6 +315,20 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                       )}
                     </div>
                     <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => handleReorder(c.id, 'up')}
+                        disabled={idx === 0 || reordering}
+                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+                      >
+                        <ArrowUpIcon size={12} />
+                      </button>
+                      <button
+                        onClick={() => handleReorder(c.id, 'down')}
+                        disabled={idx === filtered.length - 1 || reordering}
+                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+                      >
+                        <ArrowDownIcon size={12} />
+                      </button>
                       <button
                         onClick={() => setEditItem(c)}
                         className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"

--- a/src/components/category/CategoryTable.tsx
+++ b/src/components/category/CategoryTable.tsx
@@ -41,11 +41,12 @@ function ArrowDownIcon({ size = 14 }: { size?: number }) {
 }
 
 function CategoryRowDesktop({
-  c, isFirst, isLast, onMoveUp, onMoveDown, onEdit, onDelete,
+  c, isFirst, isLast, isReordering, onMoveUp, onMoveDown, onEdit, onDelete,
 }: {
   c: CategoryRow
   isFirst: boolean
   isLast: boolean
+  isReordering: boolean
   onMoveUp: () => void
   onMoveDown: () => void
   onEdit: (c: CategoryRow) => void
@@ -80,7 +81,7 @@ function CategoryRowDesktop({
         <div className="flex items-center gap-1">
           <button
             onClick={onMoveUp}
-            disabled={isFirst}
+            disabled={isFirst || isReordering}
             className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
             title="위로"
           >
@@ -88,7 +89,7 @@ function CategoryRowDesktop({
           </button>
           <button
             onClick={onMoveDown}
-            disabled={isLast}
+            disabled={isLast || isReordering}
             className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
             title="아래로"
           >
@@ -175,19 +176,23 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
       const swapIdx = direction === 'up' ? idx - 1 : idx + 1
       if (swapIdx < 0 || swapIdx >= list.length) return
 
-      const current = list[idx]
-      const target = list[swapIdx]
+      // 스왑 후 전체 리스트 재인덱싱 (sortOrder 중복 방지)
+      const reordered = [...list]
+      const [moved] = reordered.splice(idx, 1)
+      reordered.splice(swapIdx, 0, moved)
 
-      await fetch('/api/categories/reorder', {
+      const items = reordered.map((c, i) => ({ id: c.id, sortOrder: i }))
+
+      const res = await fetch('/api/categories/reorder', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          items: [
-            { id: current.id, sortOrder: target.sortOrder },
-            { id: target.id, sortOrder: current.sortOrder },
-          ],
-        }),
+        body: JSON.stringify({ items }),
       })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error ?? '정렬 변경 실패')
+      }
 
       router.refresh()
     } catch (error) {
@@ -276,6 +281,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                             c={c}
                             isFirst={idx === 0}
                             isLast={idx === g.categories.length - 1}
+                            isReordering={reordering}
                             onMoveUp={() => handleReorder(c.id, 'up')}
                             onMoveDown={() => handleReorder(c.id, 'down')}
                             onEdit={setEditItem}
@@ -290,6 +296,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                       c={c}
                       isFirst={idx === 0}
                       isLast={idx === filtered.length - 1}
+                      isReordering={reordering}
                       onMoveUp={() => handleReorder(c.id, 'up')}
                       onMoveDown={() => handleReorder(c.id, 'down')}
                       onEdit={setEditItem}
@@ -302,65 +309,89 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
 
             {/* Mobile card view */}
             <div className="sm:hidden divide-y divide-border">
-              {filtered.map((c, idx) => (
-                <div key={c.id} className="px-4 py-3.5 hover:bg-card">
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-[16px]">{c.icon ?? '📦'}</span>
-                      <span className="text-[13px] font-bold text-bright">{c.name}</span>
-                      {c._count.transactions > 0 && (
-                        <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-surface-dim">
-                          {c._count.transactions}건
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => handleReorder(c.id, 'up')}
-                        disabled={idx === 0 || reordering}
-                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
-                      >
-                        <ArrowUpIcon size={12} />
-                      </button>
-                      <button
-                        onClick={() => handleReorder(c.id, 'down')}
-                        disabled={idx === filtered.length - 1 || reordering}
-                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
-                      >
-                        <ArrowDownIcon size={12} />
-                      </button>
-                      <button
-                        onClick={() => setEditItem(c)}
-                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                      >
-                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                          <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
-                        </svg>
-                      </button>
-                      <button
-                        onClick={() => setDeleteItem(c)}
-                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                      >
-                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                          <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                  {c.keywords.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {c.keywords.map((k) => (
-                        <span
-                          key={k}
-                          className="px-1.5 py-0.5 rounded bg-surface-dim text-[11px] text-dim"
+              {(() => {
+                const renderCard = (c: CategoryRow, isFirst: boolean, isLast: boolean) => (
+                  <div key={c.id} className="px-4 py-3.5 hover:bg-card">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-[16px]">{c.icon ?? '📦'}</span>
+                        <span className="text-[13px] font-bold text-bright">{c.name}</span>
+                        {c._count.transactions > 0 && (
+                          <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-surface-dim">
+                            {c._count.transactions}건
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => handleReorder(c.id, 'up')}
+                          disabled={isFirst || reordering}
+                          className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
                         >
-                          {k}
-                        </span>
-                      ))}
+                          <ArrowUpIcon size={12} />
+                        </button>
+                        <button
+                          onClick={() => handleReorder(c.id, 'down')}
+                          disabled={isLast || reordering}
+                          className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+                        >
+                          <ArrowDownIcon size={12} />
+                        </button>
+                        <button
+                          onClick={() => setEditItem(c)}
+                          className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
+                        >
+                          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                            <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
+                          </svg>
+                        </button>
+                        <button
+                          onClick={() => setDeleteItem(c)}
+                          className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
+                        >
+                          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                            <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  )}
-                </div>
-              ))}
+                    {c.keywords.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {c.keywords.map((k) => (
+                          <span
+                            key={k}
+                            className="px-1.5 py-0.5 rounded bg-surface-dim text-[11px] text-dim"
+                          >
+                            {k}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+
+                if (grouped) {
+                  return grouped.map((g) => (
+                    <React.Fragment key={g.groupId ?? '_ungrouped'}>
+                      <div className="px-4 py-2.5 bg-white/[0.018]">
+                        <span className="text-[12px] font-bold text-bright">
+                          {g.groupIcon ? `${g.groupIcon} ` : ''}{g.groupName}
+                        </span>
+                        <span className="ml-2 text-[10px] font-semibold text-sub bg-surface px-2 py-0.5 rounded">
+                          {g.categories.length}
+                        </span>
+                      </div>
+                      {g.categories.map((c, idx) =>
+                        renderCard(c, idx === 0, idx === g.categories.length - 1)
+                      )}
+                    </React.Fragment>
+                  ))
+                }
+
+                return filtered.map((c, idx) =>
+                  renderCard(c, idx === 0, idx === filtered.length - 1)
+                )
+              })()}
             </div>
           </>
         )}

--- a/src/components/category/CategoryTable.tsx
+++ b/src/components/category/CategoryTable.tsx
@@ -176,19 +176,13 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
       const swapIdx = direction === 'up' ? idx - 1 : idx + 1
       if (swapIdx < 0 || swapIdx >= list.length) return
 
-      const current = list[idx]
-      const target = list[swapIdx]
+      // 그룹/리스트 내 정규화 후 스왑 (sortOrder 중복/경계값 안전)
+      const normalized = list.map((c, i) => ({ id: c.id, sortOrder: i }))
+      const tmp = normalized[idx].sortOrder
+      normalized[idx] = { ...normalized[idx], sortOrder: normalized[swapIdx].sortOrder }
+      normalized[swapIdx] = { ...normalized[swapIdx], sortOrder: tmp }
 
-      // sortOrder가 같으면 강제 분리 (인접 스왑)
-      const currentOrder = current.sortOrder
-      const targetOrder = target.sortOrder !== currentOrder
-        ? target.sortOrder
-        : direction === 'up' ? currentOrder - 1 : currentOrder + 1
-
-      const items = [
-        { id: current.id, sortOrder: targetOrder },
-        { id: target.id, sortOrder: currentOrder },
-      ]
+      const items = normalized
 
       const res = await fetch('/api/categories/reorder', {
         method: 'POST',


### PR DESCRIPTION
## Summary

- `POST /api/categories/reorder` 일괄 정렬 업데이트 API 신규 생성
- CategoryTable 데스크톱/모바일에 ↑/↓ 버튼 추가
- expense: 그룹 내 이동, income: 플랫 리스트 이동
- 그룹 내 정규화 후 스왑 (sortOrder 중복/경계값 안전)
- Prisma P2025 에러 분기, id 유니크 검증, fetch 응답 체크
- 모바일도 그룹 단위 렌더링 + 그룹 기준 isFirst/isLast

Closes #204

## Checklist

- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (4회, P1/P2: 0건)
- [x] 스펙 문서: `docs/specs/204-category-reorder.md`
- [x] 구현 계획: `docs/implementation_plans/204-category-reorder.md`

## Code Review

- 리뷰 횟수: 4회
- P0: 2건 (접근성, 매직넘버 — 선택 유지)
- P1: 0건 (프로젝트 맥락상 해당 없음)
- P2: 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)