### PR TITLE
fix(db): transfer 카테고리 idempotent 마이그레이션 (#289)

### DIFF
--- a/docs/specs/289-transfer-categories-migration.md
+++ b/docs/specs/289-transfer-categories-migration.md
@@ -1,0 +1,58 @@
+# 289: transfer 카테고리 idempotent 데이터 마이그레이션
+
+## 목적
+
+`prisma/seed.ts:309-312`의 4개 transfer 카테고리(`savings`, `deposit`, `investment`, `etc-transfer`)를 idempotent SQL 마이그레이션으로 분리해, 기존 DB에 `prisma migrate deploy`만 실행해도 자동 등록되도록 한다.
+
+## 배경
+
+- v0.5.0 릴리즈 PR #288의 Codex 리뷰에서 식별된 P1
+- 시드 스크립트는 신규 설치에만 실행됨. 운영 업그레이드 경로(`prisma migrate deploy`)에는 미적용
+- transaction API는 `type === 'transfer'`인 카테고리만 transfer 거래 허용 → 누락 시 자산 이체 흐름 차단
+
+## 요구사항
+
+- [ ] `prisma/migrations/<timestamp>_add_transfer_categories/migration.sql` 신규 생성
+- [ ] 4개 카테고리 INSERT (ON CONFLICT DO NOTHING으로 idempotent 보장)
+- [ ] 기존 운영 DB에 이미 있으면 충돌 없이 통과
+- [ ] 신규 DB에는 정상 생성
+
+## 기술 설계
+
+### Schema 제약
+- `slug` UNIQUE → `ON CONFLICT ("slug") DO NOTHING`
+- `name` UNIQUE → 보조 충돌 방지에 도움
+- `id`는 Prisma 측 `cuid()` 기본값, raw SQL에서는 직접 지정 필요 → `gen_random_uuid()::text` 사용
+- `keywords`는 PostgreSQL `text[]` 배열
+- `createdAt`은 default(now()) 적용
+
+### Migration SQL
+
+```sql
+INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
+VALUES
+  (gen_random_uuid()::text, 'savings', '적금', 'transfer', '🏦', ARRAY['적금','저축'], 1, NULL, NOW()),
+  (gen_random_uuid()::text, 'deposit', '예금', 'transfer', '💳', ARRAY['예금','정기예금'], 2, NULL, NOW()),
+  (gen_random_uuid()::text, 'investment', '투자계좌', 'transfer', '📈', ARRAY['투자','증권','주식계좌'], 3, NULL, NOW()),
+  (gen_random_uuid()::text, 'etc-transfer', '기타이체', 'transfer', '🔄', ARRAY['이체','송금'], 99, NULL, NOW())
+ON CONFLICT ("slug") DO NOTHING;
+```
+
+### Seed와의 일관성
+
+`prisma/seed.ts:309-312`는 그대로 유지. 신규 설치 시 시드가 createMany로 생성하지만, 시드를 거치지 않은 환경(production)에서도 마이그레이션이 보장.
+
+## 테스트 계획
+
+- [ ] `npm run lint`
+- [ ] `npx tsc --noEmit`
+- [ ] 마이그레이션 SQL 구문 검증
+- [ ] 운영 DB에 적용 후 4개 카테고리 존재 확인 (이미 있다면 ON CONFLICT 통과)
+
+## 배포
+
+`prisma migrate deploy` 시 자동 적용. 별도 수동 작업 불필요.
+
+## 라벨
+
+- `fix`, `P1`

--- a/docs/specs/289-transfer-categories-migration.md
+++ b/docs/specs/289-transfer-categories-migration.md
@@ -20,27 +20,36 @@
 ## 기술 설계
 
 ### Schema 제약
-- `slug` UNIQUE → `ON CONFLICT ("slug") DO NOTHING`
-- `name` UNIQUE → 보조 충돌 방지에 도움
-- `id`는 Prisma 측 `cuid()` 기본값, raw SQL에서는 직접 지정 필요 → `gen_random_uuid()::text` 사용
+- `slug` UNIQUE **+ `name` UNIQUE** → 둘 중 어느 쪽 충돌이든 INSERT 전체 롤백 가능
+- `id`는 Prisma 측 `cuid()` 기본값, raw SQL에서는 직접 지정 필요
 - `keywords`는 PostgreSQL `text[]` 배열
 - `createdAt`은 default(now()) 적용
+
+### 설계 결정
+
+1. **결정적 id (`cat_transfer_*`)**: `gen_random_uuid()`는 PostgreSQL 13+ 또는 pgcrypto 확장이 필요해 의존성 우려. 결정적 문자열 id로 의존성 제거. 신규 설치 경로에서는 seed의 `deleteMany`가 이를 덮어써서 cuid id로 재생성되므로, 결정적 id는 시드 미실행 환경(운영 업그레이드 경로)에서만 의미를 가짐.
+
+2. **`INSERT ... SELECT ... WHERE NOT EXISTS` 패턴**: `ON CONFLICT (slug)`만 사용하면 `name` UNIQUE 충돌 시 마이그레이션 실패 → `_prisma_migrations`에 failed 기록 → 이후 `prisma migrate deploy` 차단. slug AND name 양쪽을 가드하는 패턴으로 처리.
 
 ### Migration SQL
 
 ```sql
 INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
-VALUES
-  (gen_random_uuid()::text, 'savings', '적금', 'transfer', '🏦', ARRAY['적금','저축'], 1, NULL, NOW()),
-  (gen_random_uuid()::text, 'deposit', '예금', 'transfer', '💳', ARRAY['예금','정기예금'], 2, NULL, NOW()),
-  (gen_random_uuid()::text, 'investment', '투자계좌', 'transfer', '📈', ARRAY['투자','증권','주식계좌'], 3, NULL, NOW()),
-  (gen_random_uuid()::text, 'etc-transfer', '기타이체', 'transfer', '🔄', ARRAY['이체','송금'], 99, NULL, NOW())
-ON CONFLICT ("slug") DO NOTHING;
+SELECT 'cat_transfer_savings', 'savings', '적금', 'transfer', '🏦', ARRAY['적금','저축']::text[], 1, NULL, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "Category" WHERE slug = 'savings' OR name = '적금');
+-- (deposit / investment / etc-transfer 동일 패턴)
 ```
 
 ### Seed와의 일관성
 
-`prisma/seed.ts:309-312`는 그대로 유지. 신규 설치 시 시드가 createMany로 생성하지만, 시드를 거치지 않은 환경(production)에서도 마이그레이션이 보장.
+`prisma/seed.ts:309-312`는 그대로 유지. 신규 설치 시:
+1. 마이그레이션이 4개를 `cat_transfer_*` id로 생성
+2. seed의 `deleteMany` (line 107)가 모두 삭제
+3. seed의 `createMany`가 16개 카테고리를 cuid id로 재생성
+
+운영 업그레이드 시:
+1. 마이그레이션이 4개 중 누락분만 생성 (slug/name 양쪽 가드)
+2. seed 미실행 → 결정적 id 유지
 
 ## 테스트 계획
 

--- a/prisma/migrations/20260612120000_add_transfer_categories/migration.sql
+++ b/prisma/migrations/20260612120000_add_transfer_categories/migration.sql
@@ -1,0 +1,18 @@
+-- Issue #289: transfer 카테고리 idempotent 데이터 마이그레이션
+--
+-- prisma/seed.ts에만 등록되어 있던 4개 transfer 카테고리를 운영 업그레이드 경로
+-- (prisma migrate deploy)에도 보장. ON CONFLICT로 기존 DB에는 영향 없음.
+--
+-- transaction API는 type = 'transfer'인 카테고리만 자산 이체 거래를 허용하므로
+-- 누락 시 transfer 흐름이 차단된다.
+--
+-- id는 결정적 문자열(slug 기반)을 사용 — gen_random_uuid()는 PostgreSQL 13+ 또는
+-- pgcrypto 확장 필요. 결정적 ID로 의존성 제거 + 두 번째 실행 시에도 안전.
+
+INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
+VALUES
+  ('cat_transfer_savings',      'savings',      '적금',     'transfer', '🏦', ARRAY['적금','저축']::text[],             1,  NULL, NOW()),
+  ('cat_transfer_deposit',      'deposit',      '예금',     'transfer', '💳', ARRAY['예금','정기예금']::text[],         2,  NULL, NOW()),
+  ('cat_transfer_investment',   'investment',   '투자계좌', 'transfer', '📈', ARRAY['투자','증권','주식계좌']::text[],   3,  NULL, NOW()),
+  ('cat_transfer_etc',          'etc-transfer', '기타이체', 'transfer', '🔄', ARRAY['이체','송금']::text[],             99, NULL, NOW())
+ON CONFLICT ("slug") DO NOTHING;

--- a/prisma/migrations/20260612120000_add_transfer_categories/migration.sql
+++ b/prisma/migrations/20260612120000_add_transfer_categories/migration.sql
@@ -1,18 +1,31 @@
 -- Issue #289: transfer 카테고리 idempotent 데이터 마이그레이션
 --
 -- prisma/seed.ts에만 등록되어 있던 4개 transfer 카테고리를 운영 업그레이드 경로
--- (prisma migrate deploy)에도 보장. ON CONFLICT로 기존 DB에는 영향 없음.
+-- (prisma migrate deploy)에도 보장. 기존 DB에는 영향 없음.
 --
 -- transaction API는 type = 'transfer'인 카테고리만 자산 이체 거래를 허용하므로
 -- 누락 시 transfer 흐름이 차단된다.
 --
--- id는 결정적 문자열(slug 기반)을 사용 — gen_random_uuid()는 PostgreSQL 13+ 또는
--- pgcrypto 확장 필요. 결정적 ID로 의존성 제거 + 두 번째 실행 시에도 안전.
+-- 설계 결정:
+--   1. id는 결정적 문자열(slug 기반) — gen_random_uuid()는 PG13+ 또는 pgcrypto 필요.
+--   2. Category.slug AND name 모두 UNIQUE → ON CONFLICT 한 컬럼만 잡으면 다른 쪽
+--      충돌 시 전체 INSERT 실패 → 마이그레이션이 failed로 기록되어 이후 deploy 차단.
+--      → INSERT ... SELECT ... WHERE NOT EXISTS 패턴으로 양쪽 동시 가드.
+--   3. 신규 설치 경로(migrate deploy + db seed)에서는 시드의 deleteMany가 이 row를
+--      덮어쓰므로 결정적 id는 시드 미실행 환경(운영 업그레이드)에서만 의미를 가짐.
 
 INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
-VALUES
-  ('cat_transfer_savings',      'savings',      '적금',     'transfer', '🏦', ARRAY['적금','저축']::text[],             1,  NULL, NOW()),
-  ('cat_transfer_deposit',      'deposit',      '예금',     'transfer', '💳', ARRAY['예금','정기예금']::text[],         2,  NULL, NOW()),
-  ('cat_transfer_investment',   'investment',   '투자계좌', 'transfer', '📈', ARRAY['투자','증권','주식계좌']::text[],   3,  NULL, NOW()),
-  ('cat_transfer_etc',          'etc-transfer', '기타이체', 'transfer', '🔄', ARRAY['이체','송금']::text[],             99, NULL, NOW())
-ON CONFLICT ("slug") DO NOTHING;
+SELECT 'cat_transfer_savings', 'savings', '적금', 'transfer', '🏦', ARRAY['적금','저축']::text[], 1, NULL, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "Category" WHERE slug = 'savings' OR name = '적금');
+
+INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
+SELECT 'cat_transfer_deposit', 'deposit', '예금', 'transfer', '💳', ARRAY['예금','정기예금']::text[], 2, NULL, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "Category" WHERE slug = 'deposit' OR name = '예금');
+
+INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
+SELECT 'cat_transfer_investment', 'investment', '투자계좌', 'transfer', '📈', ARRAY['투자','증권','주식계좌']::text[], 3, NULL, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "Category" WHERE slug = 'investment' OR name = '투자계좌');
+
+INSERT INTO "Category" (id, slug, name, type, icon, keywords, "sortOrder", "groupId", "createdAt")
+SELECT 'cat_transfer_etc', 'etc-transfer', '기타이체', 'transfer', '🔄', ARRAY['이체','송금']::text[], 99, NULL, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM "Category" WHERE slug = 'etc-transfer' OR name = '기타이체');


