### PR TITLE
텔레그램 AI 대화 세션 유지 (#228)

### DIFF
--- a/docs/implementation_plans/228-ai-session-persistence.md
+++ b/docs/implementation_plans/228-ai-session-persistence.md
@@ -1,0 +1,11 @@
+# 구현 계획: 텔레그램 AI 대화 세션 유지 (#228)
+
+## 변경 파일 (2개)
+
+| 순서 | 파일 | 변경 내용 |
+|------|------|-----------|
+| 1 | `src/lib/ai/claude-advisor.ts` | sessionId 옵션 + --resume + session_id 반환 |
+| 2 | `src/bot/commands/ai.ts` | chatId별 세션 Map + /reset 커맨드 |
+
+## 패키지 추가: 없음
+## DB 마이그레이션: 없음

--- a/docs/specs/228-ai-session-persistence.md
+++ b/docs/specs/228-ai-session-persistence.md
@@ -1,0 +1,46 @@
+# 텔레그램 AI 대화 세션 유지
+
+## 목적
+
+텔레그램 AI 대화 시 이전 컨텍스트를 유지하여 연속 대화 가능.
+현재 매 질문마다 독립 프로세스가 실행되어 이전 대화가 사라짐.
+
+## 요구사항
+
+- [ ] chatId별 세션 ID 관리 (Map)
+- [ ] 첫 호출: 새 세션 → session_id 저장
+- [ ] 이후 호출: `--resume <sessionId>`로 대화 이어감
+- [ ] `/reset` 커맨드로 세션 초기화
+- [ ] `--no-session-persistence` 플래그 제거
+
+## 기술 설계
+
+### Claude CLI `--resume` 동작 (검증 완료)
+
+1. 첫 호출: `claude -p "질문" --output-format json` → 응답에 `session_id` 포함
+2. 이후 호출: `claude -p "질문" --resume <sessionId> --output-format json` → 이전 대화 이어감
+3. `--no-session-persistence` 제거해야 세션 파일이 저장됨
+
+### 변경 파일
+
+1. **`src/lib/ai/claude-advisor.ts`**
+   - `askAdvisor`에 `sessionId?: string` 옵션 추가
+   - `sessionId` 있으면 `--resume <sessionId>` 추가, `--system-prompt` 제거 (resume 시 불필요)
+   - `--no-session-persistence` 제거
+   - 응답에서 `session_id` 반환
+
+2. **`src/bot/commands/ai.ts`**
+   - chatId별 세션 ID Map 관리
+   - `fireAiQuestion`에서 세션 ID 전달 + 응답에서 세션 ID 저장
+   - `/reset` 커맨드 등록
+
+## 테스트 계획
+
+- [ ] 텔레그램에서 "내 이름은 세진이야" → "내 이름이 뭐야?" → 세진 답변
+- [ ] `/reset` → 세션 초기화 → "내 이름이 뭐야?" → 모름
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- 웹 AI 페이지 세션은 별도 이슈
+- 브리핑/자동 알림은 세션 불필요 (단발성)

--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -51,7 +51,7 @@ function fireAiQuestion(ctx: Context, question: string): void {
   }, TYPING_INTERVAL_MS)
 
   cleanExpiredSessions()
