### PR TITLE
가계부 수정 시 페이징 초기화 버그 수정 (#245)

### DIFF
--- a/docs/specs/245-expense-paging-fix.md
+++ b/docs/specs/245-expense-paging-fix.md
@@ -1,0 +1,30 @@
+# 가계부 수정 시 페이징 초기화 버그 수정
+
+## 목적
+
+가계부 내역 수정/삭제 후 페이지가 첫 페이지로 돌아가는 문제 수정.
+
+## 원인
+
+handleSaved → fetchData → offset: '0' 하드코딩 + setOffset(0) 호출.
+필터(연도/월/탭) 변경 시에는 offset 초기화가 맞지만,
+내역 수정/삭제 시에는 현재 페이지를 유지해야 함.
+
+## 요구사항
+
+- [ ] 내역 수정/삭제 후 현재 페이지 유지
+- [ ] 필터 변경 시에는 기존대로 offset 초기화
+
+## 기술 설계
+
+### 변경 파일 (1개)
+
+**`src/app/expenses/ExpensesClient.tsx`**
+- fetchData에 keepOffset 옵션 추가
+- handleSaved에서 현재 offset 유지하여 조회
+
+## 테스트 계획
+
+- [ ] 2페이지에서 내역 수정 → 2페이지 유지
+- [ ] 연도/월 변경 → 첫 페이지로 이동 (기존 동작)
+- [ ] lint + typecheck + build 통과

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -111,14 +111,15 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       .catch(() => {})
   }, [])
 
-  const fetchData = useCallback(async (y: number, m: number | undefined, t: TabType) => {
+  const fetchData = useCallback(async (y: number, m: number | undefined, t: TabType, keepOffset?: number) => {
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
 
+    const requestOffset = keepOffset ?? 0
     setLoading(true)
     try {
-      const params = new URLSearchParams({ year: String(y), offset: '0' })
+      const params = new URLSearchParams({ year: String(y), offset: String(requestOffset) })
       if (m) params.set('month', String(m))
       if (t !== 'all') params.set('type', t)
 
@@ -126,7 +127,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       if (res.ok) {
         const json: ApiResponse = await res.json()
         setData(json)
-        setOffset(0)
+        setOffset(requestOffset)
       }
       // 월 선택 시 분석 데이터도 조회 (소비 탭 또는 전체 탭에서만)
       if (m && t !== 'income') {
@@ -208,7 +209,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
   const handleTabChange = (t: TabType) => setTab(t)
 
   const handleSaved = () => {
-    fetchData(year, month, tab)
+    fetchData(year, month, tab, offset)
   }
 
   const handleEdit = (tx: TransactionRow) => {

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -126,8 +126,22 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       const res = await fetch(`/api/transactions?${params}`, { signal: controller.signal })
       if (res.ok) {
         const json: ApiResponse = await res.json()
-        setData(json)
-        setOffset(requestOffset)
+        // 삭제 후 offset >= total이면 마지막 유효 페이지로 보정
+        if (requestOffset > 0 && json.transactions.length === 0 && json.total > 0) {
+          const corrected = Math.max(0, Math.floor((json.total - 1) / json.limit) * json.limit)
+          setOffset(corrected)
+          // 보정된 offset으로 재조회
+          const retryParams = new URLSearchParams({ year: String(y), offset: String(corrected) })
+          if (m) retryParams.set('month', String(m))
+          if (t !== 'all') retryParams.set('type', t)
+          const retryRes = await fetch(`/api/transactions?${retryParams}`, { signal: controller.signal })
+          if (retryRes.ok) {
+            setData(await retryRes.json())
+          }
+        } else {
+          setData(json)
+          setOffset(requestOffset)
+        }
       }
       // 월 선택 시 분석 데이터도 조회 (소비 탭 또는 전체 탭에서만)
       if (m && t !== 'income') {
@@ -208,8 +222,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
   const handleMonthChange = (m: number | undefined) => setMonth(m)
   const handleTabChange = (t: TabType) => setTab(t)
 
-  const handleSaved = () => {
-    fetchData(year, month, tab, offset)
+  const handleSaved = (keepCurrentPage = true) => {
+    fetchData(year, month, tab, keepCurrentPage ? offset : undefined)
   }
 
   const handleEdit = (tx: TransactionRow) => {
@@ -377,7 +391,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
           categories={categories}
           assets={assets}
           onClose={() => setShowForm(false)}
-          onSaved={handleSaved}
+          onSaved={() => handleSaved(false)}
         />
       )}
 


### PR DESCRIPTION
## Summary

- 내역 수정/삭제 후 현재 페이지 유지 (기존: 항상 첫 페이지로 초기화)
- 삭제 후 offset >= total이면 마지막 유효 페이지로 자동 보정
- 생성 시에는 첫 페이지로 이동 (새 항목 표시)
- 필터(연도/월/탭) 변경 시에는 기존대로 offset 초기화

Closes #245

## 변경 파일
- `src/app/expenses/ExpensesClient.tsx` — fetchData keepOffset + 페이지 보정

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (1회, P1/P2: 0건)

## Test plan
- [ ] 2페이지에서 내역 수정 → 2페이지 유지
- [ ] 마지막 페이지에서 삭제 → 이전 페이지로 자동 이동
- [ ] 내역 생성 → 첫 페이지로 이동
- [ ] 연도/월 변경 → 첫 페이지 (기존 동작)