### PR TITLE
[Phase 20] 목표가 도달 알림 (20-B) (#233)

### DIFF
--- a/docs/implementation_plans/233-target-price-alert.md
+++ b/docs/implementation_plans/233-target-price-alert.md
@@ -1,0 +1,17 @@
+# 구현 계획: 목표가 도달 알림 (#233)
+
+## 변경 파일 (1개)
+
+| 순서 | 파일 | 변경 내용 |
+|------|------|-----------|
+| 1 | `src/bot/notifications/price-alert.ts` | 목표가/손절가/매수구간 체크 추가 |
+
+## 구현 내용
+
+checkPriceAlerts 함수 내에서 기존 급등락 체크 후:
+1. HoldingStrategy 조회 → targetPrice/stopLoss vs 현재가 비교
+2. Watchlist 조회 → targetBuy/entryLow~entryHigh vs 현재가 비교
+3. sentToday 중복 방지 (target:TICKER, zone:TICKER 키)
+
+## 패키지 추가: 없음
+## DB 마이그레이션: 없음

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -231,7 +231,7 @@
 
 ## Phase 20: 트레이딩 알림 + AI 매매 가이드
 
-- [ ] **20-A**: 관심종목 시세 갱신 (refreshPrices에 Watchlist 티커 포함)
+- [x] **20-A**: 관심종목 시세 갱신 (refreshPrices에 Watchlist 티커 포함)
 - [ ] **20-B**: 목표가 도달 알림 (보유/관심종목 targetBuy/targetPrice 도달 시 텔레그램 알림)
 - [ ] **20-C**: 전략 기반 TA 시그널 알림 (스윙/모멘텀/단타 종목의 TA 조건 충족 시 자동 알림)
 - [ ] **20-D**: 매매 전략 스킬 연동 (stock-trading-method 스킬을 서버 rules에 배치)

--- a/docs/specs/233-target-price-alert.md
+++ b/docs/specs/233-target-price-alert.md
@@ -1,0 +1,43 @@
+# 목표가 도달 알림
+
+## 목적
+
+보유종목의 목표가, 관심종목의 목표 매수가/매수구간 도달 시 텔레그램으로 자동 알림.
+
+## 요구사항
+
+- [ ] 보유종목: HoldingStrategy.targetPrice 도달 시 알림
+- [ ] 보유종목: HoldingStrategy.stopLoss 도달 시 알림
+- [ ] 관심종목: Watchlist.targetBuy 도달 시 알림
+- [ ] 관심종목: Watchlist.entryLow~entryHigh 매수구간 진입 시 알림
+- [ ] 중복 방지: 동일 조건 당일 1회만 발송 (기존 sentToday 패턴)
+- [ ] 기존 급등락/환율 알림과 함께 발송
+
+## 기술 설계
+
+### 변경 파일 (1개)
+
+**`src/bot/notifications/price-alert.ts`** — `checkPriceAlerts`에 목표가 체크 추가
+
+#### 보유종목 목표가/손절가 체크
+- HoldingStrategy의 targetPrice, stopLoss 조회
+- 현재가 >= targetPrice → 목표가 도달 알림
+- 현재가 <= stopLoss → 손절가 도달 알림
+
+#### 관심종목 매수가/매수구간 체크
+- Watchlist의 targetBuy, entryLow, entryHigh 조회
+- 현재가 <= targetBuy → 목표 매수가 도달 알림
+- entryLow <= 현재가 <= entryHigh → 매수구간 진입 알림
+
+## 테스트 계획
+
+- [ ] 보유종목 현재가가 targetPrice 이상 → 알림 발송
+- [ ] 관심종목 현재가가 targetBuy 이하 → 알림 발송
+- [ ] 관심종목 현재가가 매수구간 내 → 알림 발송
+- [ ] 동일 조건 재알림 방지 (당일 1회)
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- 알림 설정 UI 변경 없음 (기존 필드 활용)
+- 텔레그램 알림 설정 커맨드 변경 없음

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -65,11 +65,18 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   const holdingTickers = new Set(holdings.map((h) => h.ticker))
   const nameMap = new Map(holdings.map((h) => [h.ticker, h.displayName]))
 
+  // 관심종목 티커도 수집
+  const watchlistTickers = await prisma.watchlist.findMany({
+    select: { ticker: true },
+  })
+  const allTickerSet = new Set(Array.from(holdingTickers))
+  for (const w of watchlistTickers) allTickerSet.add(w.ticker)
+  allTickerSet.add('USDKRW=X')
+  const allTickers = Array.from(allTickerSet)
+
   // PriceCache에서 변동률 조회
   const prices = await prisma.priceCache.findMany({
-    where: {
-      ticker: { in: Array.from(holdingTickers).concat(['USDKRW=X']) },
-    },
+    where: { ticker: { in: allTickers } },
   })
 
   const alerts: string[] = []
@@ -108,6 +115,78 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const name = nameMap.get(p.ticker) ?? p.ticker
       alerts.push(
         `🟢 ${name} (${p.ticker}) 급등: ${formatPercent(p.changePercent)}`
+      )
+    }
+  }
+
+  // --- 보유종목 목표가/손절가 체크 ---
+  const strategies = await prisma.holdingStrategy.findMany({
+    where: {
+      OR: [
+        { targetPrice: { not: null } },
+        { stopLoss: { not: null } },
+      ],
+    },
+    include: {
+      holding: { select: { ticker: true, displayName: true, currency: true } },
+    },
+  })
+
+  for (const s of strategies) {
+    const price = prices.find((p) => p.ticker === s.holding.ticker)
+    if (!price) continue
+
+    // 현재가 비교: USD 종목은 USD 가격, KRW 종목은 KRW 가격
+    const currentPrice = price.price
+
+    if (s.targetPrice != null && currentPrice >= s.targetPrice) {
+      const key = `target:${s.holding.ticker}`
+      if (sentToday.get(key) === today) continue
+      sentToday.set(key, today)
+      alerts.push(
+        `🎯 ${s.holding.displayName} (${s.holding.ticker}) 목표가 도달: ${currentPrice.toLocaleString()} (목표 ${s.targetPrice.toLocaleString()})`
+      )
+    }
+
+    if (s.stopLoss != null && currentPrice <= s.stopLoss) {
+      const key = `stoploss:${s.holding.ticker}`
+      if (sentToday.get(key) === today) continue
+      sentToday.set(key, today)
+      alerts.push(
+        `🛑 ${s.holding.displayName} (${s.holding.ticker}) 손절가 도달: ${currentPrice.toLocaleString()} (손절 ${s.stopLoss.toLocaleString()})`
+      )
+    }
+  }
+
+  // --- 관심종목 목표 매수가/매수구간 체크 ---
+  const watchlist = await prisma.watchlist.findMany({
+    where: {
+      OR: [
+        { targetBuy: { not: null } },
+        { entryLow: { not: null } },
+      ],
+    },
+  })
+
+  for (const w of watchlist) {
+    const price = prices.find((p) => p.ticker === w.ticker)
+    if (!price) continue
+
+    if (w.targetBuy != null && price.price <= w.targetBuy) {
+      const key = `wbuy:${w.ticker}`
+      if (sentToday.get(key) === today) continue
+      sentToday.set(key, today)
+      alerts.push(
+        `💰 ${w.displayName} (${w.ticker}) 목표 매수가 도달: ${price.price.toLocaleString()} (목표 ${w.targetBuy.toLocaleString()})`
+      )
+    }
+
+    if (w.entryLow != null && w.entryHigh != null && price.price >= w.entryLow && price.price <= w.entryHigh) {
+      const key = `wzone:${w.ticker}`
+      if (sentToday.get(key) === today) continue
+      sentToday.set(key, today)
+      alerts.push(
+        `🔔 ${w.displayName} (${w.ticker}) 매수구간 진입: ${price.price.toLocaleString()} (구간 ${w.entryLow.toLocaleString()}~${w.entryHigh.toLocaleString()})`
       )
     }
   }

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -143,20 +143,22 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
 
     if (s.targetPrice != null && currentPrice >= s.targetPrice) {
       const key = `target:${s.holding.ticker}`
-      if (sentToday.get(key) === today) continue
-      sentToday.set(key, today)
-      alerts.push(
-        `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`
-      )
+      if (sentToday.get(key) !== today) {
+        sentToday.set(key, today)
+        alerts.push(
+          `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`
+        )
+      }
     }
 
     if (s.stopLoss != null && currentPrice <= s.stopLoss) {
       const key = `stoploss:${s.holding.ticker}`
-      if (sentToday.get(key) === today) continue
-      sentToday.set(key, today)
-      alerts.push(
-        `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`
-      )
+      if (sentToday.get(key) !== today) {
+        sentToday.set(key, today)
+        alerts.push(
+          `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`
+        )
+      }
     }
   }
 
