### PR TITLE
[Phase 25-C] Trade import 검증 강화 — 날짜 범위 + ticker 정규화 (#293)

### DIFF
--- a/docs/specs/293-trade-import-validation.md
+++ b/docs/specs/293-trade-import-validation.md
@@ -1,0 +1,93 @@
+# Phase 25-C: Trade import 검증 강화
+
+## 목적
+
+Phase 25-A에서 import의 market 비교 정규화는 이미 적용됐다. 이번에는 거래 입력 검증에 남아 있는 두 가지 hardening을 추가한다:
+
+1. **거래일 범위 검증**: 미래 날짜 또는 1900년 이전 날짜가 들어오면 holdings 재계산이 왜곡될 수 있음
+2. **ticker 사전 정규화**: 현재 단일/import POST 모두 validation 통과 후에 trim/uppercase를 적용해 일관성 깨질 가능성
+
+## 배경
+
+- 25-A에서 `normalizeMarket` 통일로 SATL 등록 문제 해결됨
+- import의 batch-level `['US','KR']` 검증은 이미 존재
+- 그러나 trade 데이터 자체의 추가 검증은 미흡
+
+### 거래일 검증 누락의 영향
+- recalcHolding은 trades를 `tradedAt asc`로 정렬해 순차 처리
+- 미래 trade가 들어오면 holdings 잔량/평단이 비현실적으로 계산됨
+- 1900년 같은 명백한 오타도 그대로 받아들임
+
+### ticker 정규화 순서
+- 현재: `validateTradeInput(body)` → `ticker.toUpperCase().trim()` (단일 POST)
+- 결과: displayName fallback이 trim 안 된 ticker를 사용 (`displayName || ticker`)
+- 일관성: validation 안에서 정규화된 ticker로 모든 체크 수행해야 함
+
+## 요구사항
+
+- [ ] `validateTradeInput`에 tradedAt 범위 검증 추가
+  - 미래(+1일 grace로 timezone 고려) 거부
+  - 2000-01-01 이전 거부
+- [ ] ticker 사전 정규화 (trim + uppercase)
+  - validation 진입 직전 normalize
+  - 단일 POST (`src/app/api/trades/route.ts`)
+  - import POST (`src/app/api/trades/import/route.ts`)
+
+## 기술 설계
+
+### 1. tradedAt 범위 검증 (trade-utils.ts)
+
+```ts
+const MIN_DATE = Date.UTC(2000, 0, 1)
+const MAX_FUTURE_DAYS = 1  // timezone (KST) edge case 허용
+
+if (!body.tradedAt || isNaN(Date.parse(body.tradedAt))) {
+  errors.push({ field: 'tradedAt', message: '유효한 거래일을 입력해주세요.' })
+} else {
+  const ts = Date.parse(body.tradedAt)
+  const maxFuture = Date.now() + MAX_FUTURE_DAYS * 86_400_000
+  if (ts > maxFuture) {
+    errors.push({ field: 'tradedAt', message: '미래 날짜는 입력할 수 없습니다.' })
+  } else if (ts < MIN_DATE) {
+    errors.push({ field: 'tradedAt', message: '2000-01-01 이후 날짜를 입력해주세요.' })
+  }
+}
+```
+
+### 2. ticker 정규화 순서
+
+```ts
+// 변경 전 (api/trades/route.ts)
+const errors = validateTradeInput(body)
+// ...
+const ticker = body.ticker.toUpperCase().trim()
+
+// 변경 후
+const normalizedTicker = (body.ticker ?? '').toString().trim().toUpperCase()
+const errors = validateTradeInput({ ...body, ticker: normalizedTicker })
+// ...
+const ticker = normalizedTicker
+```
+
+Import도 동일 패턴: `t.ticker` 추출 직후 정규화.
+
+## 테스트 계획
+
+- [ ] `npm run lint`
+- [ ] `npx tsc --noEmit`
+- [ ] `npm run build`
+- [ ] 수동 시나리오:
+  - 단일 거래 POST에 tradedAt = 내일 → 400 error
+  - 단일 거래 POST에 tradedAt = 1999-12-31 → 400 error
+  - 단일 거래 POST에 ticker = ' aapl ' → 정상 저장(AAPL)
+  - CSV import에 미래 거래일 → row error로 표시 + skip
+
+## 제외 사항
+
+- per-row market 지정 (현재는 batch-level) — 별도 feature
+- displayName 자동 보강 (Yahoo lookup) — 별도 feature
+- Zod 마이그레이션 — Phase 25-F
+
+## 라벨
+
+- `fix`, `P1`, `phase-25`

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { recalcHolding } from '@/lib/trade-utils'
+import { recalcHolding, validateTradedAt } from '@/lib/trade-utils'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -71,8 +71,14 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     if (fxRate !== undefined && trade.currency === 'USD' && (typeof fxRate !== 'number' || !Number.isFinite(fxRate) || fxRate <= 0)) {
       return NextResponse.json({ error: 'USD 종목은 유효한 환율이 필요합니다.' }, { status: 400 })
     }
-    if (tradedAt !== undefined && (typeof tradedAt !== 'string' || isNaN(Date.parse(tradedAt)))) {
-      return NextResponse.json({ error: '유효한 거래일을 입력해주세요.' }, { status: 400 })
+    if (tradedAt !== undefined) {
+      if (typeof tradedAt !== 'string') {
+        return NextResponse.json({ error: '유효한 거래일을 입력해주세요.' }, { status: 400 })
+      }
+      const tradedAtError = validateTradedAt(tradedAt)
+      if (tradedAtError) {
+        return NextResponse.json({ error: tradedAtError }, { status: 400 })
+      }
     }
 
     const updatedShares = shares ?? trade.shares

--- a/src/app/api/trades/import/route.ts
+++ b/src/app/api/trades/import/route.ts
@@ -69,8 +69,11 @@ export async function POST(request: NextRequest) {
         resultErrors.push({ row: i + 1, field: 'row', message: '잘못된 데이터 형식입니다.' })
         continue
       }
-      const ticker = typeof t.ticker === 'string' ? t.ticker : String(t.ticker ?? '')
-      const displayName = typeof t.displayName === 'string' ? t.displayName : ticker
+      // ticker 사전 정규화 — validation/storage 모두 동일 값 사용
+      const rawTicker = typeof t.ticker === 'string' ? t.ticker : String(t.ticker ?? '')
+      const ticker = rawTicker.trim().toUpperCase()
+      const rawDisplayName = typeof t.displayName === 'string' ? t.displayName.trim() : ''
+      const displayName = rawDisplayName || ticker
       const tradeType = typeof t.type === 'string' ? t.type : String(t.type ?? '')
       const shares = typeof t.shares === 'number' ? t.shares : Number(t.shares)
       const price = typeof t.price === 'number' ? t.price : Number(t.price)
@@ -79,7 +82,7 @@ export async function POST(request: NextRequest) {
       const errors = validateTradeInput({
         accountId,
         ticker,
-        displayName: displayName || ticker,
+        displayName,
         market,
         type: tradeType,
         shares,
@@ -96,8 +99,8 @@ export async function POST(request: NextRequest) {
       } else {
         validTrades.push({
           index: i,
-          ticker: ticker.toUpperCase().trim(),
-          displayName: displayName || ticker,
+          ticker,
+          displayName,
           type: tradeType as 'BUY' | 'SELL',
           shares,
           price,

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -60,13 +60,17 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const errors = validateTradeInput(body)
+    // ticker 사전 정규화 — validation/storage 모두 동일 값 사용
+    const normalizedTicker = typeof body.ticker === 'string'
+      ? body.ticker.trim().toUpperCase()
+      : ''
+    const errors = validateTradeInput({ ...body, ticker: normalizedTicker })
     if (errors.length > 0) {
       return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
     }
 
     const { accountId, displayName, market, type, shares, price, currency, fxRate, note, tradedAt } = body
-    const ticker = (body.ticker as string).toUpperCase().trim()
+    const ticker = normalizedTicker
 
     // 계좌 존재 확인
     const account = await prisma.account.findUnique({ where: { id: accountId } })

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -60,17 +60,25 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    // ticker 사전 정규화 — validation/storage 모두 동일 값 사용
+    // ticker / displayName 사전 정규화 — validation/storage 모두 동일 값 사용.
+    // displayName 누락 시 normalized ticker로 fallback (import 경로와 동일 거동).
     const normalizedTicker = typeof body.ticker === 'string'
       ? body.ticker.trim().toUpperCase()
       : ''
-    const errors = validateTradeInput({ ...body, ticker: normalizedTicker })
+    const rawDisplayName = typeof body.displayName === 'string' ? body.displayName.trim() : ''
+    const normalizedDisplayName = rawDisplayName || normalizedTicker
+    const errors = validateTradeInput({
+      ...body,
+      ticker: normalizedTicker,
+      displayName: normalizedDisplayName,
+    })
     if (errors.length > 0) {
       return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
     }
 
-    const { accountId, displayName, market, type, shares, price, currency, fxRate, note, tradedAt } = body
+    const { accountId, market, type, shares, price, currency, fxRate, note, tradedAt } = body
     const ticker = normalizedTicker
+    const displayName = normalizedDisplayName
 
     // 계좌 존재 확인
     const account = await prisma.account.findUnique({ where: { id: accountId } })

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -93,6 +93,9 @@ export interface TradeValidationError {
   message: string
 }
 
+const ONE_DAY_MS = 86_400_000
+const MIN_TRADE_DATE_MS = Date.UTC(2000, 0, 1)
+
 export function validateTradeInput(body: {
   accountId?: string
   ticker?: string
@@ -139,11 +142,10 @@ export function validateTradeInput(body: {
   } else {
     const ts = Date.parse(body.tradedAt)
     // 미래 1일 grace — KST 사용자가 자정 직후 입력하면 UTC로는 어제일 수 있음
-    const maxFuture = Date.now() + 86_400_000
-    const minDate = Date.UTC(2000, 0, 1)
+    const maxFuture = Date.now() + ONE_DAY_MS
     if (ts > maxFuture) {
       errors.push({ field: 'tradedAt', message: '미래 날짜는 입력할 수 없습니다.' })
-    } else if (ts < minDate) {
+    } else if (ts < MIN_TRADE_DATE_MS) {
       errors.push({ field: 'tradedAt', message: '2000-01-01 이후 날짜를 입력해주세요.' })
     }
   }

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -93,21 +93,30 @@ export interface TradeValidationError {
   message: string
 }
 
-const ONE_DAY_MS = 86_400_000
-const MIN_TRADE_DATE_MS = Date.UTC(2000, 0, 1)
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+const MIN_TRADE_DATE = '2000-01-01'
+
+/** ms 타임스탬프를 KST 캘린더 날짜 문자열(YYYY-MM-DD)로 변환 */
+function toKSTDateString(ms: number): string {
+  const d = new Date(ms + KST_OFFSET_MS)
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
+}
 
 /**
  * 거래일 문자열을 검증한다. 통과 시 null, 실패 시 사용자 메시지 반환.
  * - parse 불가
- * - 미래 1일 grace 초과 (KST 자정 직후 입력 케이스 허용)
+ * - KST 캘린더 기준 오늘보다 미래 (사용자 KST 기준 "내일 이후" 입력 차단)
  * - 2000-01-01 미만
+ *
+ * 단순한 `Date.now() + 1일` grace는 KST 사용자가 오후~저녁에 내일 날짜(UTC midnight
+ * 기준 < now+24h)를 입력하면 통과시키는 결함이 있어, KST 캘린더 날짜로 직접 비교.
  */
 export function validateTradedAt(tradedAt: string | undefined | null): string | null {
   if (!tradedAt || isNaN(Date.parse(tradedAt))) return '유효한 거래일을 입력해주세요.'
-  const ts = Date.parse(tradedAt)
-  const maxFuture = Date.now() + ONE_DAY_MS
-  if (ts > maxFuture) return '미래 날짜는 입력할 수 없습니다.'
-  if (ts < MIN_TRADE_DATE_MS) return '2000-01-01 이후 날짜를 입력해주세요.'
+  const tradedAtKST = toKSTDateString(Date.parse(tradedAt))
+  const todayKST = toKSTDateString(Date.now())
+  if (tradedAtKST > todayKST) return '미래 날짜는 입력할 수 없습니다.'
+  if (tradedAtKST < MIN_TRADE_DATE) return '2000-01-01 이후 날짜를 입력해주세요.'
   return null
 }
 

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -96,6 +96,21 @@ export interface TradeValidationError {
 const ONE_DAY_MS = 86_400_000
 const MIN_TRADE_DATE_MS = Date.UTC(2000, 0, 1)
 
+/**
+ * 거래일 문자열을 검증한다. 통과 시 null, 실패 시 사용자 메시지 반환.
+ * - parse 불가
+ * - 미래 1일 grace 초과 (KST 자정 직후 입력 케이스 허용)
+ * - 2000-01-01 미만
+ */
+export function validateTradedAt(tradedAt: string | undefined | null): string | null {
+  if (!tradedAt || isNaN(Date.parse(tradedAt))) return '유효한 거래일을 입력해주세요.'
+  const ts = Date.parse(tradedAt)
+  const maxFuture = Date.now() + ONE_DAY_MS
+  if (ts > maxFuture) return '미래 날짜는 입력할 수 없습니다.'
+  if (ts < MIN_TRADE_DATE_MS) return '2000-01-01 이후 날짜를 입력해주세요.'
+  return null
+}
+
 export function validateTradeInput(body: {
   accountId?: string
   ticker?: string
@@ -137,18 +152,8 @@ export function validateTradeInput(body: {
   if (body.market === 'KR' && body.currency && body.currency !== 'KRW') {
     errors.push({ field: 'currency', message: 'KR 시장은 KRW 통화만 가능합니다.' })
   }
-  if (!body.tradedAt || isNaN(Date.parse(body.tradedAt))) {
-    errors.push({ field: 'tradedAt', message: '유효한 거래일을 입력해주세요.' })
-  } else {
-    const ts = Date.parse(body.tradedAt)
-    // 미래 1일 grace — KST 사용자가 자정 직후 입력하면 UTC로는 어제일 수 있음
-    const maxFuture = Date.now() + ONE_DAY_MS
-    if (ts > maxFuture) {
-      errors.push({ field: 'tradedAt', message: '미래 날짜는 입력할 수 없습니다.' })
-    } else if (ts < MIN_TRADE_DATE_MS) {
-      errors.push({ field: 'tradedAt', message: '2000-01-01 이후 날짜를 입력해주세요.' })
-    }
-  }
+  const tradedAtError = validateTradedAt(body.tradedAt)
+  if (tradedAtError) errors.push({ field: 'tradedAt', message: tradedAtError })
 
   return errors
 }

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -136,6 +136,16 @@ export function validateTradeInput(body: {
   }
   if (!body.tradedAt || isNaN(Date.parse(body.tradedAt))) {
     errors.push({ field: 'tradedAt', message: '유효한 거래일을 입력해주세요.' })
+  } else {
+    const ts = Date.parse(body.tradedAt)
+    // 미래 1일 grace — KST 사용자가 자정 직후 입력하면 UTC로는 어제일 수 있음
+    const maxFuture = Date.now() + 86_400_000
+    const minDate = Date.UTC(2000, 0, 1)
+    if (ts > maxFuture) {
+      errors.push({ field: 'tradedAt', message: '미래 날짜는 입력할 수 없습니다.' })
+    } else if (ts < minDate) {
+      errors.push({ field: 'tradedAt', message: '2000-01-01 이후 날짜를 입력해주세요.' })
+    }
   }
 
   return errors


### PR DESCRIPTION
## 변경 사항

- `src/lib/trade-utils.ts`: `validateTradeInput`에 `tradedAt` 범위 검증 추가
  - 미래 1일 grace 초과 거부 (KST timezone 안전)
  - 2000-01-01 이전 거부
  - 경계값 상수(`ONE_DAY_MS`, `MIN_TRADE_DATE_MS`) 모듈 스코프 추출
- `src/app/api/trades/route.ts`: ticker를 trim+upper 후 validation에 전달 (단일 정규값)
- `src/app/api/trades/import/route.ts`: 동일 패턴 + displayName도 trim 후 fallback

## 배경

Phase 25-A에서 import의 market 비교는 이미 정규화 적용됨. 이번에는 남은 hardening 두 가지:
1. `recalcHolding`이 `tradedAt asc` 정렬로 순회하므로 미래/너무 오래된 trade가 holdings 잔량·평단을 왜곡할 수 있음
2. validation 후 trim+upper하면 displayName fallback이 trim 안 된 ticker를 그대로 사용 → 일관성 깨짐

## 거동 변화

- 단일 거래 POST: `tradedAt = 내일`, `tradedAt = 1999-12-31` → 400 에러
- 단일 거래 POST: `ticker = ' aapl '` → 정상 저장(AAPL), displayName 누락 시 AAPL로 fallback
- CSV import: 행별로 동일 검증, row 단위 에러 보고

## 체크리스트

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] 코드 리뷰 통과 (P1/P2: 0건, P0 1건 반영)

Closes #293