### PR DESCRIPTION
## 변경 사항

- `prisma/migrations/20260612120000_add_transfer_categories/migration.sql`: 4개 transfer 카테고리(savings/deposit/investment/etc-transfer) idempotent INSERT
- `docs/specs/289-transfer-categories-migration.md`: 스펙

## 배경

PR #288 (v0.5.0 릴리즈) Codex 리뷰에서 P1 후속으로 식별됨. 4개 transfer 카테고리가 `prisma/seed.ts`에만 있어 운영 업그레이드 경로(`prisma migrate deploy`)에서 누락 → 신규 설치/복구 환경에서 transfer 거래 흐름 차단 위험.

## 설계 결정

### 1. 결정적 id (`cat_transfer_*`)
`gen_random_uuid()`는 PostgreSQL 13+ 또는 pgcrypto 확장이 필요해 의존성 우려. 결정적 문자열 id로 의존성 제거.

### 2. `INSERT ... SELECT ... WHERE NOT EXISTS` 패턴
`Category.slug`와 `name` 모두 UNIQUE. `ON CONFLICT (slug)`만 잡으면 name 충돌 시 마이그레이션 전체 실패 → `_prisma_migrations`에 failed 기록 → 이후 deploy 차단. slug AND name 양쪽 가드.

### 3. 4개 row 각각 별도 INSERT
한 row의 가드 실패가 다른 row를 막지 않음.

## 동작 시나리오

| 환경 | 동작 |
|---|---|
| 운영 (이미 4개 존재, cuid id) | 4건 모두 slug/name 충돌 → 모두 skip → 안전 |
| 신규 설치 | migrate가 `cat_transfer_*` id로 생성 → seed.deleteMany가 덮어씀 → cuid id로 재생성 |
| 시드 미실행 (운영 복구) | migrate가 4개 생성, `cat_transfer_*` id 유지 |
| 일부만 존재 | 누락분만 생성 |

## 체크리스트

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] 코드 리뷰 2회 통과 (P1/P2: 0건)

## 코드 리뷰

- 라운드 1: P2 1건 (name UNIQUE 미커버) + P1 2건 (id 일관성, 스펙 불일치)
- 라운드 2: 모두 반영, 신규 이슈 없음

Closes #289