### PR TITLE
[Phase 21] 웹 자산 관리 페이지 (21-A) (#247)

### DIFF
--- a/docs/implementation_plans/247-asset-management-page.md
+++ b/docs/implementation_plans/247-asset-management-page.md
@@ -1,0 +1,18 @@
+# 구현 계획: 웹 자산 관리 페이지 (#247)
+
+## 변경 파일 (6개)
+
+| 순서 | 파일 | 변경 내용 |
+|------|------|-----------|
+| 1 | `src/components/asset/AssetTable.tsx` (신규) | 자산 테이블 + 소유자 탭 |
+| 2 | `src/components/asset/AssetForm.tsx` (신규) | 추가/수정 슬라이드 폼 |
+| 3 | `src/components/asset/AssetDeleteModal.tsx` (신규) | 삭제 확인 모달 |
+| 4 | `src/app/assets/AssetsClient.tsx` (신규) | 클라이언트 컴포넌트 (상태 관리) |
+| 5 | `src/app/assets/page.tsx` (신규) | SSR 페이지 |
+| 6 | `src/components/layout/nav-config.ts` | 네비게이션 링크 추가 |
+
+## 디자인 참조
+- 카테고리 관리 페이지 (`/categories`) 패턴: 테이블 + 소유자 탭 + 슬라이드 폼 + 삭제 모달
+
+## 패키지 추가: 없음
+## DB 마이그레이션: 없음

--- a/docs/specs/247-asset-management-page.md
+++ b/docs/specs/247-asset-management-page.md
@@ -1,0 +1,47 @@
+# 웹 자산 관리 페이지
+
+## 목적
+
+비주식 자산(주택청약, 입출금계좌, 적금, 보험 등)을 웹에서 추가/수정/삭제.
+현재 API(GET/POST/PUT/DELETE)는 존재하지만 웹 UI가 없어 텔레그램으로만 관리 가능.
+
+## 요구사항
+
+- [ ] `/assets` 페이지 신규 생성
+- [ ] 자산 목록 테이블 (이름, 카테고리, 소유자, 평가액, 이율, 만기일)
+- [ ] 자산 추가/수정 슬라이드 폼
+- [ ] 자산 삭제 모달
+- [ ] 소유자별(세진/소담/다솜/공동) 탭 필터
+- [ ] 네비게이션에 자산 관리 링크 추가
+
+## 기술 설계
+
+### 신규 파일
+
+1. `src/app/assets/page.tsx` — SSR 자산 목록 조회
+2. `src/app/assets/AssetsClient.tsx` — 클라이언트 컴포넌트
+3. `src/components/asset/AssetTable.tsx` — 자산 테이블
+4. `src/components/asset/AssetForm.tsx` — 추가/수정 폼
+5. `src/components/asset/AssetDeleteModal.tsx` — 삭제 모달
+
+### 수정 파일
+
+6. `src/components/layout/nav-config.ts` — 네비게이션에 자산 관리 추가
+
+### 카테고리 옵션
+
+savings(적금/예금), cash(입출금), insurance(보험), real_estate(부동산),
+pension(연금), loan(대출/부채), other(기타)
+
+## 테스트 계획
+
+- [ ] 자산 추가 → 목록에 표시
+- [ ] 자산 수정 → 값 반영
+- [ ] 자산 삭제 → 목록에서 제거
+- [ ] 소유자별 탭 필터 동작
+- [ ] lint + typecheck + build 통과
+
+## 제외 사항
+
+- 증여 추적 (21-B)
+- 자산 간 이체 (21-B)

--- a/src/app/assets/AssetsClient.tsx
+++ b/src/app/assets/AssetsClient.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+import AssetTable, { type AssetRow } from '@/components/asset/AssetTable'
+import AssetForm from '@/components/asset/AssetForm'
+import AssetDeleteModal from '@/components/asset/AssetDeleteModal'
+
+type OwnerTab = '전체' | '세진' | '소담' | '다솜' | '공동'
+
+interface AssetsClientProps {
+  assets: AssetRow[]
+}
+
+export default function AssetsClient({ assets }: AssetsClientProps) {
+  const [activeTab, setActiveTab] = useState<OwnerTab>('전체')
+  const [showForm, setShowForm] = useState(false)
+  const [editingAsset, setEditingAsset] = useState<AssetRow | null>(null)
+  const [deletingAsset, setDeletingAsset] = useState<AssetRow | null>(null)
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-4">
+        <div />
+        <button
+          onClick={() => setShowForm(true)}
+          className="inline-flex items-center gap-1.5 px-3 sm:px-4 py-2 rounded-lg bg-sodam/15 text-sodam text-[12px] sm:text-[13px] font-semibold border border-sodam/25 hover:bg-sodam/25 transition-all"
+        >
+          + 자산 추가
+        </button>
+      </div>
+
+      <AssetTable
+        assets={assets}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        onEdit={setEditingAsset}
+        onDelete={setDeletingAsset}
+      />
+
+      {showForm && (
+        <AssetForm mode="create" onClose={() => setShowForm(false)} />
+      )}
+
+      {editingAsset && (
+        <AssetForm mode="edit" asset={editingAsset} onClose={() => setEditingAsset(null)} />
+      )}
+
+      {deletingAsset && (
+        <AssetDeleteModal asset={deletingAsset} onClose={() => setDeletingAsset(null)} />
+      )}
+    </>
+  )
+}

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,0 +1,40 @@
+import { prisma } from '@/lib/prisma'
+import Header from '@/components/layout/Header'
+import AssetsClient from './AssetsClient'
+import { formatKRW } from '@/lib/format'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AssetsPage() {
+  const assets = await prisma.asset.findMany({
+    orderBy: [{ isLiability: 'asc' }, { owner: 'asc' }, { category: 'asc' }, { name: 'asc' }],
+  })
+
+  const totalAssets = assets.filter((a) => !a.isLiability).reduce((s, a) => s + a.value, 0)
+  const totalLiabilities = assets.filter((a) => a.isLiability).reduce((s, a) => s + a.value, 0)
+
+  const serialized = assets.map((a) => ({
+    id: a.id,
+    name: a.name,
+    category: a.category,
+    owner: a.owner,
+    value: a.value,
+    isLiability: a.isLiability,
+    interestRate: a.interestRate,
+    maturityDate: a.maturityDate?.toISOString() ?? null,
+    note: a.note,
+  }))
+
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[960px]">
+      <Header
+        title="자산 관리"
+        sub={`${assets.length}개 · 자산 ${formatKRW(totalAssets)} · 부채 ${formatKRW(totalLiabilities)}`}
+      />
+
+      <div className="mt-5">
+        <AssetsClient assets={serialized} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/asset/AssetDeleteModal.tsx
+++ b/src/components/asset/AssetDeleteModal.tsx
@@ -13,17 +13,22 @@ interface AssetDeleteModalProps {
 export default function AssetDeleteModal({ asset, onClose }: AssetDeleteModalProps) {
   const router = useRouter()
   const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const handleDelete = async () => {
     setIsDeleting(true)
+    setError(null)
     try {
       const res = await fetch(`/api/assets/${asset.id}`, { method: 'DELETE' })
       if (res.ok) {
         onClose()
         router.refresh()
+      } else {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '삭제에 실패했습니다.')
       }
     } catch {
-      // 무시
+      setError('네트워크 오류가 발생했습니다.')
     } finally {
       setIsDeleting(false)
     }
@@ -51,6 +56,8 @@ export default function AssetDeleteModal({ asset, onClose }: AssetDeleteModalPro
         <p className="text-[12px] text-red-400/80 leading-relaxed mb-5">
           이 자산을 삭제하면 복구할 수 없습니다.
         </p>
+
+        {error && <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400 mb-4">{error}</div>}
 
         <div className="flex gap-3">
           <button onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-border hover:bg-surface-dim transition-all">취소</button>

--- a/src/components/asset/AssetDeleteModal.tsx
+++ b/src/components/asset/AssetDeleteModal.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { formatKRW } from '@/lib/format'
+import type { AssetRow } from './AssetTable'
+
+interface AssetDeleteModalProps {
+  asset: AssetRow
+  onClose: () => void
+}
+
+export default function AssetDeleteModal({ asset, onClose }: AssetDeleteModalProps) {
+  const router = useRouter()
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      const res = await fetch(`/api/assets/${asset.id}`, { method: 'DELETE' })
+      if (res.ok) {
+        onClose()
+        router.refresh()
+      }
+    } catch {
+      // 무시
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" onClick={onClose} />
+      <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-[380px] bg-bg-raised border border-border rounded-[14px] z-50 p-6">
+        <h3 className="text-[15px] font-bold text-bright mb-4">자산 삭제</h3>
+
+        <div className="bg-card rounded-lg px-4 py-3 mb-4">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-[11px] text-dim">자산명</span>
+            <span className="text-[13px] text-bright font-medium">{asset.name}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-dim">금액</span>
+            <span className="text-[13px] font-semibold tabular-nums text-bright">
+              {formatKRW(asset.value)}
+            </span>
+          </div>
+        </div>
+
+        <p className="text-[12px] text-red-400/80 leading-relaxed mb-5">
+          이 자산을 삭제하면 복구할 수 없습니다.
+        </p>
+
+        <div className="flex gap-3">
+          <button onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-border hover:bg-surface-dim transition-all">취소</button>
+          <button onClick={handleDelete} disabled={isDeleting} className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-red-500/15 text-red-400 border border-red-500/25 hover:bg-red-500/25 disabled:opacity-40 transition-all">
+            {isDeleting ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/asset/AssetForm.tsx
+++ b/src/components/asset/AssetForm.tsx
@@ -64,10 +64,14 @@ export default function AssetForm({ mode, asset, onClose }: AssetFormProps) {
       const rate = parseFloat(interestRate)
       if (!Number.isFinite(rate)) { setError('유효한 이율을 입력해주세요.'); setIsSubmitting(false); return }
       body.interestRate = rate
+    } else if (isEdit) {
+      body.interestRate = null
     }
 
     if (maturityDate.trim()) {
       body.maturityDate = maturityDate
+    } else if (isEdit) {
+      body.maturityDate = null
     }
 
     try {

--- a/src/components/asset/AssetForm.tsx
+++ b/src/components/asset/AssetForm.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import type { AssetRow } from './AssetTable'
+
+const CATEGORIES = [
+  { value: 'cash', label: '입출금' },
+  { value: 'savings', label: '적금/예금' },
+  { value: 'insurance', label: '보험' },
+  { value: 'real_estate', label: '부동산' },
+  { value: 'pension', label: '연금' },
+  { value: 'loan', label: '대출' },
+  { value: 'other', label: '기타' },
+]
+
+const OWNERS = ['세진', '소담', '다솜', '공동']
+
+interface AssetFormProps {
+  mode: 'create' | 'edit'
+  asset?: AssetRow
+  onClose: () => void
+}
+
+export default function AssetForm({ mode, asset, onClose }: AssetFormProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [name, setName] = useState(asset?.name ?? '')
+  const [category, setCategory] = useState(asset?.category ?? 'cash')
+  const [owner, setOwner] = useState(asset?.owner ?? '세진')
+  const [value, setValue] = useState(asset ? String(asset.value) : '')
+  const [isLiability, setIsLiability] = useState(asset?.isLiability ?? false)
+  const [interestRate, setInterestRate] = useState(asset?.interestRate != null ? String(asset.interestRate) : '')
+  const [maturityDate, setMaturityDate] = useState(asset?.maturityDate?.slice(0, 10) ?? '')
+  const [note, setNote] = useState(asset?.note ?? '')
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    if (!name.trim()) { setError('자산명을 입력해주세요.'); setIsSubmitting(false); return }
+    const parsedValue = parseInt(value.replace(/,/g, ''))
+    if (!Number.isFinite(parsedValue) || parsedValue < 0) { setError('유효한 금액을 입력해주세요.'); setIsSubmitting(false); return }
+
+    const body: Record<string, unknown> = {
+      name: name.trim(),
+      category,
+      owner,
+      value: parsedValue,
+      isLiability,
+      note: note.trim() || null,
+    }
+
+    if (interestRate.trim()) {
+      const rate = parseFloat(interestRate)
+      if (!Number.isFinite(rate)) { setError('유효한 이율을 입력해주세요.'); setIsSubmitting(false); return }
+      body.interestRate = rate
+    }
+
+    if (maturityDate.trim()) {
+      body.maturityDate = maturityDate
+    }
+
+    try {
+      const url = mode === 'edit' ? `/api/assets/${asset!.id}` : '/api/assets'
+      const method = mode === 'edit' ? 'PUT' : 'POST'
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setError(data?.error ?? '저장에 실패했습니다.')
+        return
+      }
+      onClose()
+      router.refresh()
+    } catch {
+      setError('네트워크 오류가 발생했습니다.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const inputClasses = 'w-full bg-surface-dim border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-bright placeholder-dim focus:outline-none focus:bg-surface focus:border-border-hover transition-colors'
+  const labelClasses = 'block text-[12px] font-semibold text-sub mb-1.5'
+  const isEdit = mode === 'edit'
+  const selectStyle = {
+    backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`,
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'right 14px center',
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" onClick={onClose} />
+      <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
+        <div className="px-6 py-5 border-b border-border flex items-center justify-between">
+          <h2 className="text-[15px] font-bold text-bright">{isEdit ? '자산 수정' : '자산 추가'}</h2>
+          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">
+          <div>
+            <label className={labelClasses}>자산명</label>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="신한 적금" maxLength={100} className={inputClasses} autoFocus />
+          </div>
+
+          <div>
+            <label className={labelClasses}>카테고리</label>
+            <select value={category} onChange={(e) => setCategory(e.target.value)}
+              className={`${inputClasses} appearance-none cursor-pointer`} style={selectStyle}>
+              {CATEGORIES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+            </select>
+          </div>
+
+          <div>
+            <label className={labelClasses}>소유자</label>
+            <div className="flex gap-2">
+              {OWNERS.map((o) => (
+                <button key={o} type="button" onClick={() => setOwner(o)}
+                  className={`px-3 py-1.5 rounded-lg text-[12px] font-semibold border transition-all ${
+                    owner === o ? 'bg-surface text-bright border-border-hover' : 'border-border text-sub hover:bg-surface-dim'
+                  }`}>
+                  {o}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClasses}>금액 (원)</label>
+            <input type="text" inputMode="numeric" value={value} onChange={(e) => setValue(e.target.value.replace(/[^0-9,]/g, ''))} placeholder="0" className={inputClasses} />
+          </div>
+
+          <div>
+            <label className="flex items-center gap-2 text-[13px] text-sub cursor-pointer">
+              <input type="checkbox" checked={isLiability} onChange={(e) => setIsLiability(e.target.checked)} className="rounded border-border" />
+              부채 (대출 등)
+            </label>
+          </div>
+
+          <div>
+            <label className={labelClasses}>이율 (%)</label>
+            <input type="text" value={interestRate} onChange={(e) => setInterestRate(e.target.value)} placeholder="3.5" className={`${inputClasses} w-24`} />
+          </div>
+
+          <div>
+            <label className={labelClasses}>만기일</label>
+            <input type="date" value={maturityDate} onChange={(e) => setMaturityDate(e.target.value)} className={inputClasses} />
+          </div>
+
+          <div>
+            <label className={labelClasses}>메모</label>
+            <input type="text" value={note} onChange={(e) => setNote(e.target.value)} placeholder="메모" maxLength={200} className={inputClasses} />
+          </div>
+
+          {error && <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2.5 text-[12px] text-red-400">{error}</div>}
+
+          <div className="flex gap-3">
+            <button type="button" onClick={onClose} className="flex-1 py-2.5 rounded-lg text-[13px] font-semibold text-sub border border-border hover:bg-surface-dim transition-all">취소</button>
+            <button type="submit" disabled={isSubmitting} className="flex-1 py-2.5 rounded-lg text-[13px] font-bold bg-sodam/15 text-sodam border border-sodam/25 hover:bg-sodam/25 disabled:opacity-40 transition-all">
+              {isSubmitting ? '저장 중...' : isEdit ? '수정' : '추가'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <style jsx>{`
+        @keyframes slideIn { from { transform: translateX(100%); } to { transform: translateX(0); } }
+        .animate-slide-in { animation: slideIn 0.2s ease-out; }
+      `}</style>
+    </>
+  )
+}

--- a/src/components/asset/AssetTable.tsx
+++ b/src/components/asset/AssetTable.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { formatKRW, formatDate } from '@/lib/format'
+
+export interface AssetRow {
+  id: string
+  name: string
+  category: string
+  owner: string
+  value: number
+  isLiability: boolean
+  interestRate: number | null
+  maturityDate: string | null
+  note: string | null
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  savings: '적금/예금',
+  cash: '입출금',
+  insurance: '보험',
+  real_estate: '부동산',
+  pension: '연금',
+  loan: '대출',
+  other: '기타',
+}
+
+type OwnerTab = '전체' | '세진' | '소담' | '다솜' | '공동'
+
+interface AssetTableProps {
+  assets: AssetRow[]
+  activeTab: OwnerTab
+  onTabChange: (tab: OwnerTab) => void
+  onEdit: (asset: AssetRow) => void
+  onDelete: (asset: AssetRow) => void
+}
+
+export default function AssetTable({ assets, activeTab, onTabChange, onEdit, onDelete }: AssetTableProps) {
+  const filtered = activeTab === '전체' ? assets : assets.filter((a) => a.owner === activeTab)
+  const assetTotal = filtered.filter((a) => !a.isLiability).reduce((s, a) => s + a.value, 0)
+  const liabilityTotal = filtered.filter((a) => a.isLiability).reduce((s, a) => s + a.value, 0)
+
+  const TABS: OwnerTab[] = ['전체', '세진', '소담', '다솜', '공동']
+
+  return (
+    <>
+      <div className="flex gap-1 mb-4">
+        {TABS.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => onTabChange(tab)}
+            className={`px-4 py-2 rounded-lg text-[13px] font-semibold border transition-all ${
+              activeTab === tab
+                ? 'bg-surface text-bright border-border-hover'
+                : 'border-transparent text-sub hover:bg-surface-dim'
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      <div className="relative overflow-hidden rounded-[14px] border border-border bg-card">
+        <div className="px-5 py-3.5 border-b border-border flex justify-between items-center">
+          <div className="text-[13px] font-bold text-bright">
+            {activeTab} 자산
+          </div>
+          <div className="text-[12px] text-sub">
+            {filtered.length}개 · 자산 {formatKRW(assetTotal)} · 부채 {formatKRW(liabilityTotal)}
+          </div>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="px-5 py-10 text-center text-[13px] text-sub">
+            자산이 없습니다.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-[12px]">
+              <thead>
+                <tr className="border-b border-border bg-surface-dim">
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold">이름</th>
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold">카테고리</th>
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold">소유자</th>
+                  <th className="px-4 py-2.5 text-right text-dim font-semibold">금액</th>
+                  <th className="px-4 py-2.5 text-right text-dim font-semibold">이율</th>
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold">만기</th>
+                  <th className="px-4 py-2.5 text-center text-dim font-semibold">액션</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((a) => (
+                  <tr key={a.id} className="border-b border-border last:border-0 hover:bg-surface-dim transition-colors">
+                    <td className="px-4 py-3 text-bright font-medium">
+                      {a.name}
+                      {a.isLiability && <span className="ml-1.5 text-[10px] font-semibold text-red-400 bg-red-500/10 px-1.5 py-0.5 rounded">부채</span>}
+                    </td>
+                    <td className="px-4 py-3 text-muted">{CATEGORY_LABELS[a.category] ?? a.category}</td>
+                    <td className="px-4 py-3 text-muted">{a.owner}</td>
+                    <td className={`px-4 py-3 text-right font-semibold tabular-nums ${a.isLiability ? 'text-red-400' : 'text-bright'}`}>
+                      {a.isLiability ? '-' : ''}{formatKRW(a.value)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-muted tabular-nums">
+                      {a.interestRate != null ? `${a.interestRate}%` : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-muted tabular-nums">
+                      {a.maturityDate ? formatDate(a.maturityDate) : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-center whitespace-nowrap">
+                      <button
+                        onClick={() => onEdit(a)}
+                        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-text hover:bg-surface transition-all"
+                        title="수정"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => onDelete(a)}
+                        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
+                        title="삭제"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                          <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -44,6 +44,7 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { href: '/ai', icon: '🤖', label: 'AI 분석' },
       { href: '/networth', icon: '💰', label: '순자산' },
+      { href: '/assets', icon: '🏦', label: '자산 관리' },
       { href: '/reports', icon: '📋', label: '분기 리포트' },
       { href: '/backtest', icon: '🧪', label: '백테스팅' },
     ],


### PR DESCRIPTION
## Summary

- `/assets` 페이지 신규: 자산 목록 테이블 + 소유자별(전체/세진/소담/다솜/공동) 탭 필터
- 자산 추가/수정 슬라이드 폼 (카테고리, 소유자, 금액, 이율, 만기일, 메모)
- 자산 삭제 확인 모달 (에러 표시)
- 네비게이션에 자산 관리 링크 추가
- 기존 Asset API(GET/POST/PUT/DELETE) 활용

Closes #247

## 변경 파일
- `src/app/assets/page.tsx` (신규) — SSR 페이지
- `src/app/assets/AssetsClient.tsx` (신규) — 클라이언트 컴포넌트
- `src/components/asset/AssetTable.tsx` (신규) — 테이블 + 탭
- `src/components/asset/AssetForm.tsx` (신규) — 추가/수정 폼
- `src/components/asset/AssetDeleteModal.tsx` (신규) — 삭제 모달
- `src/components/layout/nav-config.ts` — 네비게이션 추가

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 코드 리뷰 통과 (1회, P1/P2: 0건)

## Test plan
- [ ] 자산 추가 → 목록에 표시
- [ ] 자산 수정 → 값 반영, 이율/만기일 초기화 가능
- [ ] 자산 삭제 → 목록에서 제거
- [ ] 소유자별 탭 필터 동작