### PR TITLE
[Phase 25-A] market 코드 정규화 통일 (#281)

### DIFF
--- a/docs/specs/281-normalize-market-codes.md
+++ b/docs/specs/281-normalize-market-codes.md
@@ -1,0 +1,88 @@
+# Phase 25-A: market 코드 정규화 통일
+
+## 목적
+
+DB의 `market` 필드에 Yahoo Finance raw exchange 코드(`NCM`, `NGM`, `NYQ`, `KSC` 등)와 정규화 코드(`US`, `KR`)가 혼재해 있어, 거래 등록 시 정합성 검증이 실패하는 문제를 해결한다.
+
+사용자 보고 사례:
+- 새 거래에서 SATL을 직접 입력 → `'SATL은(는) 이미 NCM/USD로 등록되어 있습니다.'` 에러로 등록 불가
+- 원인: `PriceCache.market = 'NCM'`(Yahoo raw) vs 폼에서 보낸 `market = 'US'`(정규화) 직접 비교
+
+## 배경
+
+- `src/lib/market-hours.ts:73-87`에 `normalizeMarket()`이 정의돼 있지만 31곳 중 1곳(`mcp/tools/watchlist.ts:38`)에서만 사용 중
+- `src/lib/price-fetcher.ts:58`은 Yahoo의 `quote.exchange`를 정규화 없이 그대로 `PriceCache.market`에 저장
+- 거기서 파생되는 `Watchlist`, `Holding`(시드/임포트)에도 raw 코드가 그대로 들어감
+- 폼은 정규화된 `US/KR`만 전송 → 비교 항상 실패
+
+## 요구사항
+
+- [ ] `src/lib/price-fetcher.ts`에서 `PriceCache.market` 저장 시 `normalizeMarket()` 적용
+- [ ] `src/lib/trade-service.ts:62, 72` 비교 시 양쪽을 `normalizeMarket()` 통과 후 비교
+- [ ] `src/app/api/trades/import/route.ts:118-133` 동일 패턴 적용
+- [ ] 기존 DB 데이터 일괄 정규화 마이그레이션 스크립트 (`PriceCache`, `Watchlist`, `Holding`, `Trade`)
+- [ ] 마이그레이션 결과를 한 번에 dry-run 가능
+- [ ] 기존 watchlist/holding/trade 입력 검증(`market === 'US' || 'KR'`) 유지
+
+## 기술 설계
+
+### 변경 파일
+
+| 파일 | 변경 내용 |
+|---|---|
+| `src/lib/market-hours.ts` | `normalizeMarket` 반환을 `'KR' \| 'US' \| 'FX' \| 'OTHER'` 그대로 유지. 단, `'OTHER'`로 떨어지는 경우 fallback 로깅 도입 검토 |
+| `src/lib/price-fetcher.ts` | L58: `const market = normalizeMarket(quote.exchange ?? '', ticker)` |
+| `src/lib/trade-service.ts` | L62, L72: `normalizeMarket(existing.market, ticker) !== normalizeMarket(market, ticker)`로 비교. 에러 메시지에 정규화 코드 표시 |
+| `src/app/api/trades/import/route.ts` | L118, L131: 동일 비교 정규화 |
+| `prisma/scripts/normalize-market-codes.ts` (신규) | 기존 row의 `market`을 일괄 normalize. `--dry-run` 옵션 지원 |
+
+### 마이그레이션 스크립트 동작
+
+1. `PriceCache`, `Watchlist`, `Holding`, `Trade` 각 테이블 순회
+2. 각 row의 `market` 값을 `normalizeMarket(row.market, row.ticker)`로 변환
+3. `'OTHER'`로 떨어지면 경고 로그 + skip (사람이 수동 확인)
+4. `--dry-run` 모드는 SQL 실행 없이 변경될 row 수만 출력
+5. 실 실행 시 모든 업데이트를 단일 트랜잭션 안에서 수행
+
+### 데이터 매핑 예시
+
+| Raw | Normalized |
+|---|---|
+| `NCM`, `NGM`, `NMS`, `NYQ`, `PCX` | `US` |
+| `KSC`, `KOE`, `KS`, `KQ` | `KR` |
+| `CCY` | `FX` |
+| 기타 | `OTHER` (수동 확인) |
+
+### 비교 패턴
+
+```ts
+// before
+if (existing.market !== market) { /* error */ }
+
+// after
+if (normalizeMarket(existing.market, ticker) !== normalizeMarket(market, ticker)) { /* error */ }
+```
+
+### 거동 변화
+
+- 기존 raw `NCM` row + 폼의 `US` 입력 → 정규화 후 같음(`US === US`) → 에러 사라짐
+- 마이그레이션 후 신규 row는 항상 정규화된 코드로 저장됨
+- TA 시그널 알림, price-alert는 이미 `normalizeMarket()`을 거치므로 영향 없음
+
+## 테스트 계획
+
+- [ ] `npm run lint`
+- [ ] `npx tsc --noEmit`
+- [ ] `npm run build`
+- [ ] 마이그레이션 dry-run 결과 확인 (변경 row 수 일치 여부)
+- [ ] 수동: 새 거래에서 SATL 직접 입력 시도 → 등록 성공
+
+## 제외 사항
+
+- holdings dropdown 필터링(`shares > 0`) — Phase 25-B에서 처리
+- API 응답 형식 통일 — Phase 25-E
+- 입력 검증 Zod 마이그레이션 — Phase 25-F
+
+## 라벨
+
+- `fix`, `P1`, `phase-25`

--- a/docs/specs/281-normalize-market-codes.md
+++ b/docs/specs/281-normalize-market-codes.md
@@ -82,6 +82,7 @@ if (normalizeMarket(existing.market, ticker) !== normalizeMarket(market, ticker)
 - holdings dropdown 필터링(`shares > 0`) — Phase 25-B에서 처리
 - API 응답 형식 통일 — Phase 25-E
 - 입력 검증 Zod 마이그레이션 — Phase 25-F
+- **단위 테스트 추가** — 현재 프로젝트에 테스트 프레임워크(jest/vitest)가 도입돼 있지 않음. 별도 인프라 이슈로 분리 (테스트 프레임워크 도입은 7차 마일스톤 외 별도 작업)
 
 ## 라벨
 

--- a/prisma/scripts/normalize-market-codes.ts
+++ b/prisma/scripts/normalize-market-codes.ts
@@ -15,10 +15,11 @@
  *   - normalize 결과가 OTHER인 row는 skip + 경고 (수동 확인 대상)
  */
 
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 import { normalizeMarket } from '../../src/lib/market-hours'
 
 const prisma = new PrismaClient()
+type TxClient = Prisma.TransactionClient
 
 const BATCH_SIZE = 500
 const TX_TIMEOUT_MS = 120_000 // 2분
@@ -74,7 +75,7 @@ function reportStats(tableName: string, stats: TableStats): void {
 async function processChunked<T extends Row>(
   tableName: string,
   rows: T[],
-  applyUpdate: (pk: string, market: string) => Promise<void>,
+  applyUpdate: (tx: TxClient, pk: string, market: string) => Promise<void>,
   dryRun: boolean
 ): Promise<TableStats> {
   const stats = emptyStats()
@@ -93,12 +94,13 @@ async function processChunked<T extends Row>(
   }
 
   // 배치 단위로 트랜잭션 분리 — 단일 거대 트랜잭션의 락/timeout 회피
+  // applyUpdate는 반드시 tx 클라이언트로 실행 (배치 내 원자성 보장)
   for (let i = 0; i < updates.length; i += BATCH_SIZE) {
     const batch = updates.slice(i, i + BATCH_SIZE)
     await prisma.$transaction(
-      async () => {
+      async (tx) => {
         for (const u of batch) {
-          await applyUpdate(u.pk, u.market)
+          await applyUpdate(tx, u.pk, u.market)
         }
       },
       { timeout: TX_TIMEOUT_MS }
@@ -115,8 +117,8 @@ async function migratePriceCache(dryRun: boolean): Promise<TableStats> {
   return processChunked(
     'PriceCache',
     rows.map((r) => ({ pk: r.ticker, ticker: r.ticker, market: r.market })),
-    async (ticker, market) => {
-      await prisma.priceCache.update({ where: { ticker }, data: { market } })
+    async (tx, ticker, market) => {
+      await tx.priceCache.update({ where: { ticker }, data: { market } })
     },
     dryRun
   )
@@ -127,8 +129,8 @@ async function migrateWatchlist(dryRun: boolean): Promise<TableStats> {
   return processChunked(
     'Watchlist',
     rows.map((r) => ({ pk: r.id, ticker: r.ticker, market: r.market })),
-    async (id, market) => {
-      await prisma.watchlist.update({ where: { id }, data: { market } })
+    async (tx, id, market) => {
+      await tx.watchlist.update({ where: { id }, data: { market } })
     },
     dryRun
   )
@@ -139,8 +141,8 @@ async function migrateHolding(dryRun: boolean): Promise<TableStats> {
   return processChunked(
     'Holding',
     rows.map((r) => ({ pk: r.id, ticker: r.ticker, market: r.market })),
-    async (id, market) => {
-      await prisma.holding.update({ where: { id }, data: { market } })
+    async (tx, id, market) => {
+      await tx.holding.update({ where: { id }, data: { market } })
     },
     dryRun
   )
@@ -151,8 +153,8 @@ async function migrateTrade(dryRun: boolean): Promise<TableStats> {
   return processChunked(
     'Trade',
     rows.map((r) => ({ pk: r.id, ticker: r.ticker, market: r.market })),
-    async (id, market) => {
-      await prisma.trade.update({ where: { id }, data: { market } })
+    async (tx, id, market) => {
+      await tx.trade.update({ where: { id }, data: { market } })
     },
     dryRun
   )

--- a/prisma/scripts/normalize-market-codes.ts
+++ b/prisma/scripts/normalize-market-codes.ts
@@ -7,6 +7,12 @@
  * 사용법:
  *   tsx prisma/scripts/normalize-market-codes.ts --dry-run   # 변경 row 수만 출력
  *   tsx prisma/scripts/normalize-market-codes.ts             # 실제 적용
+ *
+ * 설계:
+ *   - 테이블별로 별도 트랜잭션 (락 경합 최소화, 부분 실패 격리)
+ *   - 배치 단위 업데이트 (BATCH_SIZE)
+ *   - 명시 timeout으로 인터랙티브 트랜잭션 기본 5초 초과 방지
+ *   - normalize 결과가 OTHER인 row는 skip + 경고 (수동 확인 대상)
  */
 
 import { PrismaClient } from '@prisma/client'
@@ -14,11 +20,14 @@ import { normalizeMarket } from '../../src/lib/market-hours'
 
 const prisma = new PrismaClient()
 
+const BATCH_SIZE = 500
+const TX_TIMEOUT_MS = 120_000 // 2분
+
 interface TableStats {
   scanned: number
   changed: number
   unchanged: number
-  other: number // normalize 결과가 OTHER인 row (수동 확인 대상)
+  other: number
   otherSamples: { key: string; raw: string }[]
 }
 
@@ -26,32 +35,32 @@ function emptyStats(): TableStats {
   return { scanned: 0, changed: 0, unchanged: 0, other: 0, otherSamples: [] }
 }
 
-async function processTable(
-  tableName: string,
-  rows: { pk: string; ticker: string; market: string }[],
-  applyUpdate: (pk: string, market: string) => Promise<void>,
-  dryRun: boolean
-): Promise<TableStats> {
-  const stats = emptyStats()
-  for (const row of rows) {
-    stats.scanned++
-    const normalized = normalizeMarket(row.market, row.ticker)
-    if (normalized === 'OTHER') {
-      stats.other++
-      if (stats.otherSamples.length < 5) {
-        stats.otherSamples.push({ key: row.ticker, raw: row.market })
-      }
-      continue
+interface Row {
+  pk: string
+  ticker: string
+  market: string
+}
+
+function classifyRow(row: Row, stats: TableStats): string | null {
+  stats.scanned++
+  const normalized = normalizeMarket(row.market, row.ticker)
+  if (normalized === 'OTHER') {
+    stats.other++
+    if (stats.otherSamples.length < 5) {
+      stats.otherSamples.push({ key: row.ticker, raw: row.market })
     }
-    if (normalized === row.market) {
-      stats.unchanged++
-      continue
-    }
-    stats.changed++
-    if (!dryRun) {
-      await applyUpdate(row.pk, normalized)
-    }
+    console.warn(`  [OTHER] ${row.ticker} raw=${row.market} (skipped)`)
+    return null
   }
+  if (normalized === row.market) {
+    stats.unchanged++
+    return null
+  }
+  stats.changed++
+  return normalized
+}
+
+function reportStats(tableName: string, stats: TableStats): void {
   console.log(
     `[${tableName}] scanned=${stats.scanned} changed=${stats.changed} unchanged=${stats.unchanged} OTHER=${stats.other}`
   )
@@ -60,53 +69,103 @@ async function processTable(
       `  OTHER 샘플: ${stats.otherSamples.map((s) => `${s.key}(${s.raw})`).join(', ')}`
     )
   }
+}
+
+async function processChunked<T extends Row>(
+  tableName: string,
+  rows: T[],
+  applyUpdate: (pk: string, market: string) => Promise<void>,
+  dryRun: boolean
+): Promise<TableStats> {
+  const stats = emptyStats()
+  const updates: { pk: string; market: string }[] = []
+
+  for (const row of rows) {
+    const normalized = classifyRow(row, stats)
+    if (normalized !== null) {
+      updates.push({ pk: row.pk, market: normalized })
+    }
+  }
+
+  if (dryRun || updates.length === 0) {
+    reportStats(tableName, stats)
+    return stats
+  }
+
+  // 배치 단위로 트랜잭션 분리 — 단일 거대 트랜잭션의 락/timeout 회피
+  for (let i = 0; i < updates.length; i += BATCH_SIZE) {
+    const batch = updates.slice(i, i + BATCH_SIZE)
+    await prisma.$transaction(
+      async () => {
+        for (const u of batch) {
+          await applyUpdate(u.pk, u.market)
+        }
+      },
+      { timeout: TX_TIMEOUT_MS }
+    )
+    console.log(`  [${tableName}] ${Math.min(i + BATCH_SIZE, updates.length)}/${updates.length} 업데이트 완료`)
+  }
+
+  reportStats(tableName, stats)
   return stats
+}
+
+async function migratePriceCache(dryRun: boolean): Promise<TableStats> {
+  const rows = await prisma.priceCache.findMany({ select: { ticker: true, market: true } })
+  return processChunked(
+    'PriceCache',
+    rows.map((r) => ({ pk: r.ticker, ticker: r.ticker, market: r.market })),
+    async (ticker, market) => {
+      await prisma.priceCache.update({ where: { ticker }, data: { market } })
+    },
+    dryRun
+  )
+}
+
+async function migrateWatchlist(dryRun: boolean): Promise<TableStats> {
+  const rows = await prisma.watchlist.findMany({ select: { id: true, ticker: true, market: true } })
+  return processChunked(
+    'Watchlist',
+    rows.map((r) => ({ pk: r.id, ticker: r.ticker, market: r.market })),
+    async (id, market) => {
+      await prisma.watchlist.update({ where: { id }, data: { market } })
+    },
+    dryRun
+  )
+}
+
+async function migrateHolding(dryRun: boolean): Promise<TableStats> {
+  const rows = await prisma.holding.findMany({ select: { id: true, ticker: true, market: true } })
+  return processChunked(
+    'Holding',
+    rows.map((r) => ({ pk: r.id, ticker: r.ticker, market: r.market })),
+    async (id, market) => {
+      await prisma.holding.update({ where: { id }, data: { market } })
+    },
+    dryRun
+  )
+}
+
+async function migrateTrade(dryRun: boolean): Promise<TableStats> {
+  const rows = await prisma.trade.findMany({ select: { id: true, ticker: true, market: true } })
+  return processChunked(
+    'Trade',
+    rows.map((r) => ({ pk: r.id, ticker: r.ticker, market: r.market })),
+    async (id, market) => {
+      await prisma.trade.update({ where: { id }, data: { market } })
+    },
+    dryRun
+  )
 }
 
 async function main(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run')
-  console.log(`[migrate] market 코드 정규화 시작 (dry-run=${dryRun})`)
+  console.log(`[migrate] market 코드 정규화 시작 (dry-run=${dryRun}, batchSize=${BATCH_SIZE})`)
 
-  const priceCaches = await prisma.priceCache.findMany({ select: { ticker: true, market: true } })
-  const watchlists = await prisma.watchlist.findMany({ select: { id: true, ticker: true, market: true } })
-  const holdings = await prisma.holding.findMany({ select: { id: true, ticker: true, market: true } })
-  const trades = await prisma.trade.findMany({ select: { id: true, ticker: true, market: true } })
-
-  await prisma.$transaction(async (tx) => {
-    // PriceCache는 ticker가 PK
-    await processTable(
-      'PriceCache',
-      priceCaches.map((p) => ({ pk: p.ticker, ticker: p.ticker, market: p.market })),
-      async (ticker, market) => {
-        await tx.priceCache.update({ where: { ticker }, data: { market } })
-      },
-      dryRun
-    )
-    await processTable(
-      'Watchlist',
-      watchlists.map((w) => ({ pk: w.id, ticker: w.ticker, market: w.market })),
-      async (id, market) => {
-        await tx.watchlist.update({ where: { id }, data: { market } })
-      },
-      dryRun
-    )
-    await processTable(
-      'Holding',
-      holdings.map((h) => ({ pk: h.id, ticker: h.ticker, market: h.market })),
-      async (id, market) => {
-        await tx.holding.update({ where: { id }, data: { market } })
-      },
-      dryRun
-    )
-    await processTable(
-      'Trade',
-      trades.map((t) => ({ pk: t.id, ticker: t.ticker, market: t.market })),
-      async (id, market) => {
-        await tx.trade.update({ where: { id }, data: { market } })
-      },
-      dryRun
-    )
-  })
+  await migratePriceCache(dryRun)
+  await migrateWatchlist(dryRun)
+  await migrateHolding(dryRun)
+  await migrateTrade(dryRun)
 
   console.log(`[migrate] 완료${dryRun ? ' (dry-run, DB 미반영)' : ''}`)
 }

--- a/prisma/scripts/normalize-market-codes.ts
+++ b/prisma/scripts/normalize-market-codes.ts
@@ -1,0 +1,121 @@
+/**
+ * market 코드 정규화 마이그레이션 스크립트 (Phase 25-A, #281)
+ *
+ * 기존 DB의 PriceCache, Watchlist, Holding, Trade의 market 필드를
+ * normalizeMarket()으로 일괄 변환한다.
+ *
+ * 사용법:
+ *   tsx prisma/scripts/normalize-market-codes.ts --dry-run   # 변경 row 수만 출력
+ *   tsx prisma/scripts/normalize-market-codes.ts             # 실제 적용
+ */
+
+import { PrismaClient } from '@prisma/client'
+import { normalizeMarket } from '../../src/lib/market-hours'
+
+const prisma = new PrismaClient()
+
+interface TableStats {
+  scanned: number
+  changed: number
+  unchanged: number
+  other: number // normalize 결과가 OTHER인 row (수동 확인 대상)
+  otherSamples: { key: string; raw: string }[]
+}
+
+function emptyStats(): TableStats {
+  return { scanned: 0, changed: 0, unchanged: 0, other: 0, otherSamples: [] }
+}
+
+async function processTable(
+  tableName: string,
+  rows: { pk: string; ticker: string; market: string }[],
+  applyUpdate: (pk: string, market: string) => Promise<void>,
+  dryRun: boolean
+): Promise<TableStats> {
+  const stats = emptyStats()
+  for (const row of rows) {
+    stats.scanned++
+    const normalized = normalizeMarket(row.market, row.ticker)
+    if (normalized === 'OTHER') {
+      stats.other++
+      if (stats.otherSamples.length < 5) {
+        stats.otherSamples.push({ key: row.ticker, raw: row.market })
+      }
+      continue
+    }
+    if (normalized === row.market) {
+      stats.unchanged++
+      continue
+    }
+    stats.changed++
+    if (!dryRun) {
+      await applyUpdate(row.pk, normalized)
+    }
+  }
+  console.log(
+    `[${tableName}] scanned=${stats.scanned} changed=${stats.changed} unchanged=${stats.unchanged} OTHER=${stats.other}`
+  )
+  if (stats.other > 0) {
+    console.log(
+      `  OTHER 샘플: ${stats.otherSamples.map((s) => `${s.key}(${s.raw})`).join(', ')}`
+    )
+  }
+  return stats
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run')
+  console.log(`[migrate] market 코드 정규화 시작 (dry-run=${dryRun})`)
+
+  const priceCaches = await prisma.priceCache.findMany({ select: { ticker: true, market: true } })
+  const watchlists = await prisma.watchlist.findMany({ select: { id: true, ticker: true, market: true } })
+  const holdings = await prisma.holding.findMany({ select: { id: true, ticker: true, market: true } })
+  const trades = await prisma.trade.findMany({ select: { id: true, ticker: true, market: true } })
+
+  await prisma.$transaction(async (tx) => {
+    // PriceCache는 ticker가 PK
+    await processTable(
+      'PriceCache',
+      priceCaches.map((p) => ({ pk: p.ticker, ticker: p.ticker, market: p.market })),
+      async (ticker, market) => {
+        await tx.priceCache.update({ where: { ticker }, data: { market } })
+      },
+      dryRun
+    )
+    await processTable(
+      'Watchlist',
+      watchlists.map((w) => ({ pk: w.id, ticker: w.ticker, market: w.market })),
+      async (id, market) => {
+        await tx.watchlist.update({ where: { id }, data: { market } })
+      },
+      dryRun
+    )
+    await processTable(
+      'Holding',
+      holdings.map((h) => ({ pk: h.id, ticker: h.ticker, market: h.market })),
+      async (id, market) => {
+        await tx.holding.update({ where: { id }, data: { market } })
+      },
+      dryRun
+    )
+    await processTable(
+      'Trade',
+      trades.map((t) => ({ pk: t.id, ticker: t.ticker, market: t.market })),
+      async (id, market) => {
+        await tx.trade.update({ where: { id }, data: { market } })
+      },
+      dryRun
+    )
+  })
+
+  console.log(`[migrate] 완료${dryRun ? ' (dry-run, DB 미반영)' : ''}`)
+}
+
+main()
+  .catch((err) => {
+    console.error('[migrate] 실패:', err)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/app/api/trades/import/route.ts
+++ b/src/app/api/trades/import/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW, validateTradeInput } from '@/lib/trade-utils'
+import { normalizeMarket } from '@/lib/market-hours'
 import type { ImportResult } from '@/types/csv-import'
 
 export const dynamic = 'force-dynamic'
@@ -114,10 +115,12 @@ export async function POST(request: NextRequest) {
       select: { ticker: true, market: true, currency: true },
       distinct: ['ticker'],
     })
+    // market은 정규화된 값으로 비교 (raw Yahoo 코드 NCM/NYQ 등과 정규화된 US/KR이 혼재 가능)
     for (const meta of existingMeta) {
-      if (meta.market !== market || meta.currency !== currency) {
+      const normalizedExisting = normalizeMarket(meta.market, meta.ticker)
+      if (normalizedExisting !== market || meta.currency !== currency) {
         return NextResponse.json(
-          { error: `${meta.ticker}은(는) 이미 ${meta.market}/${meta.currency}로 등록되어 있습니다.` },
+          { error: `${meta.ticker}은(는) 이미 ${normalizedExisting}/${meta.currency}로 등록되어 있습니다.` },
           { status: 400 }
         )
       }
@@ -128,9 +131,10 @@ export async function POST(request: NextRequest) {
       select: { ticker: true, market: true, currency: true },
     })
     for (const h of existingHoldings) {
-      if (h.market !== market || h.currency !== currency) {
+      const normalizedExisting = normalizeMarket(h.market, h.ticker)
+      if (normalizedExisting !== market || h.currency !== currency) {
         return NextResponse.json(
-          { error: `${h.ticker}은(는) 이미 ${h.market}/${h.currency}로 등록되어 있습니다.` },
+          { error: `${h.ticker}은(는) 이미 ${normalizedExisting}/${h.currency}로 등록되어 있습니다.` },
           { status: 400 }
         )
       }
@@ -206,7 +210,7 @@ export async function POST(request: NextRequest) {
                 accountId,
                 ticker: existingHolding.ticker,
                 displayName: existingHolding.displayName,
-                market: existingHolding.market,
+                market: normalizeMarket(existingHolding.market, existingHolding.ticker),
                 type: 'BUY',
                 shares: existingHolding.shares,
                 price: baselinePrice,

--- a/src/app/api/trades/import/route.ts
+++ b/src/app/api/trades/import/route.ts
@@ -210,7 +210,8 @@ export async function POST(request: NextRequest) {
                 accountId,
                 ticker: existingHolding.ticker,
                 displayName: existingHolding.displayName,
-                market: normalizeMarket(existingHolding.market, existingHolding.ticker),
+                // 사전 검증에서 normalize(existing) === market 임이 확인됨 — 입력값 그대로 사용
+                market,
                 type: 'BUY',
                 shares: existingHolding.shares,
                 price: baselinePrice,

--- a/src/lib/market-hours.ts
+++ b/src/lib/market-hours.ts
@@ -71,7 +71,7 @@ const FX_MARKETS = new Set(['FX', 'CCY'])
  * market이 모호하면 ticker suffix(`.KS`, `.KQ`)로 fallback.
  */
 export function normalizeMarket(market: string, ticker?: string): 'KR' | 'US' | 'FX' | 'OTHER' {
-  const upper = market.toUpperCase()
+  const upper = (market ?? '').trim().toUpperCase()
   if (KR_MARKETS.has(upper)) return 'KR'
   if (US_MARKETS.has(upper)) return 'US'
   if (FX_MARKETS.has(upper)) return 'FX'

--- a/src/lib/price-fetcher.ts
+++ b/src/lib/price-fetcher.ts
@@ -61,10 +61,11 @@ export async function fetchQuote(ticker: string): Promise<QuoteResult> {
   const displayName = quote.shortName ?? quote.longName ?? ticker
 
   // PriceCache upsert — 존재하면 갱신, 없으면 생성 (fallback 조회 시 캐시 적재)
+  // market은 update 분기에도 포함 — 기존 raw 코드가 신규 정규화 코드로 자연 수렴되도록 보장
   try {
     await prisma.priceCache.upsert({
       where: { ticker },
-      update: { price, change, changePercent: changePct },
+      update: { price, change, changePercent: changePct, market },
       create: { ticker, displayName, market, currency, price, change, changePercent: changePct },
     })
   } catch (error) {
@@ -165,6 +166,7 @@ async function doRefreshPrices(): Promise<RefreshResult> {
       const change = quote.regularMarketChange != null ? Number(quote.regularMarketChange) : null
       const changePct = quote.regularMarketChangePercent != null ? Number(quote.regularMarketChangePercent) : null
 
+      const normalizedMarket = normalizeMarket(meta.market, ticker)
       await prisma.priceCache.upsert({
         where: { ticker },
         update: {
@@ -172,11 +174,12 @@ async function doRefreshPrices(): Promise<RefreshResult> {
           change,
           changePercent: changePct,
           displayName: meta.displayName,
+          market: normalizedMarket,
         },
         create: {
           ticker,
           displayName: meta.displayName,
-          market: normalizeMarket(meta.market, ticker),
+          market: normalizedMarket,
           price,
           currency: meta.currency,
           change,

--- a/src/lib/price-fetcher.ts
+++ b/src/lib/price-fetcher.ts
@@ -1,5 +1,6 @@
 import YahooFinance from 'yahoo-finance2'
 import { prisma } from './prisma'
+import { normalizeMarket } from './market-hours'
 
 const yahooFinance = new YahooFinance()
 
@@ -55,7 +56,8 @@ export async function fetchQuote(ticker: string): Promise<QuoteResult> {
   const change = quote.regularMarketChange != null ? Number(quote.regularMarketChange) : null
   const changePct = quote.regularMarketChangePercent != null ? Number(quote.regularMarketChangePercent) : null
   const currency = quote.currency ?? 'USD'
-  const market = quote.exchange ?? 'unknown'
+  // Yahoo의 raw exchange 코드(NCM/NYQ/KSC 등)를 정규화해 저장 — 비교 일관성 보장
+  const market = normalizeMarket(quote.exchange ?? '', ticker)
   const displayName = quote.shortName ?? quote.longName ?? ticker
 
   // PriceCache upsert — 존재하면 갱신, 없으면 생성 (fallback 조회 시 캐시 적재)
@@ -174,7 +176,7 @@ async function doRefreshPrices(): Promise<RefreshResult> {
         create: {
           ticker,
           displayName: meta.displayName,
-          market: meta.market,
+          market: normalizeMarket(meta.market, ticker),
           price,
           currency: meta.currency,
           change,

--- a/src/lib/trade-service.ts
+++ b/src/lib/trade-service.ts
@@ -65,6 +65,11 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
   if (existingTrade) {
     const normalizedExisting = normalizeMarket(existingTrade.market, ticker)
     if (normalizedExisting !== normalizedInputMarket || existingTrade.currency !== currency) {
+      console.warn(
+        `[trade-service] market/currency 불일치 (Trade): ticker=${ticker} ` +
+        `existing(raw=${existingTrade.market}, normalized=${normalizedExisting}, ${existingTrade.currency}) ` +
+        `input(raw=${market}, normalized=${normalizedInputMarket}, ${currency})`
+      )
       throw new Error(`${ticker}은(는) 이미 ${normalizedExisting}/${existingTrade.currency}로 등록되어 있습니다.`)
     }
   }
@@ -78,6 +83,11 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
     if (existingHolding) {
       const normalizedExisting = normalizeMarket(existingHolding.market, ticker)
       if (normalizedExisting !== normalizedInputMarket || existingHolding.currency !== currency) {
+        console.warn(
+          `[trade-service] market/currency 불일치 (Holding): ticker=${ticker} ` +
+          `existing(raw=${existingHolding.market}, normalized=${normalizedExisting}, ${existingHolding.currency}) ` +
+          `input(raw=${market}, normalized=${normalizedInputMarket}, ${currency})`
+        )
         throw new Error(`${ticker}은(는) 이미 ${normalizedExisting}/${existingHolding.currency}로 등록되어 있습니다.`)
       }
     }
@@ -111,7 +121,8 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
             accountId,
             ticker: existingHolding.ticker,
             displayName: existingHolding.displayName,
-            market: normalizeMarket(existingHolding.market, existingHolding.ticker),
+            // 사전 검증에서 normalize(existing) === normalizedInputMarket 임이 확인됨 — 입력값 그대로 사용
+            market: normalizedInputMarket,
             type: 'BUY',
             shares: existingHolding.shares,
             price: baselinePrice,

--- a/src/lib/trade-service.ts
+++ b/src/lib/trade-service.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW } from '@/lib/trade-utils'
+import { normalizeMarket } from '@/lib/market-hours'
 
 export interface CreateTradeInput {
   accountId: string
@@ -55,12 +56,17 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
   const totalKRW = calcTotalKRW(price, shares, currency, fxRate)
 
   // 기존 거래와 market/currency 일관성 검증
+  // market은 정규화된 값으로 비교 (raw Yahoo 코드 NCM/NYQ 등과 정규화된 US/KR이 혼재할 수 있음)
+  const normalizedInputMarket = normalizeMarket(market, ticker)
   const existingTrade = await prisma.trade.findFirst({
     where: { accountId, ticker },
     select: { market: true, currency: true },
   })
-  if (existingTrade && (existingTrade.market !== market || existingTrade.currency !== currency)) {
-    throw new Error(`${ticker}은(는) 이미 ${existingTrade.market}/${existingTrade.currency}로 등록되어 있습니다.`)
+  if (existingTrade) {
+    const normalizedExisting = normalizeMarket(existingTrade.market, ticker)
+    if (normalizedExisting !== normalizedInputMarket || existingTrade.currency !== currency) {
+      throw new Error(`${ticker}은(는) 이미 ${normalizedExisting}/${existingTrade.currency}로 등록되어 있습니다.`)
+    }
   }
 
   // Holding-only 상태 (시드 데이터, Trade 없음)에서도 market/currency 검증
@@ -69,8 +75,11 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
       where: { accountId_ticker: { accountId, ticker } },
       select: { market: true, currency: true },
     })
-    if (existingHolding && (existingHolding.market !== market || existingHolding.currency !== currency)) {
-      throw new Error(`${ticker}은(는) 이미 ${existingHolding.market}/${existingHolding.currency}로 등록되어 있습니다.`)
+    if (existingHolding) {
+      const normalizedExisting = normalizeMarket(existingHolding.market, ticker)
+      if (normalizedExisting !== normalizedInputMarket || existingHolding.currency !== currency) {
+        throw new Error(`${ticker}은(는) 이미 ${normalizedExisting}/${existingHolding.currency}로 등록되어 있습니다.`)
+      }
     }
   }
 
@@ -102,7 +111,7 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
             accountId,
             ticker: existingHolding.ticker,
             displayName: existingHolding.displayName,
-            market: existingHolding.market,
+            market: normalizeMarket(existingHolding.market, existingHolding.ticker),
             type: 'BUY',
             shares: existingHolding.shares,
             price: baselinePrice,
@@ -121,7 +130,7 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
         accountId,
         ticker,
         displayName,
-        market,
+        market: normalizedInputMarket,
         type,
         shares,
         price,
@@ -156,7 +165,7 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
           accountId,
           ticker,
           displayName,
-          market,
+          market: normalizedInputMarket,
           shares: holdingState.shares,
           avgPrice: holdingState.avgPrice,
           currency,


### PR DESCRIPTION
## 변경 사항

- `src/lib/price-fetcher.ts`: PriceCache 저장 시 `normalizeMarket()` 적용 (create + update 분기)
- `src/lib/trade-service.ts`: market 비교를 정규화 후 수행, 신규 Trade/Holding/baseline 모두 정규화된 값 저장. raw vs normalized 컨텍스트를 서버 로그에 남김
- `src/app/api/trades/import/route.ts`: 동일 비교 정규화, baseline trade는 검증된 입력 market 그대로 사용
- `src/lib/market-hours.ts`: `normalizeMarket` 입력 `trim()` 적용 (공백/null 방어)
- `prisma/scripts/normalize-market-codes.ts`: 테이블별 분리 + 500-row 배치 + 2분 timeout 마이그레이션 스크립트 (`--dry-run` 지원)
- `docs/specs/281-normalize-market-codes.md`: 스펙 추가

## 배경

DB의 `market` 필드에 Yahoo의 raw exchange 코드(`NCM`, `NYQ`, `KSC` 등)와 정규화 코드(`US`, `KR`)가 혼재해 있어, 신규 거래 등록 시 일관성 검증이 항상 실패하는 문제가 있었습니다.

사용자 보고: SATL을 직접 입력 시 `'SATL은(는) 이미 NCM/USD로 등록되어 있습니다.'` 에러로 등록 불가.

원인: `price-fetcher.ts`가 Yahoo의 `quote.exchange`를 정규화 없이 `PriceCache.market`에 저장 → 거기서 파생된 Watchlist/Holding에도 raw 코드가 들어감 → 폼은 `'US'/'KR'`만 보냄 → 비교 실패.

## 마이그레이션

배포 후 1회 실행:

```bash
# dry-run으로 변경 row 수 확인
tsx prisma/scripts/normalize-market-codes.ts --dry-run

# 실제 적용
tsx prisma/scripts/normalize-market-codes.ts
```

테이블별 분리 트랜잭션 + 배치 처리로 락 경합 최소화.

## 체크리스트

- [x] 린트 (`npm run lint`)
- [x] 타입체크 (`npx tsc --noEmit`)
- [x] 빌드 (`npm run build`)
- [x] 코드 리뷰 (P1/P2: 0건)

## 코드 리뷰 결과

- 리뷰 횟수: 2회 (codex-cli 모델 차단으로 내부 pr-review-toolkit:code-reviewer 사용)
- 라운드 1: P1 4건(upsert update market, 트랜잭션 batch, baseline OTHER 정책, 테스트 부재) + P0 3건
- 라운드 2: P1 0건 / P2 0건 통과. P0 2건 잔존(반영 선택)
- 테스트 부재(P1)는 프로젝트에 jest/vitest 인프라가 없어 별도 작업으로 분리

Closes #281