### PR TITLE
[Phase 25-E] API 응답 형식 일관화 (#297)

### DIFF
--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -7,3 +7,5 @@
 - Trade 생성 시 Holding 업데이트를 Prisma transaction으로 묶을 것
 - 금액 관련 응답은 항상 currency 필드 포함
 - 날짜는 ISO 8601 형식으로 반환
+- DELETE 핸들러는 본문 없이 `new NextResponse(null, { status: 204 })` 로 응답. `{ success: true }` 등 wrapper 금지
+- catch 블록에서 `error.message` 를 그대로 노출하지 않는다. 사용자에게 보여도 안전한 비즈니스 예외는 `@/lib/api-errors` 의 `businessErrorResponse(err)` 로 통과시키고, 그 외는 한국어 정적 메시지(`'서버 오류가 발생했습니다.'` 등)로 응답

--- a/docs/specs/297-api-response-consistency.md
+++ b/docs/specs/297-api-response-consistency.md
@@ -1,0 +1,84 @@
+# [Phase 25-E] API 응답 형식 일관화
+
+## 목적
+
+`src/app/api/**/route.ts` 의 응답 형식 불일치를 즉시 효과 있는 두 가지에 집중해 해소한다. envelope 통일 같은 대형 마이그레이션은 별도 후속 작업으로 분리.
+
+## 배경
+
+- DELETE 핸들러가 `{ success: true }` 와 `204 No Content` 두 가지로 갈려있어 클라이언트 측 처리 패턴이 흐트러진다.
+- `src/app/api/trades/*` 라우트들은 catch 블록에서 `error.message` 를 그대로 노출한다. 현재는 비즈니스 예외(`보유 수량 부족`, `초과합니다`)만 던지므로 사고는 없지만, 새로운 예외 경로가 추가되면 내부 메시지가 사용자에게 노출될 위험이 있다.
+
+## 요구사항
+
+- [ ] **DELETE 응답 통일**: 모든 DELETE 핸들러가 `new NextResponse(null, { status: 204 })` 또는 동등한 빈 204 응답으로 반환.
+- [ ] **에러 메시지 안전 필터**: `error.message` 노출 경로에 화이트리스트 통과 검사를 추가. 통과 못한 메시지는 `'서버 오류가 발생했습니다.'` 로 대체.
+- [ ] **CLAUDE.md/api-routes.md 규칙 보강**: DELETE = 204, 화이트리스트 패턴 명문화.
+
+## 기술 설계
+
+### 1. DELETE 응답 통일
+
+다음 7개 라우트의 DELETE 핸들러를 204로 통일한다.
+
+| 파일 | 현재 | 변경 후 |
+|---|---|---|
+| `src/app/api/trades/[id]/route.ts` | `NextResponse.json({ success: true })` | `new NextResponse(null, { status: 204 })` |
+| `src/app/api/categories/[id]/route.ts` | 동일 | 동일 |
+| `src/app/api/assets/[id]/route.ts` | 동일 | 동일 |
+| `src/app/api/dividends/[id]/route.ts` | 동일 | 동일 |
+| `src/app/api/deposits/[id]/route.ts` | 동일 | 동일 |
+| `src/app/api/income-profiles/[id]/route.ts` | 동일 | 동일 |
+| `src/app/api/categories/reorder/route.ts` | 동일 | 동일 |
+
+클라이언트 사이드 점검:
+- 모든 DELETE 호출자는 `res.ok` 만 확인하고 성공 본문을 파싱하지 않음을 확인했다. body 파싱은 에러 경로에서만 일어난다. 변경 안전.
+
+### 2. 에러 메시지 안전 필터
+
+`src/lib/api-errors.ts` (신규) 에 화이트리스트 헬퍼 한 쌍을 둔다. 패턴은 실제로 `throw` 되는 비즈니스 메시지만 정확히 잠그도록 종단까지 명시한다.
+
+```ts
+const SAFE_BUSINESS_PATTERNS: ReadonlyArray<(msg: string) => boolean> = [
+  (m) => m.startsWith('보유 수량 부족'),                                  // recalcHolding
+  (m) => m.includes('보유 수량(') && m.includes('초과합니다'),             // createTrade
+  (m) => m.includes('이미 ') && m.includes('등록되어 있'),                 // createTrade (티커 충돌)
+]
+
+export function isSafeBusinessError(err: unknown): err is Error {
+  return err instanceof Error && SAFE_BUSINESS_PATTERNS.some((p) => p(err.message))
+}
+
+export function businessErrorResponse(err: unknown): NextResponse | null {
+  if (!isSafeBusinessError(err)) return null
+  return NextResponse.json({ error: err.message }, { status: 400 })
+}
+```
+
+적용 라우트(3개):
+- `src/app/api/trades/route.ts` POST catch → `businessErrorResponse(err) ?? '거래 기록에 실패했습니다.'`
+- `src/app/api/trades/[id]/route.ts` PUT catch → 동일 패턴
+- `src/app/api/trades/[id]/route.ts` DELETE catch → 정적 메시지("이 거래를 삭제하면 ...")로 치환해야 하므로 `isSafeBusinessError` 만 사용
+- `src/app/api/trades/import/route.ts` POST catch → 동일 패턴
+
+향후 새 비즈니스 예외 메시지를 노출하려면 `SAFE_BUSINESS_PATTERNS` 에 종단까지 명시한 패턴을 추가한다. 짧은 부사/동사(`'이미'`, `'초과합니다'`) 단독 매칭은 피한다 — 외부 라이브러리 메시지가 우연히 통과될 수 있다.
+
+### 3. 규칙 문서 보강
+
+`.claude/rules/api-routes.md` 항목 추가:
+- DELETE 핸들러는 본문 없이 204 No Content 로 응답.
+- catch 블록에서 `error.message` 를 직접 노출하지 않는다. 비즈니스 예외만 `safeErrorMessage()` 화이트리스트로 통과시킨다.
+
+## 테스트 계획
+
+- 거래 삭제 → 클라이언트가 정상적으로 닫히는지 (`/trades` 페이지 + 삭제 모달)
+- 카테고리/자산/배당/예금 삭제 → 동일 회귀 테스트
+- 거래 생성 시 `보유 수량 부족` 케이스 발생 → 메시지가 사용자에게 그대로 노출
+- 거래 생성 시 알 수 없는 DB 에러 발생 → `'서버 오류가 발생했습니다.'` 노출 (직접 검증 어려움 → 화이트리스트 단위 테스트로 보강)
+- `isSafeBusinessError` / `businessErrorResponse` 단위 테스트는 Phase 25-F 에서 vitest 도입 후 함께 추가 (현재 프로젝트에 테스트 러너 미설치)
+
+## 제외 사항
+
+- 응답 envelope (`ApiResponse<T>`) 전면 도입 — 53개 라우트 + 클라이언트 fetcher까지 영향. 별도 이슈로.
+- POST/PUT 응답 키 일관화 (`{ resource }` vs raw) — 영향 범위 동일.
+- DELETE 외 메서드의 에러 메시지 노출 패턴 — 현재 trades 외에는 모두 정적 메시지 사용. 신규 추가 시점에 가이드 적용.

--- a/src/app/api/assets/[id]/route.ts
+++ b/src/app/api/assets/[id]/route.ts
@@ -117,7 +117,7 @@ export async function DELETE(_request: NextRequest, props: { params: Promise<{ i
     }
 
     await prisma.asset.delete({ where: { id } })
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
     console.error('DELETE /api/assets/[id] error:', error)
     return NextResponse.json({ error: '자산 삭제에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -166,7 +166,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
     }
 
     await prisma.category.delete({ where: { id: params.id } })
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === 'P2003') {

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
       )
     )
 
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       return NextResponse.json(

--- a/src/app/api/deposits/[id]/route.ts
+++ b/src/app/api/deposits/[id]/route.ts
@@ -95,7 +95,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
         })
       }
     })
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
     console.error('DELETE /api/deposits/[id] error:', error)
     return NextResponse.json({ error: '입금 삭제에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/dividends/[id]/route.ts
+++ b/src/app/api/dividends/[id]/route.ts
@@ -96,7 +96,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
     }
 
     await prisma.dividend.delete({ where: { id: params.id } })
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
     console.error('DELETE /api/dividends/[id] error:', error)
     return NextResponse.json({ error: '배당 삭제에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/income-profiles/[id]/route.ts
+++ b/src/app/api/income-profiles/[id]/route.ts
@@ -78,7 +78,7 @@ export async function DELETE(_request: NextRequest, props: { params: Promise<{ i
   try {
     const { id } = params
     await prisma.incomeProfile.delete({ where: { id } })
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
     return handlePrismaError(error, '근로소득 프로필 삭제')
   }

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, validateTradedAt, validateFxRateForUSD } from '@/lib/trade-utils'
+import { businessErrorResponse, isSafeBusinessError } from '@/lib/api-errors'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -119,9 +120,8 @@ export async function PUT(request: NextRequest, props: RouteParams) {
 
     return NextResponse.json(result)
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('보유 수량 부족')) {
-      return NextResponse.json({ error: error.message }, { status: 400 })
-    }
+    const businessResponse = businessErrorResponse(error)
+    if (businessResponse) return businessResponse
     console.error('PUT /api/trades/[id] error:', error)
     return NextResponse.json({ error: '거래 수정에 실패했습니다.' }, { status: 500 })
   }
@@ -144,9 +144,9 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
       )
     }, { isolationLevel: 'Serializable' })
 
-    return NextResponse.json({ success: true })
+    return new NextResponse(null, { status: 204 })
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('보유 수량 부족')) {
+    if (isSafeBusinessError(error) && error.message.startsWith('보유 수량 부족')) {
       return NextResponse.json({ error: '이 거래를 삭제하면 보유 수량이 음수가 됩니다.' }, { status: 400 })
     }
     console.error('DELETE /api/trades/[id] error:', error)

--- a/src/app/api/trades/import/route.ts
+++ b/src/app/api/trades/import/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW, validateTradeInput } from '@/lib/trade-utils'
 import { normalizeMarket } from '@/lib/market-hours'
