### PR TITLE
TA 시그널 알림 포맷 개선 (#259)

### DIFF
--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -10,6 +10,7 @@ import { generateTAReport } from '@/lib/ta/engine'
 import { askAdvisor } from '@/lib/ai/claude-advisor'
 import { getBot } from '@/bot/index'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
+import { markdownToTelegramHtml } from '@/bot/utils/markdown'
 import type { TAReport } from '@/lib/ta/types'
 
 /** 당일 시그널 발송 기록 (키 → date string) */
@@ -197,7 +198,9 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     }
     const guide = aiGuides.get(r.ticker)
     if (guide) {
-      lines.push(`  💡 ${escapeHtml(guide.slice(0, 200))}`)
+      const guideHtml = markdownToTelegramHtml(guide.slice(0, 300))
+      lines.push('')
+      lines.push(`  💡 ${guideHtml}`)
     }
     lines.push('')
   }


### PR DESCRIPTION
## Summary

- AI 가이드의 마크다운(`**볼드**` 등)을 `markdownToTelegramHtml`로 변환하여 정상 렌더링
- 시그널과 AI 가이드 사이 줄바꿈 추가 (시각 구분)
- 가이드 길이 200→300자로 확장

Closes #259

## Checklist
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과

## Test plan
- [ ] TA 시그널 알림 → AI 가이드 볼드/이탤릭 정상 렌더링
- [ ] AI 가이드와 시그널 사이 시각적 구분 확인