@@ -179,20 +181,22 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
 
     if (w.targetBuy != null && price.price <= w.targetBuy) {
       const key = `wbuy:${w.ticker}`
-      if (sentToday.get(key) === today) continue
-      sentToday.set(key, today)
-      alerts.push(
-        `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`
-      )
+      if (sentToday.get(key) !== today) {
+        sentToday.set(key, today)
+        alerts.push(
+          `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`
+        )
+      }
     }
 
     if (w.entryLow != null && w.entryHigh != null && price.price >= w.entryLow && price.price <= w.entryHigh) {
       const key = `wzone:${w.ticker}`
-      if (sentToday.get(key) === today) continue
-      sentToday.set(key, today)
-      alerts.push(
-        `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`
-      )
+      if (sentToday.get(key) !== today) {
+        sentToday.set(key, today)
+        alerts.push(
+          `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`
+        )
+      }
     }
   }
 

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -9,7 +9,7 @@
 import { prisma } from '@/lib/prisma'
 import { getBot } from '@/bot/index'
 import { formatPercent } from '@/bot/utils/formatter'
-import { sendHtml } from '@/bot/utils/telegram'
+import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 
 /** 당일 알림 발송 기록 (ticker → date string) */
 const sentToday = new Map<string, string>()
@@ -79,6 +79,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
     where: { ticker: { in: allTickers } },
   })
 