-  askAdvisor(question, { sessionId: chatSessions.get(chatId)?.sessionId })
+  askAdvisor(question, { sessionId: chatSessions.get(chatId)?.sessionId, persist: true })
     .then(async (result) => {
       if (result.sessionId) chatSessions.set(chatId, { sessionId: result.sessionId, lastUsed: Date.now() })
       const chunks = splitMessage(result.response)

--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -14,11 +14,15 @@ import { markdownToTelegramHtml } from '../utils/markdown'
 const TYPING_INTERVAL_MS = 5000
 const MIN_AI_TEXT_LENGTH = 3
 
+// chatId별 AI 세션 ID 관리
+const chatSessions = new Map<number, string>()
+
 // ============================================================
 // AI 질문 처리
 // ============================================================
 
 function fireAiQuestion(ctx: Context, question: string): void {
+  const chatId = ctx.chat?.id ?? 0
   ctx.reply('🤔 생각 중...')
     .catch((e) => console.error('[bot] 생각 중 응답 실패:', e))
 
@@ -27,8 +31,9 @@ function fireAiQuestion(ctx: Context, question: string): void {
       .catch(() => { /* 무시 */ })
   }, TYPING_INTERVAL_MS)
 
-  askAdvisor(question)
+  askAdvisor(question, { sessionId: chatSessions.get(chatId) })
     .then(async (result) => {
+      if (result.sessionId) chatSessions.set(chatId, result.sessionId)
       const chunks = splitMessage(result.response)
       for (const chunk of chunks) {
         const chunkHtml = markdownToTelegramHtml(chunk)
@@ -412,6 +417,13 @@ export function registerAiCommands(bot: Bot): void {
     }
 
     fireAiQuestion(ctx, question)
+  })
+
+  // AI 세션 초기화
+  bot.command('reset', async (ctx) => {
+    const chatId = ctx.chat?.id ?? 0
+    chatSessions.delete(chatId)
+    await ctx.reply('🔄 AI 대화 세션이 초기화되었습니다.')
   })
 
   // aitrade: 콜백 처리

--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -14,15 +14,34 @@ import { markdownToTelegramHtml } from '../utils/markdown'
 const TYPING_INTERVAL_MS = 5000
 const MIN_AI_TEXT_LENGTH = 3
 
-// chatId별 AI 세션 ID 관리
-const chatSessions = new Map<number, string>()
+// chatId별 AI 세션 ID + 마지막 사용 시각 관리
+const chatSessions = new Map<number, { sessionId: string; lastUsed: number }>()
+// chatId별 진행 중 플래그 (직렬화)
+const chatBusy = new Set<number>()
+// 24시간 미사용 세션 정리
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000
+function cleanExpiredSessions(): void {
+  const now = Date.now()
+  chatSessions.forEach((v, k) => {
+    if (now - v.lastUsed > SESSION_TTL_MS) chatSessions.delete(k)
+  })
+}
 
 // ============================================================
 // AI 질문 처리
 // ============================================================
 
 function fireAiQuestion(ctx: Context, question: string): void {
-  const chatId = ctx.chat?.id ?? 0
+  const chatId = ctx.chat?.id
+  if (!chatId) return
+
+  if (chatBusy.has(chatId)) {
+    ctx.reply('⏳ 이전 질문을 처리 중입니다. 잠시 후 다시 시도해주세요.')
+      .catch(() => {})
+    return
+  }
+  chatBusy.add(chatId)
+
   ctx.reply('🤔 생각 중...')
     .catch((e) => console.error('[bot] 생각 중 응답 실패:', e))
 
@@ -31,9 +50,10 @@ function fireAiQuestion(ctx: Context, question: string): void {
       .catch(() => { /* 무시 */ })
   }, TYPING_INTERVAL_MS)
 
-  askAdvisor(question, { sessionId: chatSessions.get(chatId) })
+  cleanExpiredSessions()
+  askAdvisor(question, { sessionId: chatSessions.get(chatId)?.sessionId })
     .then(async (result) => {
-      if (result.sessionId) chatSessions.set(chatId, result.sessionId)
+      if (result.sessionId) chatSessions.set(chatId, { sessionId: result.sessionId, lastUsed: Date.now() })
       const chunks = splitMessage(result.response)
       for (const chunk of chunks) {
         const chunkHtml = markdownToTelegramHtml(chunk)
@@ -55,7 +75,7 @@ function fireAiQuestion(ctx: Context, question: string): void {
       }
     })
     .catch((e) => console.error('[bot] AI 응답 전송 실패:', e))
-    .finally(() => clearInterval(typingInterval))
+    .finally(() => { clearInterval(typingInterval); chatBusy.delete(chatId) })
 }
 
 // ============================================================
@@ -421,7 +441,8 @@ export function registerAiCommands(bot: Bot): void {
 
   // AI 세션 초기화
   bot.command('reset', async (ctx) => {
-    const chatId = ctx.chat?.id ?? 0
+    const chatId = ctx.chat?.id
+    if (!chatId) return
     chatSessions.delete(chatId)
     await ctx.reply('🔄 AI 대화 세션이 초기화되었습니다.')
   })

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -137,6 +137,11 @@ export async function askAdvisor(
     '--permission-mode', 'dontAsk',
   )
 
+  // 세션 옵트인: sessionId 제공 시에만 세션 유지, 나머지는 비저장
+  if (!sessionId) {
+    cmdParts.push('--no-session-persistence')
+  }
+
   const cmd = cmdParts.join(' ')
 
   return new Promise<AdvisorResult>((resolve, reject) => {

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -11,6 +11,8 @@ export interface AdvisorOptions {
   timeout?: number
   /** API 비용 상한 USD (기본: 0.50) */
   maxBudgetUsd?: number
+  /** 기존 세션 이어가기 */
+  sessionId?: string
 }
 
 export interface AdvisorResult {
@@ -18,6 +20,7 @@ export interface AdvisorResult {
   model: AdvisorModel
   durationMs: number
   costUsd: number
+  sessionId: string
 }
 
 export class AdvisorTimeoutError extends Error {
@@ -62,6 +65,7 @@ interface ClaudeJsonOutput {
   result: string
   duration_ms: number
   total_cost_usd: number
+  session_id: string
 }
 
 /**
@@ -85,6 +89,7 @@ export async function askAdvisor(
     model = 'haiku',
     timeout = 180_000,
     maxBudgetUsd = 0.50,
+    sessionId,
   } = options
 
   // 프롬프트 길이 제한
@@ -108,20 +113,31 @@ export async function askAdvisor(
   const mcpConfigPath = process.env.MCP_CONFIG_PATH
     ?? path.join(projectRoot, 'src/lib/ai/mcp-config.json')
 
-  const cmd = [
+  const cmdParts = [
     'claude',
     '-p', shellEscape(prompt),
     '--output-format', 'json',
     '--model', model,
-    '--system-prompt', shellEscape(SYSTEM_PROMPT),
+  ]
+
+  if (sessionId) {
+    // 세션 이어가기: --resume 사용, system-prompt는 이미 세션에 포함
+    cmdParts.push('--resume', shellEscape(sessionId))
+  } else {
+    // 새 세션: system-prompt 포함
+    cmdParts.push('--system-prompt', shellEscape(SYSTEM_PROMPT))
+  }
+
+  cmdParts.push(
     '--mcp-config', shellEscape(mcpConfigPath),
     '--strict-mcp-config',
     '--allowedTools', shellEscape(ALLOWED_TOOLS),
     '--tools', '"WebSearch,WebFetch"',
     '--max-budget-usd', String(maxBudgetUsd),
     '--permission-mode', 'dontAsk',
-    '--no-session-persistence',
-  ].join(' ')
+  )
+
+  const cmd = cmdParts.join(' ')
 
   return new Promise<AdvisorResult>((resolve, reject) => {
     const chunks: Buffer[] = []
@@ -168,6 +184,7 @@ export async function askAdvisor(
           model,
           durationMs: output.duration_ms,
           costUsd: output.total_cost_usd,
+          sessionId: output.session_id ?? '',
         })
       } catch {
         reject(new AdvisorError('AI 응답을 파싱할 수 없습니다.'))

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -13,6 +13,8 @@ export interface AdvisorOptions {
   maxBudgetUsd?: number
   /** 기존 세션 이어가기 */
   sessionId?: string
+  /** 세션을 디스크에 저장 (기본: false). 텔레그램 AI만 true */
+  persist?: boolean
 }
 
 export interface AdvisorResult {
@@ -90,6 +92,7 @@ export async function askAdvisor(
     timeout = 180_000,
     maxBudgetUsd = 0.50,
     sessionId,
+    persist = false,
   } = options
 
   // 프롬프트 길이 제한
@@ -137,8 +140,8 @@ export async function askAdvisor(
     '--permission-mode', 'dontAsk',
   )
 
-  // 세션 옵트인: sessionId 제공 시에만 세션 유지, 나머지는 비저장
-  if (!sessionId) {
+  // 세션 저장: persist=true인 경우만 저장, 그 외 비저장
+  if (!persist) {
     cmdParts.push('--no-session-persistence')
   }
 


### PR DESCRIPTION
## Summary

- `--resume`으로 chatId별 AI 대화 세션 유지 (이전 컨텍스트 기억)
- `/reset` 커맨드로 세션 초기화
- 세션 옵트인: 텔레그램 AI만 세션 저장, 브리핑/웹 등은 `--no-session-persistence` 유지
- 동일 chat 요청 직렬화 (chatBusy 가드)
- 24시간 미사용 세션 자동 정리

Closes #228

## 변경 파일
- `src/lib/ai/claude-advisor.ts` — sessionId 옵션 + --resume + 옵트인 세션 저장
- `src/bot/commands/ai.ts` — chatSessions Map + /reset + 직렬화 + TTL

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (1회, P1/P2: 0건)

## Test plan
- [ ] "내 이름은 세진이야" → "내 이름 뭐야?" → 세진 답변 (세션 유지)
- [ ] `/reset` → "내 이름 뭐야?" → 모름 (세션 초기화)
- [ ] 연속 질문 시 "이전 질문 처리 중" 안내 (직렬화)
- [ ] 브리핑/웹 AI → 세션 미저장 확인