+import { businessErrorResponse } from '@/lib/api-errors'
 import type { ImportResult } from '@/types/csv-import'
 
 export const dynamic = 'force-dynamic'
@@ -303,9 +304,8 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ result }, { status: 201 })
   } catch (error) {
-    if (error instanceof Error && (error.message.includes('초과합니다') || error.message.startsWith('보유 수량 부족'))) {
-      return NextResponse.json({ error: error.message }, { status: 400 })
-    }
+    const businessResponse = businessErrorResponse(error)
+    if (businessResponse) return businessResponse
     console.error('POST /api/trades/import error:', error)
     return NextResponse.json(
       { error: '거래 일괄 등록에 실패했습니다.' },

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateTradeInput } from '@/lib/trade-utils'
 import { createTrade } from '@/lib/trade-service'
+import { businessErrorResponse } from '@/lib/api-errors'
 
 export const dynamic = 'force-dynamic'
 
@@ -102,13 +103,8 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result, { status: 201 })
   } catch (error) {
-    if (error instanceof Error && (
-      error.message.includes('초과합니다') ||
-      error.message.startsWith('보유 수량 부족') ||
-      error.message.includes('이미')
-    )) {
-      return NextResponse.json({ error: error.message }, { status: 400 })
-    }
+    const businessResponse = businessErrorResponse(error)
+    if (businessResponse) return businessResponse
     console.error('POST /api/trades error:', error)
     return NextResponse.json(
       { error: '거래 기록에 실패했습니다.' },

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+// 사용자에게 노출해도 안전한 비즈니스 예외 메시지를 식별하는 화이트리스트.
+// 새 메시지를 추가할 때는 우연 매칭을 피하기 위해 메시지 형식을 명시적으로 잠근다.
+const SAFE_BUSINESS_PATTERNS: ReadonlyArray<(msg: string) => boolean> = [
+  (m) => m.startsWith('보유 수량 부족'),
+  (m) => m.includes('보유 수량(') && m.includes('초과합니다'),
+  (m) => m.includes('이미 ') && m.includes('등록되어 있'),
+]
+
+export function isSafeBusinessError(err: unknown): err is Error {
+  return err instanceof Error && SAFE_BUSINESS_PATTERNS.some((p) => p(err.message))
+}
+
+export function businessErrorResponse(err: unknown): NextResponse | null {
+  if (!isSafeBusinessError(err)) return null
+  return NextResponse.json({ error: err.message }, { status: 400 })
+}


### PR DESCRIPTION
## 요약

`src/app/api/**/route.ts` 의 응답 형식 불일치를 즉시 효과 있는 두 가지에 집중해 해소.

### 변경
1. **DELETE 응답 통일 → 204 No Content**
   - `/api/trades/[id]`, `/api/categories/[id]`, `/api/assets/[id]`, `/api/dividends/[id]`, `/api/deposits/[id]`, `/api/income-profiles/[id]` DELETE 핸들러
   - `/api/categories/reorder` POST (응답 본문이 의미상 없는 케이스)
   - 기존 `{ success: true }` → `new NextResponse(null, { status: 204 })`
2. **에러 메시지 안전 필터 도입** (`src/lib/api-errors.ts`)
   - `isSafeBusinessError(err)` / `businessErrorResponse(err)`
   - `SAFE_BUSINESS_PATTERNS` 는 throw 메시지 종단까지 잠가 우연 매칭 차단
   - `trades`, `trades/[id]`, `trades/import` catch 분기를 헬퍼로 통합
3. **규칙 문서 보강** (`.claude/rules/api-routes.md`)
   - DELETE = 204, catch 화이트리스트 패턴 명문화

### 클라이언트 호환성
13개 DELETE/reorder 호출자 점검: 모두 `res.ok` 만 확인하고 성공 시 body 파싱하지 않음. 회귀 없음.

### 제외 (별도 phase)
- 응답 envelope (`ApiResponse<T>`) 전면 도입 — 53개 라우트 + 클라이언트 fetcher 영향
- POST/PUT 응답 키 일관화
- `isSafeBusinessError` / `businessErrorResponse` 단위 테스트 — Phase 25-F 에서 vitest 도입 시 함께 추가

Closes #297

## 체크리스트
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건, 2회차 통과)

## 코드 리뷰 결과
- **1차**: P2=0 / P1=2 (스펙↔구현 불일치, `'이미'` 광범위 매칭) / P0=3
- **2차**: P2=0 / P1=0 / P0=0 ✅