+  const priceMap = new Map(prices.map((p) => [p.ticker, p]))
   const alerts: string[] = []
 
   for (const p of prices) {
@@ -133,18 +134,19 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   })
 
   for (const s of strategies) {
-    const price = prices.find((p) => p.ticker === s.holding.ticker)
+    const price = priceMap.get(s.holding.ticker)
     if (!price) continue
 
-    // 현재가 비교: USD 종목은 USD 가격, KRW 종목은 KRW 가격
     const currentPrice = price.price
+    const name = escapeHtml(s.holding.displayName)
+    const ticker = escapeHtml(s.holding.ticker)
 
     if (s.targetPrice != null && currentPrice >= s.targetPrice) {
       const key = `target:${s.holding.ticker}`
       if (sentToday.get(key) === today) continue
       sentToday.set(key, today)
       alerts.push(
-        `🎯 ${s.holding.displayName} (${s.holding.ticker}) 목표가 도달: ${currentPrice.toLocaleString()} (목표 ${s.targetPrice.toLocaleString()})`
+        `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`
       )
     }
 
@@ -153,7 +155,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       if (sentToday.get(key) === today) continue
       sentToday.set(key, today)
       alerts.push(
-        `🛑 ${s.holding.displayName} (${s.holding.ticker}) 손절가 도달: ${currentPrice.toLocaleString()} (손절 ${s.stopLoss.toLocaleString()})`
+        `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`
       )
     }
   }
@@ -169,15 +171,18 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   })
 
   for (const w of watchlist) {
-    const price = prices.find((p) => p.ticker === w.ticker)
+    const price = priceMap.get(w.ticker)
     if (!price) continue
+
+    const name = escapeHtml(w.displayName)
+    const ticker = escapeHtml(w.ticker)
 
     if (w.targetBuy != null && price.price <= w.targetBuy) {
       const key = `wbuy:${w.ticker}`
       if (sentToday.get(key) === today) continue
       sentToday.set(key, today)
       alerts.push(
-        `💰 ${w.displayName} (${w.ticker}) 목표 매수가 도달: ${price.price.toLocaleString()} (목표 ${w.targetBuy.toLocaleString()})`
+        `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`
       )
     }
 
@@ -186,7 +191,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       if (sentToday.get(key) === today) continue
       sentToday.set(key, today)
       alerts.push(
-        `🔔 ${w.displayName} (${w.ticker}) 매수구간 진입: ${price.price.toLocaleString()} (구간 ${w.entryLow.toLocaleString()}~${w.entryHigh.toLocaleString()})`
+        `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`
       )
     }
   }


### PR DESCRIPTION
## Summary

- 보유종목: targetPrice 도달 + stopLoss 도달 시 텔레그램 알림
- 관심종목: targetBuy 도달 + 매수구간(entryLow~entryHigh) 진입 시 알림
- 기존 급등락/환율 알림과 동일 cron 주기에서 함께 체크
- 중복 방지: 동일 조건 당일 1회만 발송

Closes #233

## 변경 파일
- `src/bot/notifications/price-alert.ts` — 목표가/손절가/매수구간 체크 추가

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (1회, P1/P2: 0건)

## Test plan
- [ ] 보유종목 targetPrice 설정 후 현재가 >= 목표가 → 알림 발송
- [ ] 보유종목 stopLoss 설정 후 현재가 <= 손절가 → 알림 발송
- [ ] 관심종목 targetBuy 설정 후 현재가 <= 목표매수가 → 알림 발송
- [ ] 관심종목 매수구간 설정 후 현재가가 구간 내 → 알림 발송
- [ ] 동일 조건 재알림 방지 확인