### PR TITLE
텔레그램 메시지 발송 네트워크 타임아웃 재시도 (#255)

### DIFF
--- a/src/bot/utils/telegram.ts
+++ b/src/bot/utils/telegram.ts
@@ -87,15 +87,14 @@ function isParseError(error: unknown): boolean {
 }
 
 /**
- * 네트워크 에러 여부 판별 (ETIMEDOUT, ECONNRESET 등)
+ * 안전하게 재시도 가능한 네트워크 에러 판별.
+ * ETIMEDOUT/ENOTFOUND만 재시도 (연결 자체 실패 → 요청 미도달 보장).
+ * ECONNRESET은 요청 도달 후 응답 실패일 수 있어 중복 메시지 위험 → 재시도 안 함.
  */
-function isNetworkError(error: unknown): boolean {
+function isRetryableNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
-  const msg = error.message.toLowerCase()
-  if (msg.includes('network request') && msg.includes('failed')) return true
   const inner = (error as { error?: { code?: string } }).error
-  if (inner?.code === 'ETIMEDOUT' || inner?.code === 'ECONNRESET' || inner?.code === 'ENOTFOUND') return true
-  return false
+  return inner?.code === 'ETIMEDOUT' || inner?.code === 'ENOTFOUND'
 }
 
 /**
@@ -108,7 +107,7 @@ async function withRetry<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
       return await fn()
     } catch (error) {
       lastError = error
-      if (!isNetworkError(error) || attempt === maxRetries) throw error
+      if (!isRetryableNetworkError(error) || attempt === maxRetries) throw error
       const delay = 1000 * (attempt + 1) // 1초, 2초
       await new Promise((r) => setTimeout(r, delay))
     }

--- a/src/bot/utils/telegram.ts
+++ b/src/bot/utils/telegram.ts
@@ -37,11 +37,11 @@ export async function replyHtml(ctx: Context, html: string): Promise<void> {
   const chunks = splitMessage(html)
   for (const chunk of chunks) {
     try {
-      await ctx.reply(chunk, { parse_mode: 'HTML' })
+      await withRetry(() => ctx.reply(chunk, { parse_mode: 'HTML' }))
     } catch (error) {
       if (isParseError(error)) {
         const plain = chunk.replace(/<[^>]+>/g, '')
-        await ctx.reply(plain)
+        await withRetry(() => ctx.reply(plain))
       } else {
         throw error
       }
@@ -60,11 +60,11 @@ export async function sendHtml(
   const chunks = splitMessage(html)
   for (const chunk of chunks) {
     try {
-      await bot.api.sendMessage(chatId, chunk, { parse_mode: 'HTML' })
+      await withRetry(() => bot.api.sendMessage(chatId, chunk, { parse_mode: 'HTML' }))
     } catch (error) {
       if (isParseError(error)) {
         const plain = chunk.replace(/<[^>]+>/g, '')
-        await bot.api.sendMessage(chatId, plain)
+        await withRetry(() => bot.api.sendMessage(chatId, plain))
       } else {
         throw error
       }
@@ -84,4 +84,34 @@ function isParseError(error: unknown): boolean {
     return true
   }
   return false
+}
+
+/**
+ * 네트워크 에러 여부 판별 (ETIMEDOUT, ECONNRESET 등)
+ */
+function isNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const msg = error.message.toLowerCase()
+  if (msg.includes('network request') && msg.includes('failed')) return true
+  const inner = (error as { error?: { code?: string } }).error
+  if (inner?.code === 'ETIMEDOUT' || inner?.code === 'ECONNRESET' || inner?.code === 'ENOTFOUND') return true
+  return false
+}
+
+/**
+ * 재시도 래퍼: 네트워크 에러 시 지수 백오프로 재시도 (최대 2회)
+ */
+async function withRetry<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      if (!isNetworkError(error) || attempt === maxRetries) throw error
+      const delay = 1000 * (attempt + 1) // 1초, 2초
+      await new Promise((r) => setTimeout(r, delay))
+    }
+  }
+  throw lastError
 }


### PR DESCRIPTION
## Summary

- 간헐적 ETIMEDOUT/ECONNRESET 에러 대응
- `withRetry` 래퍼: 네트워크 에러 시 1초/2초 지수 백오프 재시도 (최대 2회)
- `sendHtml`/`replyHtml`의 모든 Telegram API 호출에 적용
- HTML 파싱 에러 등 비네트워크 에러는 재시도하지 않음

Closes #255

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과

## Test plan
- [ ] 정상 발송 → 기존과 동일 동작
- [ ] 네트워크 타임아웃 발생 시 → 자동 재시도 후 성공
- [ ] 재시도 3회 실패 → 에러 throw (기존 에러 핸들링 유지)