### PR TITLE
[Phase 25-H-2] next-auth 4 → Auth.js v5 마이그레이션 (#286)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,10 @@ DATABASE_URL="postgresql://user:password@localhost:5432/myfinance"
 BASE_URL="http://localhost:4100"
 PORT=4100
 
-# NextAuth.js
-NEXTAUTH_URL="http://localhost:4100"
-NEXTAUTH_SECRET="generate-with-openssl-rand-base64-32"
+# Auth.js v5 (구 NextAuth)
+# AUTH_SECRET: openssl rand -base64 32 로 생성. 운영에서는 강한 값 필수.
+# (구 NEXTAUTH_SECRET는 fallback 지원되지만, 신규 환경은 AUTH_SECRET 사용 권장)
+AUTH_SECRET="generate-with-openssl-rand-base64-32"
 AUTH_PIN="your-pin-here"
 
 # Telegram Bot

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@ PORT=4100
 AUTH_SECRET="generate-with-openssl-rand-base64-32"
 AUTH_PIN="your-pin-here"
 
+# v5에서 production 환경(NODE_ENV=production)은 trustHost가 자동 활성화되지 않음.
+# 결과: Nginx 뒤에서 UntrustedHost 에러로 로그인 전면 차단.
+# 둘 중 하나를 반드시 설정:
+#   - AUTH_URL: 서비스 절대 URL 명시 (예: https://finance.starryjeju.net)
+#   - AUTH_TRUST_HOST: 신뢰 가능한 reverse proxy 환경이면 "true" (Nginx로 단일 서버 운영 시 해당)
+AUTH_TRUST_HOST="true"
+
 # Telegram Bot
 TELEGRAM_BOT_TOKEN="your-bot-token"
 TELEGRAM_ALLOWED_CHAT_IDS="123456789"

--- a/docs/specs/286-authjs-v5-migration.md
+++ b/docs/specs/286-authjs-v5-migration.md
@@ -58,8 +58,9 @@ Auth.js v5는 쿠키 prefix가 `next-auth.*` → `authjs.*`로 바뀐다. 배포
 ## 배포 시 주의
 
 1. `.env`의 `NEXTAUTH_SECRET` → `AUTH_SECRET`으로 변수명 변경 (값은 동일 유지 가능. 변수명 변경만)
-2. PM2 재시작
-3. 첫 접속 시 강제 로그아웃 (쿠키 prefix 변경) — PIN 재입력
+2. **`AUTH_TRUST_HOST="true"` 추가 필수** — v5는 production에서 trustHost가 자동 활성화되지 않아 Nginx 리버스 프록시 환경에서 모든 로그인이 `UntrustedHost` 에러로 실패한다. 대안으로 `AUTH_URL="https://finance.starryjeju.net"` 설정도 가능.
+3. PM2 재시작
+4. 첫 접속 시 강제 로그아웃 (쿠키 prefix 변경) — PIN 재입력
 
 ## 제외 사항
 

--- a/docs/specs/286-authjs-v5-migration.md
+++ b/docs/specs/286-authjs-v5-migration.md
@@ -1,0 +1,71 @@
+# Phase 25-H-2: next-auth 4 → Auth.js v5 마이그레이션
+
+## 목적
+
+Phase 25-H-1에 이어 남은 Dependabot 권고를 해결하기 위해 `next-auth` 4 → `next-auth@5` (Auth.js v5) 마이그레이션을 수행한다. 특히 `uuid` 보안 권고(next-auth v4 → uuid v8 종속)와 일부 next 권고 해결이 목표.
+
+## 배경
+
+PR #285에서 Next 14→15.5.19 적용 후에도 4건의 권고가 남았다:
+- `uuid` < 11.1.1 (next-auth v4 → uuid@8.3.2 종속)
+- `next-auth` >= 4.11.0 권고 매칭 (next 의존)
+- `next`, `postcss` (next 번들 내부)
+
+next-auth v5는 uuid를 의존하지 않으므로 마이그레이션 시 uuid 권고는 자체 해결된다.
+
+## 요구사항
+
+- [ ] `next-auth` 4.24 → `next-auth@5` (beta — 2년 이상 안정 베타)
+- [ ] `src/lib/auth.ts`를 Auth.js v5 API로 재작성 (`handlers`, `auth`, `signIn`, `signOut` export)
+- [ ] `[...nextauth]/route.ts`를 `handlers.GET/POST` 패턴으로 변경
+- [ ] `middleware.ts`를 `auth()` 래퍼로 전환 (req.auth 접근)
+- [ ] 타입 augmentation을 `@auth/core/jwt`로 이전
+- [ ] 환경변수: `NEXTAUTH_SECRET` → `AUTH_SECRET` (fallback 유지)
+- [ ] dev 서버 동작 확인 (signin redirect, 401 JSON, /api/auth/* 엔드포인트)
+
+## 기술 설계
+
+### 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/lib/auth.ts` | `NextAuthOptions` → `NextAuth()` 호출 + export `{ handlers, auth, signIn, signOut }`. authorize 콜백의 `req.headers['x-forwarded-for']` (Node) → `request.headers.get('x-forwarded-for')` (Web Request) |
+| `src/app/api/auth/[...nextauth]/route.ts` | `NextAuth(opts)` 직접 호출 → `import { handlers } from '@/lib/auth'; export const { GET, POST } = handlers` |
+| `src/middleware.ts` | `getToken({ req })` → `auth((request) => ...)` 래퍼. `request.auth` 존재 여부로 인증 판정 |
+| `src/types/next-auth.d.ts` | `next-auth/jwt` 모듈 → `@auth/core/jwt`. Session.user 옵셔널 처리 (v5 DefaultSession 구조 반영) |
+| `.env.example` | `NEXTAUTH_URL` 제거 (v5는 request 기반 자동 추론), `NEXTAUTH_SECRET` → `AUTH_SECRET` |
+
+### 변경 없는 파일 (호환)
+
+- `src/app/auth/signin/page.tsx` — `signIn` from `next-auth/react` 그대로 동작
+- `src/components/auth/AuthProvider.tsx` — `SessionProvider` 그대로 동작
+
+### 쿠키 prefix 변경 영향
+
+Auth.js v5는 쿠키 prefix가 `next-auth.*` → `authjs.*`로 바뀐다. 배포 직후 한 번 강제 로그아웃이 필요하다(사용자가 다시 PIN 입력).
+
+## 테스트 계획
+
+- [ ] `npm run lint`
+- [ ] `npx tsc --noEmit`
+- [ ] `npm run build`
+- [ ] dev 서버:
+  - 미인증 `/` → `/auth/signin` 307 redirect
+  - 미인증 `/api/*` → 401 JSON
+  - `/api/auth/providers` 정상 응답
+  - `/api/auth/csrf` 토큰 반환
+
+## 배포 시 주의
+
+1. `.env`의 `NEXTAUTH_SECRET` → `AUTH_SECRET`으로 변수명 변경 (값은 동일 유지 가능. 변수명 변경만)
+2. PM2 재시작
+3. 첫 접속 시 강제 로그아웃 (쿠키 prefix 변경) — PIN 재입력
+
+## 제외 사항
+
+- 남은 3건의 `next` 내부 postcss 권고 — Next 16 업그레이드 필요 (별도 작업, 보안 영향 미미)
+- DB 어댑터 도입 (현재는 JWT 전략, 변경 없음)
+
+## 라벨
+
+- `chore`, `P1`, `phase-25-H`

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "grammy": "^1.41.1",
         "marked": "^17.0.4",
         "next": "^15.5.16",
-        "next-auth": "^4.24.13",
+        "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
         "node-cron": "^4.2.1",
         "papaparse": "^5.5.3",
@@ -54,6 +54,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -1258,15 +1287,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
-      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
@@ -6030,9 +6050,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6478,30 +6498,25 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.14",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
-      "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
       "license": "ISC",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.0",
-        "jose": "^4.15.5",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
+        "@auth/core": "0.41.2"
       },
       "peerDependencies": {
-        "@auth/core": "0.34.3",
-        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
         "nodemailer": "^7.0.7",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "react": "^18.2.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
-        "@auth/core": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
           "optional": true
         },
         "nodemailer": {
@@ -6665,11 +6680,14 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "license": "MIT"
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6809,15 +6827,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
-      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6837,42 +6846,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/openid-client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/openid-client/node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -7276,9 +7249,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.29.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
-      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7286,13 +7259,10 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
-      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
       "license": "MIT",
-      "dependencies": {
-        "pretty-format": "^3.8.0"
-      },
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -7306,12 +7276,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "license": "MIT"
     },
     "node_modules/prisma": {
       "version": "6.19.3",
@@ -9031,15 +8995,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -9239,12 +9194,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grammy": "^1.41.1",
     "marked": "^17.0.4",
     "next": "^15.5.16",
-    "next-auth": "^4.24.13",
+    "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "node-cron": "^4.2.1",
     "papaparse": "^5.5.3",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,3 @@
-import NextAuth from 'next-auth'
-import { authOptions } from '@/lib/auth'
+import { handlers } from '@/lib/auth'
 
-const handler = NextAuth(authOptions)
-export { handler as GET, handler as POST }
+export const { GET, POST } = handlers

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -30,11 +30,16 @@ export default function SignInPage() {
       })
 
       if (!result || result.error || !result.ok) {
-        setError(
-          result?.error?.includes('너무 많은 시도')
-            ? '너무 많은 시도입니다. 5분 후 다시 시도하세요.'
-            : 'PIN이 올바르지 않습니다',
-        )
+        // Auth.js v5는 CredentialsSignin 서브클래스의 code를 클라이언트로 전달한다
+        // (일반 Error message는 sanitize됨)
+        const code = result?.code
+        if (code === 'rate_limited') {
+          setError('너무 많은 시도입니다. 5분 후 다시 시도하세요.')
+        } else if (code === 'missing_auth_pin') {
+          setError('서버 설정 오류: AUTH_PIN 환경변수가 없습니다')
+        } else {
+          setError('PIN이 올바르지 않습니다')
+        }
         setPin('')
         return
       }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,16 @@
-import NextAuth from 'next-auth'
+import NextAuth, { CredentialsSignin } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
+
+// Auth.js v5는 authorize 내부에서 throw된 일반 Error의 message를 클라이언트로
+// 노출하지 않고 모두 'CredentialsSignin'으로 sanitize한다.
+// CredentialsSignin을 상속하면 code 필드가 client signIn 결과로 전달돼,
+// signin 페이지에서 케이스별 메시지 분기가 가능해진다.
+class RateLimitedError extends CredentialsSignin {
+  code = 'rate_limited'
+}
+class MissingAuthPinError extends CredentialsSignin {
+  code = 'missing_auth_pin'
+}
 
 const MAX_ATTEMPTS = 5
 const LOCKOUT_MS = 5 * 60 * 1000 // 5분
@@ -62,9 +73,8 @@ function clearFailures(key: string): void {
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  // v5: AUTH_SECRET 환경변수 자동 사용. NEXTAUTH_SECRET 후방 호환은 v5가 처리하지 않으므로
-  // 배포 시 .env에 AUTH_SECRET 설정 필요. NEXTAUTH_SECRET이 있으면 fallback.
-  secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
+  // v5는 AUTH_SECRET을 우선 사용하고, NEXTAUTH_SECRET도 자동 fallback한다
+  // (node_modules/next-auth/lib/env.js). 명시적 지정 없음.
   providers: [
     Credentials({
       name: 'PIN',
@@ -74,7 +84,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       async authorize(credentials, request) {
         const pin = process.env.AUTH_PIN
         if (!pin) {
-          throw new Error('AUTH_PIN 환경변수가 설정되지 않았습니다')
+          throw new MissingAuthPinError()
         }
 
         // v5에서는 Request 객체로 헤더 접근 (next-auth v4는 NodeJS req였음)
@@ -82,7 +92,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const rateLimitKey = forwarded?.split(',')[0]?.trim() || 'unknown'
 
         if (!checkRateLimit(rateLimitKey)) {
-          throw new Error('너무 많은 시도입니다. 5분 후 다시 시도하세요.')
+          throw new RateLimitedError()
         }
 
         if (credentials?.pin === pin) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,5 @@
-import type { NextAuthOptions } from 'next-auth'
-import CredentialsProvider from 'next-auth/providers/credentials'
+import NextAuth from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
 
 const MAX_ATTEMPTS = 5
 const LOCKOUT_MS = 5 * 60 * 1000 // 5분
@@ -61,22 +61,25 @@ function clearFailures(key: string): void {
   failedAttempts.delete(key)
 }
 
-export const authOptions: NextAuthOptions = {
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  // v5: AUTH_SECRET 환경변수 자동 사용. NEXTAUTH_SECRET 후방 호환은 v5가 처리하지 않으므로
+  // 배포 시 .env에 AUTH_SECRET 설정 필요. NEXTAUTH_SECRET이 있으면 fallback.
+  secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
   providers: [
-    CredentialsProvider({
+    Credentials({
       name: 'PIN',
       credentials: {
         pin: { label: 'PIN', type: 'password' },
       },
-      async authorize(credentials, req) {
+      async authorize(credentials, request) {
         const pin = process.env.AUTH_PIN
         if (!pin) {
           throw new Error('AUTH_PIN 환경변수가 설정되지 않았습니다')
         }
 
-        const forwarded = req?.headers?.['x-forwarded-for']
-        const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded
-        const rateLimitKey = raw?.split(',')[0]?.trim() || 'unknown'
+        // v5에서는 Request 객체로 헤더 접근 (next-auth v4는 NodeJS req였음)
+        const forwarded = request.headers.get('x-forwarded-for')
+        const rateLimitKey = forwarded?.split(',')[0]?.trim() || 'unknown'
 
         if (!checkRateLimit(rateLimitKey)) {
           throw new Error('너무 많은 시도입니다. 5분 후 다시 시도하세요.')
@@ -113,4 +116,4 @@ export const authOptions: NextAuthOptions = {
   pages: {
     signIn: '/auth/signin',
   },
-}
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,9 @@
-import { getToken } from 'next-auth/jwt'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
 
-export async function middleware(request: NextRequest) {
-  const token = await getToken({ req: request })
-
-  if (!token) {
+// Auth.js v5: auth()를 미들웨어로 직접 export하면 req.auth로 세션 접근 가능
+export default auth((request) => {
+  if (!request.auth) {
     // API 요청은 401 JSON 반환 (리다이렉트하면 클라이언트 파싱 에러)
     if (request.nextUrl.pathname.startsWith('/api/')) {
       return NextResponse.json({ error: '인증이 필요합니다' }, { status: 401 })
@@ -17,7 +16,7 @@ export async function middleware(request: NextRequest) {
   }
 
   return NextResponse.next()
-}
+})
 
 export const config = {
   matcher: [

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,18 +1,25 @@
-import { DefaultSession } from 'next-auth'
+// Auth.js v5 type augmentation
+// 참고: 모듈 augmentation은 v4의 'next-auth/jwt' 대신 '@auth/core/jwt'를 사용한다.
+
+import 'next-auth'
 
 declare module 'next-auth' {
   interface User {
-    role: string
+    role?: string
   }
 
   interface Session {
-    user: DefaultSession['user'] & {
+    user: {
       role?: string
+      name?: string | null
+      email?: string | null
+      image?: string | null
+      id?: string
     }
   }
 }
 
-declare module 'next-auth/jwt' {
+declare module '@auth/core/jwt' {
   interface JWT {
     role?: string
   }


### PR DESCRIPTION
## 변경 사항

### 의존성
- `next-auth` 4.24 → **5.0.0-beta.31** (Auth.js v5; 2년+ 안정 베타)
- `uuid` 종속성 제거 (Auth.js v5는 uuid 미의존)

### 코드 마이그레이션 (7개 파일)
- `src/lib/auth.ts`: `NextAuthOptions` → `NextAuth()` 호출. `handlers/auth/signIn/signOut` 명명 export. authorize() request 객체가 Web Request로 변경
- `src/app/api/auth/[...nextauth]/route.ts`: `handlers.GET/POST` re-export 패턴
- `src/middleware.ts`: `getToken({ req })` → `auth((request) => ...)` 래퍼. `request.auth`로 세션 접근
- `src/types/next-auth.d.ts`: JWT augmentation을 `@auth/core/jwt`로 이전, Session.user 옵셔널 구조 반영
- `src/app/auth/signin/page.tsx`: 에러 분기를 `result.code` 기반으로 변경 (v5는 일반 Error message를 sanitize함)
- `.env.example`: `NEXTAUTH_URL` 제거, `NEXTAUTH_SECRET` → `AUTH_SECRET`, **`AUTH_TRUST_HOST="true"` 추가**
- `docs/specs/286-authjs-v5-migration.md`: 스펙

### 새로 도입한 에러 클래스
`CredentialsSignin` 상속한 `RateLimitedError`(code='rate_limited') / `MissingAuthPinError`(code='missing_auth_pin')로 v5의 에러 sanitize 우회. 클라이언트에서 case별 메시지 분기 가능.

## 보안 패치 결과

- `uuid` 의존성 자체 제거 — 권고 해결
- `next` HIGH 권고 → moderate로 다운그레이드
- 남은 3 moderate는 모두 next 내부 postcss (Next 16 필요, 별도 작업)

## 검증

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` (Next + MCP + bot 모두 통과)
- [x] 코드 리뷰 3회 → P1/P2: 0건
- [x] dev 서버 실동작:
  - 미인증 `/` → `/auth/signin` 307 redirect
  - 미인증 `/api/*` → 401 JSON
  - `/api/auth/providers` → Credentials 응답
  - `/api/auth/csrf` → 정상 토큰 발급
  - `authjs.*` 쿠키 prefix (v5 기본)

## 배포 시 주의

1. `.env`의 `NEXTAUTH_SECRET` → `AUTH_SECRET` 변수명 변경 (값은 동일 유지 가능)
2. **`.env`에 `AUTH_TRUST_HOST="true"` 추가 필수** — 없으면 Nginx 뒤에서 `UntrustedHost` 에러로 로그인 전면 차단됨. 대안: `AUTH_URL="https://finance.starryjeju.net"`
3. PM2 재시작
4. 첫 접속 시 강제 로그아웃 (쿠키 prefix `next-auth.*` → `authjs.*`로 변경)

Closes #286