### PR TITLE
이체(transfer) 카테고리 타입 추가 (#210)

### DIFF
--- a/docs/implementation_plans/210-transfer-category-type.md
+++ b/docs/implementation_plans/210-transfer-category-type.md
@@ -1,0 +1,22 @@
+# 구현 계획: 이체(transfer) 카테고리 타입 추가 (#210)
+
+## 변경 파일 (7개)
+
+| 순서 | 파일 | 변경 내용 |
+|------|------|-----------|
+| 1 | `src/lib/category-utils.ts` | CATEGORY_TYPES에 'transfer' 추가, 라벨 '이체', 에러 메시지 수정 |
+| 2 | `prisma/seed.ts` | transfer 카테고리 시드 추가 (적금, 예금, 투자계좌, 기타이체) |
+| 3 | `src/components/expense/TransactionForm.tsx` | transferCategories 필터 추가, isTransfer 시 transfer 카테고리 표시 |
+| 4 | `src/components/category/CategoryClient.tsx` | 탭 타입에 'transfer' 추가 |
+| 5 | `src/components/category/CategoryTable.tsx` | 탭 타입에 'transfer' 추가, 탭 배열에 이체 탭 추가 |
+| 6 | `src/components/category/CategoryEditPanel.tsx` | type 변경 시 transfer→groupId null (income과 동일) |
+| 7 | `src/components/settings/WhooingSettings.tsx` | transfer 그룹은 이미 ['expense','income'] 순회에 포함 안 됨 → 배열에 'transfer' 추가 |
+
+## 변경 불필요 (확인 완료)
+- `src/app/api/categories/route.ts` — CATEGORY_TYPES import해서 검증 → 자동 반영
+- `src/app/api/categories/[id]/route.ts` — CATEGORY_TYPES import해서 검증 → 자동 반영
+- `src/components/expense/RecurringForm.tsx` — expense/income optgroup만 표시, transfer 반복거래는 불필요
+- 차트/분석/예산/봇 — expense/income만 집계하므로 영향 없음
+
+## 패키지 추가: 없음
+## DB 마이그레이션: 없음 (Category.type은 String)

--- a/docs/specs/210-transfer-category-type.md
+++ b/docs/specs/210-transfer-category-type.md
@@ -1,0 +1,49 @@
+# 이체(transfer) 카테고리 타입 추가
+
+## 목적
+
+출금/입금(이체) 거래에 적합한 카테고리를 제공한다.
+현재 카테고리 type은 "expense"/"income"만 존재하여,
+적금 이체·투자계좌 입금 등의 거래에 맞는 카테고리가 없다.
+
+## 요구사항
+
+- [ ] Category type에 "transfer" 추가 (DB String 타입이라 마이그레이션 불필요)
+- [ ] 기본 transfer 카테고리 시드 추가 (적금, 예금, 투자계좌, 기타이체 등)
+- [ ] TransactionForm: transfer 유형 선택 시 transfer 카테고리만 표시
+- [ ] 카테고리 관리 UI/API: transfer 타입 생성·수정 지원
+- [ ] 후잉 매핑 UI: transfer 그룹 표시
+- [ ] 기존 소비/수입 기능 회귀 없음
+
+## 기술 설계
+
+### 변경 불필요 (정상 동작)
+- 차트/분석: expense/income만 집계 → transfer 제외가 올바른 동작
+- 예산: expense 카테고리만 대상 → transfer 무관
+- 가계부 필터(all/소비/수입): transfer는 "전체"에서만 표시
+- 텔레그램 봇: expense/income 입력만 지원 → transfer 무관
+
+### 변경 파일
+
+1. **`prisma/seed.ts`** — transfer 카테고리 시드 추가
+2. **`src/app/api/categories/route.ts`** — POST 유효성에 "transfer" 허용
+3. **`src/app/api/categories/[id]/route.ts`** — PUT 유효성에 "transfer" 허용
+4. **`src/components/expense/TransactionForm.tsx`** — transfer 유형 시 transfer 카테고리 표시
+5. **`src/components/category/CategoryEditPanel.tsx`** — transfer 타입 옵션 추가
+6. **`src/components/category/CategoryClient.tsx`** — transfer 탭/필터 추가
+7. **`src/components/settings/WhooingSettings.tsx`** — transfer 그룹 표시
+8. **`src/components/expense/RecurringForm.tsx`** — transfer 카테고리 그룹 표시 (반복거래도 이체 가능)
+
+## 테스트 계획
+
+- [ ] TransactionForm에서 출금/입금 선택 시 transfer 카테고리만 표시
+- [ ] 카테고리 관리에서 transfer 타입 생성·수정·삭제 가능
+- [ ] 후잉 설정에서 transfer 그룹 매핑 가능
+- [ ] 기존 소비/수입 차트·분석·예산 정상 동작 (회귀)
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- transfer 거래 로직 자체 변경 없음 (이미 동작 중)
+- 가계부 필터에 "이체" 탭 추가하지 않음 (전체 탭에서 보임)
+- 텔레그램 봇 이체 입력 지원하지 않음

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -305,6 +305,11 @@ async function main() {
       { slug: 'salary', name: '월급', type: 'income', icon: '💰', keywords: ['월급', '급여', '보너스', '상여', '성과급'], sortOrder: 1 },
       { slug: 'side-income', name: '부수입', type: 'income', icon: '💵', keywords: ['부수입', '알바', '프리랜서', '용돈'], sortOrder: 2 },
       { slug: 'etc-income', name: '기타수입', type: 'income', icon: '📥', keywords: [], sortOrder: 99 },
+      // 이체
+      { slug: 'savings', name: '적금', type: 'transfer', icon: '🏦', keywords: ['적금', '저축'], sortOrder: 1 },
+      { slug: 'deposit', name: '예금', type: 'transfer', icon: '💳', keywords: ['예금', '정기예금'], sortOrder: 2 },
+      { slug: 'investment', name: '투자계좌', type: 'transfer', icon: '📈', keywords: ['투자', '증권', '주식계좌'], sortOrder: 3 },
+      { slug: 'etc-transfer', name: '기타이체', type: 'transfer', icon: '🔄', keywords: ['이체', '송금'], sortOrder: 99 },
     ]
 
     await tx.category.createMany({ data: categories })

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -340,7 +340,7 @@ async function main() {
   console.log('  RSU Schedules: 2')
   console.log('  Deposits: 4')
   console.log('  Stock Options: 4 (카카오, 베스팅 7건)')
-  console.log('  Categories: 12 (소비 9 + 수입 3)')
+  console.log('  Categories: 16 (소비 9 + 수입 3 + 이체 4)')
   console.log(`  AlertConfig: ${alertDefaults.length}`)
 }
 

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -83,11 +83,11 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
     // type 변경 시 트랜잭션으로 체크+업데이트 원자 실행
     if (isTypeChange) {
-      // income으로 변경 시 groupId 초기화 (그룹은 expense 전용)
+      // income/transfer로 변경 시 groupId 초기화 (그룹은 expense 전용)
       const updateDataWithType = {
         ...baseUpdateData,
         type: type as string,
-        ...(type === 'income' ? { groupId: null } : {}),
+        ...(type !== 'expense' ? { groupId: null } : {}),
       }
       const updated = await prisma.$transaction(async (tx) => {
         const fresh = await tx.category.findUnique({

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     const type = searchParams.get('type')
 
     const where: Record<string, unknown> = {}
-    if (type === 'expense' || type === 'income') {
+    if (type === 'expense' || type === 'income' || type === 'transfer') {
       where.type = type
     }
 

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -43,6 +43,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (txType && category.type !== 'transfer') {
       return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
     }
+    if (!txType && category.type === 'transfer') {
+      return NextResponse.json({ error: '이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.' }, { status: 400 })
+    }
 
     const existing = await prisma.transaction.findUnique({ where: { id } })
     if (!existing) {

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -40,8 +40,8 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (!category) {
       return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
     }
-    if (txType && category.type !== 'expense') {
-      return NextResponse.json({ error: '출금/입금은 소비 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+    if (txType && category.type !== 'transfer') {
+      return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
     }
 
     const existing = await prisma.transaction.findUnique({ where: { id } })

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -150,7 +150,7 @@ export async function GET(request: NextRequest) {
       if (!cat) continue
       if (cat.type === 'expense') {
         byMonth[m].expense += tx.amount
-      } else {
+      } else if (cat.type === 'income') {
         byMonth[m].income += tx.amount
       }
     }
@@ -168,7 +168,7 @@ export async function GET(request: NextRequest) {
         const count = row._count
 
         if (cat.type === 'expense') totalExpense += rowTotal
-        else totalIncome += rowTotal
+        else if (cat.type === 'income') totalIncome += rowTotal
         filteredCount += count
 
         return {

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -243,9 +243,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
     }
 
-    // transfer 유형은 expense 카테고리만 허용
-    if (txType && category.type !== 'expense') {
-      return NextResponse.json({ error: '출금/입금은 소비 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+    // transfer 유형은 transfer 카테고리만 허용
+    if (txType && category.type !== 'transfer') {
+      return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
     }
 
     // 자산 존재 확인 (transfer 유형)

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -243,9 +243,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
     }
 
-    // transfer 유형은 transfer 카테고리만 허용
+    // transfer 유형 ↔ transfer 카테고리 일치 검증
     if (txType && category.type !== 'transfer') {
       return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+    }
+    if (!txType && category.type === 'transfer') {
+      return NextResponse.json({ error: '이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.' }, { status: 400 })
     }
 
     // 자산 존재 확인 (transfer 유형)

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -32,7 +32,7 @@ interface CategoryOption {
   id: string
   name: string
   icon: string | null
-  type: 'expense' | 'income'
+  type: 'expense' | 'income' | 'transfer'
 }
 
 interface ApiResponse {
@@ -97,7 +97,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
             id: c.id,
             name: c.name,
             icon: c.icon,
-            type: c.type as 'expense' | 'income',
+            type: c.type as 'expense' | 'income' | 'transfer',
           })))
         }
       })

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -54,7 +54,7 @@ async function fetchInitialData() {
     if (!cat) continue
     if (cat.type === 'expense') {
       byMonth[m].expense += tx.amount
-    } else {
+    } else if (cat.type === 'income') {
       byMonth[m].income += tx.amount
     }
   }
@@ -70,7 +70,7 @@ async function fetchInitialData() {
       if (!cat) return null
       const amount = row._sum.amount ?? 0
       if (cat.type === 'expense') totalExpense += amount
-      else totalIncome += amount
+      else if (cat.type === 'income') totalIncome += amount
       filteredCount += row._count
       return {
         categoryId: row.categoryId,

--- a/src/components/category/CategoryClient.tsx
+++ b/src/components/category/CategoryClient.tsx
@@ -8,14 +8,18 @@ interface CategoryClientProps {
   categories: CategoryRow[]
 }
 
-function getInitialTab(categories: CategoryRow[]): 'expense' | 'income' {
+type CategoryTab = 'expense' | 'income' | 'transfer'
+
+function getInitialTab(categories: CategoryRow[]): CategoryTab {
   const hasExpense = categories.some((c) => c.type === 'expense')
   if (hasExpense) return 'expense'
-  return 'income'
+  const hasIncome = categories.some((c) => c.type === 'income')
+  if (hasIncome) return 'income'
+  return 'transfer'
 }
 
 export default function CategoryClient({ categories }: CategoryClientProps) {
-  const [activeTab, setActiveTab] = useState<'expense' | 'income'>(() => getInitialTab(categories))
+  const [activeTab, setActiveTab] = useState<CategoryTab>(() => getInitialTab(categories))
   const [showForm, setShowForm] = useState(false)
 
   return (

--- a/src/components/category/CategoryDeleteModal.tsx
+++ b/src/components/category/CategoryDeleteModal.tsx
@@ -62,7 +62,7 @@ export default function CategoryDeleteModal({ category, onClose }: CategoryDelet
                 <div className="flex items-center justify-between">
                   <span className="text-[11px] text-dim">유형</span>
                   <span className="text-[13px] text-muted">
-                    {category.type === 'expense' ? '소비' : '수입'}
+                    {category.type === 'expense' ? '소비' : category.type === 'income' ? '수입' : '이체'}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">

--- a/src/components/category/CategoryTable.tsx
+++ b/src/components/category/CategoryTable.tsx
@@ -18,10 +18,12 @@ export interface CategoryRow {
   _count: { transactions: number; budgets: number }
 }
 
+type CategoryTab = 'expense' | 'income' | 'transfer'
+
 interface CategoryTableProps {
   categories: CategoryRow[]
-  activeTab: 'expense' | 'income'
-  onTabChange: (tab: 'expense' | 'income') => void
+  activeTab: CategoryTab
+  onTabChange: (tab: CategoryTab) => void
 }
 
 function ArrowUpIcon({ size = 14 }: { size?: number }) {
@@ -207,7 +209,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
     <>
       {/* Tab */}
       <div className="flex gap-1 mb-4">
-        {([['expense', '소비'], ['income', '수입']] as const).map(([value, label]) => (
+        {([['expense', '소비'], ['income', '수입'], ['transfer', '이체']] as const).map(([value, label]) => (
           <button
             key={value}
             onClick={() => onTabChange(value)}
@@ -225,7 +227,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
       <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
         <div className="px-5 py-3.5 border-b border-border flex justify-between items-center">
           <div className="text-[13px] font-bold text-bright">
-            {activeTab === 'expense' ? '소비' : '수입'} 카테고리
+            {activeTab === 'expense' ? '소비' : activeTab === 'income' ? '수입' : '이체'} 카테고리
           </div>
           <div className="text-[12px] text-sub">{filtered.length}개</div>
         </div>

--- a/src/components/expense/TransactionDeleteModal.tsx
+++ b/src/components/expense/TransactionDeleteModal.tsx
@@ -9,7 +9,8 @@ interface TransactionForDelete {
   description: string
   categoryName: string
   categoryIcon: string | null
-  categoryType: 'expense' | 'income'
+  categoryType: string
+  type?: string | null
   transactedAt: string
 }
 
@@ -56,6 +57,7 @@ export default function TransactionDeleteModal({
   }
 
   const isExpense = transaction.categoryType === 'expense'
+  const isTransfer = transaction.type === 'transfer_out' || transaction.type === 'transfer_in'
 
   return (
     <>
@@ -84,8 +86,8 @@ export default function TransactionDeleteModal({
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-[11px] text-dim">금액</span>
-                  <span className={`text-[13px] font-semibold tabular-nums ${isExpense ? 'text-red-400' : 'text-emerald-400'}`}>
-                    {isExpense ? '-' : '+'}{formatKRW(transaction.amount)}
+                  <span className={`text-[13px] font-semibold tabular-nums ${isTransfer ? 'text-sodam' : isExpense ? 'text-red-400' : 'text-emerald-400'}`}>
+                    {isTransfer ? (transaction.type === 'transfer_out' ? '↑' : '↓') : isExpense ? '-' : '+'}{formatKRW(transaction.amount)}
                   </span>
                 </div>
               </div>

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -88,7 +88,7 @@ export default function TransactionForm({
     if (timerRef.current) clearTimeout(timerRef.current)
     if (abortRef.current) abortRef.current.abort()
 
-    if (query.trim().length < 2) {
+    if (query.trim().length < 2 || type === 'transfer_out' || type === 'transfer_in') {
       setSuggestions([])
       return
     }

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -14,7 +14,7 @@ interface CategoryOption {
   id: string
   name: string
   icon: string | null
-  type: 'expense' | 'income'
+  type: 'expense' | 'income' | 'transfer'
 }
 
 interface AssetOption {
@@ -136,6 +136,7 @@ export default function TransactionForm({
 
   const expenseCategories = categories.filter((c) => c.type === 'expense')
   const incomeCategories = categories.filter((c) => c.type === 'income')
+  const transferCategories = categories.filter((c) => c.type === 'transfer')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -230,7 +231,10 @@ export default function TransactionForm({
                   key={t.value}
                   type="button"
                   onClick={() => {
+                    const wasTransfer = txType === 'transfer_out' || txType === 'transfer_in'
+                    const willBeTransfer = t.value === 'transfer_out' || t.value === 'transfer_in'
                     setTxType(t.value)
+                    if (wasTransfer !== willBeTransfer) setCategoryId('')
                     if (description.trim().length >= 2) {
                       fetchSuggestions(description, t.value)
                     } else {
@@ -316,23 +320,37 @@ export default function TransactionForm({
               }}
             >
               <option value="">카테고리 선택</option>
-              {expenseCategories.length > 0 && (
-                <optgroup label="소비">
-                  {expenseCategories.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.icon ? `${c.icon} ` : ''}{c.name}
-                    </option>
-                  ))}
-                </optgroup>
-              )}
-              {incomeCategories.length > 0 && (
-                <optgroup label="수입">
-                  {incomeCategories.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.icon ? `${c.icon} ` : ''}{c.name}
-                    </option>
-                  ))}
-                </optgroup>
+              {isTransfer ? (
+                transferCategories.length > 0 && (
+                  <optgroup label="이체">
+                    {transferCategories.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.icon ? `${c.icon} ` : ''}{c.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                )
+              ) : (
+                <>
+                  {expenseCategories.length > 0 && (
+                    <optgroup label="소비">
+                      {expenseCategories.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.icon ? `${c.icon} ` : ''}{c.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                  {incomeCategories.length > 0 && (
+                    <optgroup label="수입">
+                      {incomeCategories.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.icon ? `${c.icon} ` : ''}{c.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                </>
               )}
             </select>
           </div>

--- a/src/components/expense/TransactionTable.tsx
+++ b/src/components/expense/TransactionTable.tsx
@@ -74,6 +74,7 @@ export default function TransactionTable({
               <tbody>
                 {transactions.map((tx) => {
                   const isExpense = tx.categoryType === 'expense'
+                  const isTransfer = tx.type === 'transfer_out' || tx.type === 'transfer_in'
                   return (
                     <tr key={tx.id} className="border-b border-border last:border-0 hover:bg-surface-dim transition-colors">
                       <td className="px-4 py-3 text-sub tabular-nums whitespace-nowrap">
@@ -95,8 +96,8 @@ export default function TransactionTable({
                           </span>
                         )}
                       </td>
-                      <td className={`px-4 py-3 text-right font-semibold tabular-nums whitespace-nowrap ${isExpense ? 'text-red-400' : 'text-emerald-400'}`}>
-                        {isExpense ? '-' : '+'}{formatKRW(tx.amount)}
+                      <td className={`px-4 py-3 text-right font-semibold tabular-nums whitespace-nowrap ${isTransfer ? 'text-sodam' : isExpense ? 'text-red-400' : 'text-emerald-400'}`}>
+                        {isTransfer ? (tx.type === 'transfer_out' ? '↑' : '↓') : isExpense ? '-' : '+'}{formatKRW(tx.amount)}
                       </td>
                       {hasActions && (
                         <td className="px-4 py-3 text-center whitespace-nowrap">

--- a/src/components/settings/WhooingSettings.tsx
+++ b/src/components/settings/WhooingSettings.tsx
@@ -153,14 +153,14 @@ export default function WhooingSettings() {
               </tr>
             </thead>
             <tbody>
-              {(['expense', 'income'] as const).map((type) => {
+              {(['expense', 'income', 'transfer'] as const).map((type) => {
                 const grouped = categories.filter((c) => c.type === type)
                 if (grouped.length === 0) return null
                 return (
                   <Fragment key={type}>
                     <tr className="bg-surface-dim">
                       <td colSpan={3} className="px-4 py-2 text-[11px] font-bold text-sub uppercase tracking-wide">
-                        {type === 'expense' ? '소비' : '수입'}
+                        {type === 'expense' ? '소비' : type === 'income' ? '수입' : '이체'}
                       </td>
                     </tr>
                     {grouped.map((cat) => {
@@ -172,7 +172,7 @@ export default function WhooingSettings() {
                           </td>
                           <td className="px-4 py-2">
                             <input className={`w-full ${inputClasses} py-1.5`} value={m.left}
-                              onChange={(e) => updateMapping(cat.id, 'left', e.target.value)} placeholder={type === 'expense' ? '식료품' : '급여'} />
+                              onChange={(e) => updateMapping(cat.id, 'left', e.target.value)} placeholder={type === 'expense' ? '식료품' : type === 'income' ? '급여' : '적금'} />
                           </td>
                           <td className="px-4 py-2">
                             <input className={`w-full ${inputClasses} py-1.5`} value={m.right}

--- a/src/lib/category-utils.ts
+++ b/src/lib/category-utils.ts
@@ -2,12 +2,13 @@
  * 카테고리 유틸리티: 입력 검증, 상수
  */
 
-export const CATEGORY_TYPES = ['expense', 'income'] as const
+export const CATEGORY_TYPES = ['expense', 'income', 'transfer'] as const
 export type CategoryType = (typeof CATEGORY_TYPES)[number]
 
 export const CATEGORY_TYPE_LABELS: Record<CategoryType, string> = {
   expense: '소비',
   income: '수입',
+  transfer: '이체',
 }
 
 export interface CategoryValidationError {
@@ -25,7 +26,7 @@ export function validateCategoryInput(body: Record<string, unknown>): CategoryVa
   }
 
   if (!body.type || typeof body.type !== 'string' || !(CATEGORY_TYPES as readonly string[]).includes(body.type)) {
-    errors.push({ field: 'type', message: '유형을 선택해주세요. (소비 또는 수입)' })
+    errors.push({ field: 'type', message: '유형을 선택해주세요. (소비, 수입 또는 이체)' })
   }
 
   if (body.icon !== undefined && body.icon !== null && typeof body.icon !== 'string') {


### PR DESCRIPTION
## Summary

- Category type에 `transfer` 추가 (적금, 예금, 투자계좌, 기타이체)
- TransactionForm: 출금/입금 유형 선택 시 transfer 카테고리만 표시
- 유형 전환(일반↔이체) 시 카테고리 자동 리셋
- API: transfer ↔ transfer 카테고리 양방향 검증
- 집계(byMonth, summary): transfer 카테고리를 소비/수입에서 제외
- 카테고리 관리 UI: 이체 탭 추가
- 후잉 매핑 UI: 이체 그룹 표시
- 금액 표시: transfer 거래는 ↑/↓ + sodam 컬러

Closes #210

## 변경 파일 (12개)
- `src/lib/category-utils.ts` — CATEGORY_TYPES에 'transfer' 추가
- `prisma/seed.ts` — transfer 카테고리 시드 4개
- `src/components/expense/TransactionForm.tsx` — transfer 카테고리 필터, 추천 비활성화
- `src/components/category/CategoryClient.tsx` — 이체 탭
- `src/components/category/CategoryTable.tsx` — 이체 탭
- `src/components/category/CategoryDeleteModal.tsx` — 이체 라벨
- `src/components/expense/TransactionTable.tsx` — transfer 금액 표시
- `src/components/expense/TransactionDeleteModal.tsx` — transfer 금액 표시
- `src/components/settings/WhooingSettings.tsx` — 이체 그룹
- `src/app/api/transactions/route.ts` — 양방향 검증 + 집계 제외
- `src/app/api/transactions/[id]/route.ts` — 양방향 검증
- `src/app/expenses/page.tsx` — SSR 집계 제외

## 배포 가이드
기존 transfer 거래가 expense 카테고리로 저장되어 있으므로, 배포 후 아래 SQL로 마이그레이션 필요:
```sql
-- 1. transfer 카테고리 추가 (시드 or 웹 UI에서)
-- 2. 기존 transfer 거래의 카테고리를 transfer 타입으로 변경
UPDATE "Transaction" t
SET "categoryId" = (SELECT id FROM "Category" WHERE slug = 'etc-transfer')
WHERE t.type IN ('transfer_out', 'transfer_in');
```

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (3회, P1/P2: 0건)

## Test plan
- [ ] TransactionForm에서 출금/입금 선택 시 transfer 카테고리만 표시
- [ ] 소비→출금 전환 시 카테고리 리셋 확인
- [ ] 카테고리 관리에서 이체 탭 + CRUD 정상
- [ ] 후잉 설정에서 이체 그룹 매핑 가능
- [ ] 기존 소비/수입 차트·분석·예산 정상 동작 (회귀)
- [ ] transfer 거래가 소비/수입 합계에 포함되지 않음