### PR TITLE
[Phase 25-D] USD 거래/배당 환율 검증 강화 (#295)

### DIFF
--- a/docs/specs/295-usd-fxrate-validation.md
+++ b/docs/specs/295-usd-fxrate-validation.md
@@ -1,0 +1,66 @@
+# Phase 25-D: USD 거래/배당 환율 검증 강화
+
+## 목적
+
+USD 통화 거래/배당의 환율 검증을 일관되게 강화한다. 특히 **편집 경로(PUT)에서 환율 미지정 시 기존 값이 손상돼 있으면 `totalKRW = 0`이 되는** 잠재적 데이터 손상 경로를 차단한다.
+
+## 배경
+
+검토 결과:
+- 생성 경로(POST): trade(`trade-utils.ts:128`), dividend(`dividend-utils.ts:43`) 모두 `currency === 'USD' && fxRate <= 0` 거부 — 안전
+- 배당 편집 경로(`dividends/[id]/route.ts:59`): 최종 적용값을 한 번 더 검증 — 안전
+- **거래 편집 경로(`trades/[id]/route.ts:71`)**: `fxRate !== undefined` 일 때만 검증. `fxRate` 미지정으로 PUT 보내면 line 86이 `trade.fxRate`로 fallback. 만약 stored `trade.fxRate`가 어떤 이유로 null/0이면, line 88에서 `updatedFxRate ?? 0`이 적용되어 `totalKRW = 0`으로 silently 저장됨
+
+## 요구사항
+
+- [ ] `validateFxRateForUSD(fxRate)` 공용 헬퍼 추출 (`trade-utils.ts`)
+- [ ] 거래 편집 PUT: 최종 적용 fxRate가 USD인 경우 항상 양수 보장
+- [ ] 배당 편집 PUT: 기존 검증 유지(이미 안전), 동일 헬퍼로 코드 일관성
+- [ ] totalKRW = 0 silent 저장 차단 (USD인데 환율 미존재 시 400 응답)
+
+## 기술 설계
+
+### 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/lib/trade-utils.ts` | `validateFxRateForUSD(fxRate): string \| null` 헬퍼 export |
+| `src/app/api/trades/[id]/route.ts` | 최종 `updatedFxRate` 검증을 PUT 끝부분에 추가 |
+
+### 헬퍼 시그니처
+
+```ts
+/** USD 거래/배당의 환율을 검증. 통과 시 null, 실패 시 사용자 메시지. */
+export function validateFxRateForUSD(fxRate: unknown): string | null {
+  if (typeof fxRate !== 'number' || !Number.isFinite(fxRate) || fxRate <= 0) {
+    return 'USD 종목은 유효한 환율이 필요합니다.'
+  }
+  return null
+}
+```
+
+### 거동 변화
+
+- 생성: 기존 동작 유지 (이미 안전)
+- 거래 편집: USD 거래에 fxRate 누락 + stored 값 손상 시 → 400 응답
+- 배당 편집: 기존 동작 유지 (이미 안전)
+- `recalcHoldingFromTrades`가 정상 fxRate로만 trigger되므로 holdings 평단 왜곡 추가 차단
+
+## 테스트 계획
+
+- [ ] `npm run lint`
+- [ ] `npx tsc --noEmit`
+- [ ] `npm run build`
+- [ ] 수동:
+  - USD 거래에 `fxRate: null` PUT → 400
+  - 손상된 stored fxRate=null인 USD 거래에 shares만 PUT → 400 (silent 0 저장 방지)
+
+## 제외 사항
+
+- 환율 자동 적용 (현재 시세) — 별도 feature (UX 개선 후보), 25-D 범위 외
+- KRW 거래의 fxRate 처리(항상 null) — 변경 없음
+- Asset 입금/이체의 환율 — 25-D 범위 외 (별도 점검)
+
+## 라벨
+
+- `fix`, `P1`, `phase-25`

--- a/src/app/api/dividends/[id]/route.ts
+++ b/src/app/api/dividends/[id]/route.ts
@@ -34,7 +34,7 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       return NextResponse.json({ error: '세금은 0 이상이어야 합니다.' }, { status: 400 })
     }
     if (fxRate !== undefined && fxRate !== null && existing.currency === 'USD') {
-      const fxError = validateFxRateForUSD(fxRate)
+      const fxError = validateFxRateForUSD(fxRate, 'USD 배당')
       if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
     }
     if (reinvested !== undefined && typeof reinvested !== 'boolean') {
@@ -59,7 +59,7 @@ export async function PUT(request: NextRequest, props: RouteParams) {
 
     // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
     if (existing.currency === 'USD') {
-      const fxError = validateFxRateForUSD(nextFxRate)
+      const fxError = validateFxRateForUSD(nextFxRate, 'USD 배당')
       if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
     }
 

--- a/src/app/api/dividends/[id]/route.ts
+++ b/src/app/api/dividends/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calcAmountKRW } from '@/lib/dividend-utils'
+import { validateFxRateForUSD } from '@/lib/trade-utils'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -32,8 +33,9 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     if (taxAmount !== undefined && taxAmount !== null && (typeof taxAmount !== 'number' || !Number.isFinite(taxAmount) || taxAmount < 0)) {
       return NextResponse.json({ error: '세금은 0 이상이어야 합니다.' }, { status: 400 })
     }
-    if (fxRate !== undefined && fxRate !== null && existing.currency === 'USD' && (typeof fxRate !== 'number' || !Number.isFinite(fxRate) || fxRate <= 0)) {
-      return NextResponse.json({ error: 'USD 배당은 유효한 환율이 필요합니다.' }, { status: 400 })
+    if (fxRate !== undefined && fxRate !== null && existing.currency === 'USD') {
+      const fxError = validateFxRateForUSD(fxRate)
+      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
     }
     if (reinvested !== undefined && typeof reinvested !== 'boolean') {
       return NextResponse.json({ error: '재투자 여부는 true/false여야 합니다.' }, { status: 400 })
@@ -55,9 +57,10 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       return NextResponse.json({ error: '세금이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
     }
 
-    // USD는 반드시 유효한 fxRate가 있어야 함
-    if (existing.currency === 'USD' && (!nextFxRate || !Number.isFinite(nextFxRate) || nextFxRate <= 0)) {
-      return NextResponse.json({ error: 'USD 배당은 유효한 환율이 필요합니다.' }, { status: 400 })
+    // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
+    if (existing.currency === 'USD') {
+      const fxError = validateFxRateForUSD(nextFxRate)
+      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
     }
 
     // 서버 측 amountKRW 재계산

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { recalcHolding, validateTradedAt } from '@/lib/trade-utils'
+import { recalcHolding, validateTradedAt, validateFxRateForUSD } from '@/lib/trade-utils'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -68,8 +68,9 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     if (price !== undefined && (typeof price !== 'number' || !Number.isFinite(price) || price <= 0)) {
       return NextResponse.json({ error: '단가는 0보다 큰 숫자여야 합니다.' }, { status: 400 })
     }
-    if (fxRate !== undefined && trade.currency === 'USD' && (typeof fxRate !== 'number' || !Number.isFinite(fxRate) || fxRate <= 0)) {
-      return NextResponse.json({ error: 'USD 종목은 유효한 환율이 필요합니다.' }, { status: 400 })
+    if (fxRate !== undefined && trade.currency === 'USD') {
+      const fxError = validateFxRateForUSD(fxRate)
+      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
     }
     if (tradedAt !== undefined) {
       if (typeof tradedAt !== 'string') {
@@ -84,8 +85,15 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     const updatedShares = shares ?? trade.shares
     const updatedPrice = price ?? trade.price
     const updatedFxRate = fxRate !== undefined ? fxRate : trade.fxRate
+
+    // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
+    if (trade.currency === 'USD') {
+      const fxError = validateFxRateForUSD(updatedFxRate)
+      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+    }
+
     const updatedTotalKRW = trade.currency === 'USD'
-      ? Math.round(updatedPrice * updatedShares * (updatedFxRate ?? 0))
+      ? Math.round(updatedPrice * updatedShares * (updatedFxRate as number))
       : Math.round(updatedPrice * updatedShares)
 
     const result = await prisma.$transaction(async (tx) => {

--- a/src/lib/dividend-utils.ts
+++ b/src/lib/dividend-utils.ts
@@ -2,6 +2,8 @@
  * 배당금 유틸리티: 세율 상수, 입력 검증, 세금 자동 계산
  */
 
+import { validateFxRateForUSD } from './trade-utils'
+
 /** US 배당 원천징수 세율 15% */
 export const US_DIVIDEND_TAX_RATE = 0.15
 
@@ -40,8 +42,9 @@ export function validateDividendInput(body: {
   if (!body.currency || !['USD', 'KRW'].includes(body.currency)) {
     errors.push({ field: 'currency', message: '통화를 선택해주세요 (USD/KRW).' })
   }
-  if (body.currency === 'USD' && (typeof body.fxRate !== 'number' || !Number.isFinite(body.fxRate) || body.fxRate <= 0)) {
-    errors.push({ field: 'fxRate', message: 'USD 배당은 유효한 환율을 입력해야 합니다.' })
+  if (body.currency === 'USD') {
+    const fxError = validateFxRateForUSD(body.fxRate)
+    if (fxError) errors.push({ field: 'fxRate', message: fxError })
   }
 
   return errors

--- a/src/lib/dividend-utils.ts
+++ b/src/lib/dividend-utils.ts
@@ -43,7 +43,7 @@ export function validateDividendInput(body: {
     errors.push({ field: 'currency', message: '통화를 선택해주세요 (USD/KRW).' })
   }
   if (body.currency === 'USD') {
-    const fxError = validateFxRateForUSD(body.fxRate)
+    const fxError = validateFxRateForUSD(body.fxRate, 'USD 배당')
     if (fxError) errors.push({ field: 'fxRate', message: fxError })
   }
 

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -105,10 +105,11 @@ function toKSTDateString(ms: number): string {
 /**
  * USD 거래/배당의 환율을 검증한다. 통과 시 null, 실패 시 사용자 메시지.
  * 양수 + finite number만 허용. null/undefined/0/NaN 모두 거부.
+ * @param label 에러 메시지의 도메인 라벨 (예: 'USD 종목', 'USD 배당')
  */
-export function validateFxRateForUSD(fxRate: unknown): string | null {
+export function validateFxRateForUSD(fxRate: unknown, label = 'USD 종목'): string | null {
   if (typeof fxRate !== 'number' || !Number.isFinite(fxRate) || fxRate <= 0) {
-    return 'USD 종목은 유효한 환율이 필요합니다.'
+    return `${label}은 유효한 환율이 필요합니다.`
   }
   return null
 }

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -103,6 +103,17 @@ function toKSTDateString(ms: number): string {
 }
 
 /**
+ * USD 거래/배당의 환율을 검증한다. 통과 시 null, 실패 시 사용자 메시지.
+ * 양수 + finite number만 허용. null/undefined/0/NaN 모두 거부.
+ */
+export function validateFxRateForUSD(fxRate: unknown): string | null {
+  if (typeof fxRate !== 'number' || !Number.isFinite(fxRate) || fxRate <= 0) {
+    return 'USD 종목은 유효한 환율이 필요합니다.'
+  }
+  return null
+}
+
+/**
  * 거래일 문자열을 검증한다. 통과 시 null, 실패 시 사용자 메시지 반환.
  * - parse 불가
  * - KST 캘린더 기준 오늘보다 미래 (사용자 KST 기준 "내일 이후" 입력 차단)
@@ -152,8 +163,9 @@ export function validateTradeInput(body: {
   if (!body.currency || !['USD', 'KRW'].includes(body.currency)) {
     errors.push({ field: 'currency', message: '통화를 선택해주세요 (USD/KRW).' })
   }
-  if (body.currency === 'USD' && (typeof body.fxRate !== 'number' || !Number.isFinite(body.fxRate) || body.fxRate <= 0)) {
-    errors.push({ field: 'fxRate', message: 'USD 종목은 유효한 환율을 입력해야 합니다.' })
+  if (body.currency === 'USD') {
+    const fxError = validateFxRateForUSD(body.fxRate)
+    if (fxError) errors.push({ field: 'fxRate', message: fxError })
   }
   if (body.market === 'US' && body.currency && body.currency !== 'USD') {
     errors.push({ field: 'currency', message: 'US 시장은 USD 통화만 가능합니다.' })


### PR DESCRIPTION
## 변경 사항

### 헬퍼 추출
- `src/lib/trade-utils.ts`: `validateFxRateForUSD(fxRate, label?): string | null` export
- 호출 단순화: `validateTradeInput` / `validateDividendInput` 모두 헬퍼 호출
- 도메인 라벨 인자로 dividend 메시지("USD 배당") 유지

### 편집 경로 silent 0 차단
- `src/app/api/trades/[id]/route.ts` PUT: 최종 `updatedFxRate`가 USD에 대해 양수 보장
- `src/app/api/dividends/[id]/route.ts` PUT: 동일 헬퍼로 코드 일관성 (기존 안전 로직 유지)

## 배경

**거래 편집 경로의 회귀 시나리오:**
1. USD 거래의 stored `trade.fxRate`가 어떤 이유로 null/0/손상
2. 사용자가 `shares`만 수정해 PUT 호출 (fxRate 미지정)
3. 기존 코드: `updatedFxRate ?? 0` → totalKRW = 0으로 silent 저장
4. 수정 후: stored가 손상되어도 USD인 경우 400 에러로 즉시 차단

배당 편집 경로는 이미 안전했으나 코드 일관성을 위해 동일 헬퍼로 통일.

## 거동 변화

| 시나리오 | 기존 | 신규 |
|---|---|---|
| 생성 (USD, fxRate 누락) | 400 | 400 (변동 없음) |
| 거래 편집 (stored 정상, fxRate 누락) | 통과 | 통과 (변동 없음) |
| 거래 편집 (stored 손상, fxRate 누락) | silent 0 저장 | 400 |
| 배당 편집 | 400 / 안전 | 400 / 안전 |

## 체크리스트

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] 코드 리뷰 통과 (P1/P2: 0건, P0 메시지 라벨 반영. 테스트 인프라 부재는 별도)

Closes #295