### PR TITLE
거래 내역에서 반복거래 등록 기능 (#206)

### DIFF
--- a/docs/implementation_plans/206-recurring-from-transaction.md
+++ b/docs/implementation_plans/206-recurring-from-transaction.md
@@ -1,0 +1,18 @@
+# 구현 계획: 거래 내역에서 반복거래 등록 (#206)
+
+## 변경 파일 (3개)
+
+| 순서 | 파일 | 변경 내용 |
+|------|------|-----------|
+| 1 | `src/components/expense/RecurringForm.tsx` | `RecurringPrefill` 인터페이스 export, `prefill` prop 추가, 초기값 분기 |
+| 2 | `src/components/expense/TransactionTable.tsx` | `onRegisterRecurring` prop, "반복 등록" 버튼 추가 |
+| 3 | `src/app/expenses/ExpensesClient.tsx` | `recurringPrefill` 상태, 핸들러, RecurringForm 렌더 |
+
+## 구현 순서
+
+1. RecurringForm에 prefill 지원 추가 (하위 컴포넌트 먼저)
+2. TransactionTable에 반복 등록 버튼 추가
+3. ExpensesClient에서 상태 연결
+
+## 패키지 추가: 없음
+## DB 마이그레이션: 없음

--- a/docs/specs/206-recurring-from-transaction.md
+++ b/docs/specs/206-recurring-from-transaction.md
@@ -1,0 +1,54 @@
+# 거래 내역에서 반복거래 등록
+
+## 목적
+
+가계부 내역 리스트에서 특정 거래를 반복거래로 바로 등록할 수 있는 기능.
+현재는 반복거래 페이지(`/recurring`)에서 처음부터 수동 입력해야 하지만,
+기존 거래의 금액·내용·카테고리를 프리필하여 편의성을 높인다.
+
+## 요구사항
+
+- [ ] 거래 내역 테이블 액션 열에 "반복 등록" 버튼 추가
+- [ ] transfer 유형(`transfer_in`, `transfer_out`) 거래에는 버튼 미표시
+- [ ] 버튼 클릭 시 RecurringForm이 열리며 금액·내용·카테고리 프리필
+- [ ] 주기·실행일·시작일은 프리필하지 않음 (거래에 없는 정보)
+- [ ] 다른 폼(추가/수정)과 동시 열림 방지
+- [ ] 저장 시 기존 `POST /api/recurring` API 그대로 사용
+- [ ] 반복거래 페이지 기존 생성/수정 기능 회귀 없음
+
+## 기술 설계
+
+### 변경 파일 (3개, 프론트엔드만)
+
+1. **`src/components/expense/RecurringForm.tsx`**
+   - `RecurringPrefill` 인터페이스 export (`{ amount, description, categoryId }`)
+   - `prefill?` prop 추가
+   - 초기값 우선순위: `item`(edit) → `prefill`(프리필) → 빈값
+
+2. **`src/components/expense/TransactionTable.tsx`**
+   - `onRegisterRecurring?` 콜백 prop 추가
+   - 삭제 버튼 뒤에 "반복 등록" 버튼 (순환 화살표 아이콘, sodam 컬러)
+   - transfer 유형 제외 조건
+
+3. **`src/app/expenses/ExpensesClient.tsx`**
+   - `recurringPrefill` 상태 + 핸들러
+   - 동시 폼 열림 방지 (설정 시 `editingTx`/`showForm` 초기화)
+   - RecurringForm 조건부 렌더
+
+### API 변경: 없음
+
+기존 `POST /api/recurring` 그대로 사용.
+
+## 테스트 계획
+
+- [ ] 거래 내역에서 "반복 등록" 클릭 → RecurringForm 열림, 금액·내용·카테고리 프리필 확인
+- [ ] 주기·실행일 선택 후 저장 → `/recurring` 페이지에서 생성 확인
+- [ ] transfer 유형 거래에는 반복 등록 버튼 미표시
+- [ ] 반복거래 페이지 기존 생성/수정 정상 동작 (회귀)
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- 반복거래 자동 실행 로직 변경 없음
+- API 엔드포인트 추가/변경 없음
+- 반복거래 페이지 UI 변경 없음

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -7,6 +7,7 @@ import CategoryPieChart from '@/components/expense/CategoryPieChart'
 import TransactionTable, { type TransactionRow } from '@/components/expense/TransactionTable'
 import TransactionForm from '@/components/expense/TransactionForm'
 import TransactionDeleteModal from '@/components/expense/TransactionDeleteModal'
+import RecurringForm, { type RecurringPrefill } from '@/components/expense/RecurringForm'
 import MonthCompare from '@/components/expense/MonthCompare'
 import SpendingTrend from '@/components/expense/SpendingTrend'
 
@@ -83,6 +84,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
   const [deletingTx, setDeletingTx] = useState<TransactionRow | null>(null)
   const [categories, setCategories] = useState<CategoryOption[]>([])
   const [assets, setAssets] = useState<{ id: string; name: string; category: string; value: number; isLiability: boolean }[]>([])
+  const [recurringPrefill, setRecurringPrefill] = useState<RecurringPrefill | null>(null)
 
   // 카테고리 + 자산 목록 fetch (폼 select용)
   useEffect(() => {
@@ -215,6 +217,16 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
 
   const handleDelete = (tx: TransactionRow) => {
     setDeletingTx(tx)
+  }
+
+  const handleRegisterRecurring = (tx: TransactionRow) => {
+    setShowForm(false)
+    setEditingTx(null)
+    setRecurringPrefill({
+      amount: tx.amount,
+      description: tx.description,
+      categoryId: tx.categoryId,
+    })
   }
 
   const segmentBase = 'px-3 py-1.5 text-[12px] font-semibold rounded-md transition-all cursor-pointer'
@@ -353,6 +365,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
         onPageChange={handlePageChange}
         onEdit={handleEdit}
         onDelete={handleDelete}
+        onRegisterRecurring={handleRegisterRecurring}
       />
 
       {/* 내역 추가 폼 */}
@@ -392,6 +405,17 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
           transaction={deletingTx}
           onClose={() => setDeletingTx(null)}
           onDeleted={handleSaved}
+        />
+      )}
+
+      {/* 반복 거래 등록 폼 */}
+      {recurringPrefill && (
+        <RecurringForm
+          mode="create"
+          prefill={recurringPrefill}
+          categories={categories}
+          onClose={() => setRecurringPrefill(null)}
+          onSaved={handleSaved}
         />
       )}
     </div>

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -220,6 +220,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
   }
 
   const handleRegisterRecurring = (tx: TransactionRow) => {
+    if (tx.type === 'transfer_in' || tx.type === 'transfer_out') return
     setShowForm(false)
     setEditingTx(null)
     setRecurringPrefill({
@@ -411,6 +412,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       {/* 반복 거래 등록 폼 */}
       {recurringPrefill && (
         <RecurringForm
+          key={`${recurringPrefill.description}-${recurringPrefill.amount}`}
           mode="create"
           prefill={recurringPrefill}
           categories={categories}

--- a/src/components/expense/RecurringForm.tsx
+++ b/src/components/expense/RecurringForm.tsx
@@ -10,9 +10,16 @@ interface CategoryOption {
   type: string
 }
 
+export interface RecurringPrefill {
+  amount: number
+  description: string
+  categoryId: string
+}
+
 interface RecurringFormProps {
   mode: 'create' | 'edit'
   item?: RecurringRow
+  prefill?: RecurringPrefill
   categories: CategoryOption[]
   onClose: () => void
   onSaved: () => void
@@ -22,13 +29,13 @@ type Frequency = 'monthly' | 'weekly' | 'yearly'
 
 const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
 
-export default function RecurringForm({ mode, item, categories, onClose, onSaved }: RecurringFormProps) {
+export default function RecurringForm({ mode, item, prefill, categories, onClose, onSaved }: RecurringFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const [amount, setAmount] = useState(item ? String(item.amount) : '')
-  const [description, setDescription] = useState(item?.description ?? '')
-  const [categoryId, setCategoryId] = useState(item?.categoryId ?? '')
+  const [amount, setAmount] = useState(item ? String(item.amount) : prefill ? String(prefill.amount) : '')
+  const [description, setDescription] = useState(item?.description ?? prefill?.description ?? '')
+  const [categoryId, setCategoryId] = useState(item?.categoryId ?? prefill?.categoryId ?? '')
   const [frequency, setFrequency] = useState<Frequency>((item?.frequency as Frequency) ?? 'monthly')
   const [dayOfMonth, setDayOfMonth] = useState(item?.dayOfMonth ?? 1)
   const [dayOfWeek, setDayOfWeek] = useState(item?.dayOfWeek ?? 1)

--- a/src/components/expense/TransactionTable.tsx
+++ b/src/components/expense/TransactionTable.tsx
@@ -24,6 +24,7 @@ interface TransactionTableProps {
   onPageChange: (offset: number) => void
   onEdit?: (tx: TransactionRow) => void
   onDelete?: (tx: TransactionRow) => void
+  onRegisterRecurring?: (tx: TransactionRow) => void
 }
 
 export default function TransactionTable({
@@ -34,10 +35,11 @@ export default function TransactionTable({
   onPageChange,
   onEdit,
   onDelete,
+  onRegisterRecurring,
 }: TransactionTableProps) {
   const totalPages = Math.ceil(total / limit)
   const currentPage = Math.floor(offset / limit) + 1
-  const hasActions = onEdit || onDelete
+  const hasActions = onEdit || onDelete || onRegisterRecurring
 
   return (
     <div className="rounded-[14px] border border-border bg-card overflow-hidden">
@@ -117,6 +119,17 @@ export default function TransactionTable({
                             >
                               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                                 <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
+                              </svg>
+                            </button>
+                          )}
+                          {onRegisterRecurring && tx.type !== 'transfer_out' && tx.type !== 'transfer_in' && (
+                            <button
+                              onClick={() => onRegisterRecurring(tx)}
+                              className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-sodam hover:bg-sodam/10 transition-all"
+                              title="반복 등록"
+                            >
+                              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                                <path d="M13.5 8A5.5 5.5 0 113 5.5M3 2v3.5H6.5" />
                               </svg>
                             </button>
                           )}


### PR DESCRIPTION
## Summary

- 거래 내역 테이블에 "반복 등록" 버튼 추가 (transfer 유형 제외)
- 클릭 시 RecurringForm에 금액·내용·카테고리 프리필
- 기존 `POST /api/recurring` API 그대로 사용, API 변경 없음

Closes #206

## 변경 파일
- `src/components/expense/RecurringForm.tsx` — `RecurringPrefill` export, `prefill` prop
- `src/components/expense/TransactionTable.tsx` — `onRegisterRecurring` 버튼
- `src/app/expenses/ExpensesClient.tsx` — 상태 연결, transfer 가드, key remount

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (2회, P1/P2: 0건)

## Test plan
- [ ] 거래 내역에서 "반복 등록" 클릭 → RecurringForm 열림, 금액·내용·카테고리 프리필 확인
- [ ] 주기·실행일 선택 후 저장 → `/recurring` 페이지에서 생성 확인
- [ ] transfer 유형 거래에는 반복 등록 버튼 미표시
- [ ] 반복거래 페이지 기존 생성/수정 정상 동작 (회귀)