### PR TITLE
[Phase 25-F] 핵심 입력 헬퍼 Zod 통합 + vitest 도입 (#299)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ npx prisma studio        # DB 브라우저 GUI
 
 검증 순서 (PR 전 필수):
 ```bash
-npm run lint && npx tsc --noEmit && npm run build
+npm run lint && npx tsc --noEmit && npm run test:run && npm run build
 ```
 
 배포 (서버):

--- a/docs/specs/299-zod-core-validation.md
+++ b/docs/specs/299-zod-core-validation.md
@@ -1,0 +1,146 @@
+# [Phase 25-F] 입력 검증 Zod 통합 (핵심 입력 경로)
+
+## 목적
+
+핵심 입력 경로 3개 (`trade-utils`, `dividend-utils`, `transaction-utils`) 의 `validate*Input` 헬퍼 내부를 Zod schema 기반으로 전환한다. 호출 측 시그니처 (`ValidationError[]` 반환) 는 유지해 API 라우트 코드는 무변경. 동시에 vitest 를 도입해 헬퍼 단위 테스트 + 25-E 에서 위임한 `api-errors` 테스트 빚을 청산한다.
+
+## 배경
+
+- 인라인 `typeof` / `Number.isFinite` / `includes` 검증이 헬퍼 3개에 흩어져 있다. 단일 진실 표현이 어려워 25-D 같이 검증 로직이 늘어날 때 회귀 위험이 커진다.
+- Zod schema 는 의도 표현과 타입 추론을 동시에 제공한다. 글로벌 룰 (`coding-style.md` Input Validation 항) 권장 사항.
+- 테스트 러너 부재 → 검증 로직 회귀가 자동 검출되지 않는다.
+
+## 요구사항
+
+- [ ] `zod` 런타임 의존성 추가
+- [ ] `vitest` + `@vitest/coverage-v8` dev 의존성 추가
+- [ ] `package.json` 스크립트: `test`, `test:run`, `test:coverage`
+- [ ] `trade-utils.ts` 의 `validateTradeInput` 내부를 Zod schema 로 전환 (외부 시그니처 동일)
+- [ ] `dividend-utils.ts` 의 `validateDividendInput` 동일 전환
+- [ ] `transaction-utils.ts` 의 `validateTransactionInput` 동일 전환
+- [ ] `src/lib/__tests__/api-errors.test.ts` 추가 (25-E 빚 청산)
+- [ ] `src/lib/__tests__/trade-utils.test.ts` 추가 (Zod 전환된 schema 회귀 방지)
+- [ ] `src/lib/__tests__/dividend-utils.test.ts` 추가
+- [ ] `src/lib/__tests__/transaction-utils.test.ts` 추가
+- [ ] `CLAUDE.md` 검증 순서에 `npm test` 추가
+
+## 기술 설계
+
+### 1. 어댑터 패턴
+
+Zod 의 `ZodError` 를 기존 `ValidationError[]` 시그니처로 매핑하는 헬퍼를 `src/lib/zod-utils.ts` (신규) 에 둔다.
+
+```ts
+import { ZodError, ZodIssue } from 'zod'
+
+export interface ValidationError {
+  field: string
+  message: string
+}
+
+export function zodErrorsToValidation(err: ZodError): ValidationError[] {
+  return err.issues.map((issue: ZodIssue) => ({
+    field: issue.path.join('.') || issue.path[0]?.toString() || '_',
+    message: issue.message,
+  }))
+}
+```
+
+각 `validate*Input` 은 schema.safeParse(body) → 실패 시 어댑터, 성공 시 빈 배열.
+
+### 2. trade-utils — Zod schema
+
+```ts
+const TradeInputSchema = z.object({
+  accountId: z.string().min(1, '계좌를 선택해주세요.'),
+  ticker: z.string().trim().min(1, '종목을 선택해주세요.'),
+  displayName: z.string().trim().min(1, '종목명을 입력해주세요.'),
+  market: z.enum(['US', 'KR'], { errorMap: () => ({ message: '시장을 선택해주세요 (US/KR).' }) }),
+  type: z.enum(['BUY', 'SELL'], { errorMap: () => ({ message: '거래 유형을 선택해주세요 (BUY/SELL).' }) }),
+  shares: z.number().int().positive().finite({ message: '수량은 1 이상의 정수여야 합니다.' }),
+  price: z.number().positive().finite({ message: '단가는 0보다 큰 숫자여야 합니다.' }),
+  currency: z.enum(['USD', 'KRW'], { errorMap: () => ({ message: '통화를 선택해주세요 (USD/KRW).' }) }),
+  // fxRate / tradedAt 은 USD 분기 + validateTradedAt 헬퍼가 한국어 메시지로 통일 처리.
+  // schema 단계 type-level 영문 메시지 ('Invalid input: expected number, received NaN' 등)
+  // 가 사용자에게 노출되지 않도록 unknown 으로 받는다. CSV import 의 Number(...) → NaN 케이스 동일 경로.
+  fxRate: z.unknown().optional(),
+  tradedAt: z.unknown().optional(),
+}).superRefine((data, ctx) => {
+  if (data.currency === 'USD') {
+    const e = validateFxRateForUSD(data.fxRate)
+    if (e) ctx.addIssue({ code: 'custom', path: ['fxRate'], message: e })
+  }
+  if (data.market === 'US' && data.currency && data.currency !== 'USD') {
+    ctx.addIssue({ code: 'custom', path: ['currency'], message: 'US 시장은 USD 통화만 가능합니다.' })
+  }
+  if (data.market === 'KR' && data.currency && data.currency !== 'KRW') {
+    ctx.addIssue({ code: 'custom', path: ['currency'], message: 'KR 시장은 KRW 통화만 가능합니다.' })
+  }
+  const tradedAtError = validateTradedAt(data.tradedAt)
+  if (tradedAtError) ctx.addIssue({ code: 'custom', path: ['tradedAt'], message: tradedAtError })
+})
+```
+
+기존 헬퍼 `validateFxRateForUSD`, `validateTradedAt` 은 그대로 호출 — KST 캘린더 비교 같은 복잡한 도메인 로직은 함수형 유지가 더 명확.
+
+### 3. dividend-utils — Zod schema
+
+`validateTradeInput` 과 동일 패턴. `superRefine` 으로 currency==='USD' 환율 검증.
+
+### 4. transaction-utils — Zod schema
+
+`amount` 의 `≤ 2_147_483_647` 상한, `type` 의 transfer 유형 + linkedAssetId 의존 검증을 `superRefine` 으로 표현.
+
+### 5. vitest 셋업
+
+`vitest.config.ts`:
+```ts
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+})
+```
+
+`vite-tsconfig-paths` 도 dev 의존성으로 추가 (`@/lib/...` alias 해소).
+
+### 6. 단위 테스트 케이스 (요약)
+
+- `api-errors.test.ts`:
+  - 화이트리스트 매칭 (3 케이스)
+  - 비매칭 (3 케이스: `'USD 거래에는 유효한 환율이 필요합니다.'`, `'random'`, `'이미 처리됨'`)
+  - `businessErrorResponse` 의 NextResponse 반환 형식 (`status: 400`, `body.error`)
+- `trade-utils.test.ts`:
+  - 정상 케이스 (KRW BUY, USD BUY)
+  - 각 필수 필드 누락
+  - 음수/0 수량 / 음수 단가
+  - USD 환율 0/NaN/null
+  - market-currency 교차검증 위반
+  - 미래 거래일 / 2000-01-01 미만
+- `dividend-utils.test.ts`:
+  - 정상 KRW / USD
+  - 음수 amountGross / amountNet
+  - USD 환율 검증
+- `transaction-utils.test.ts`:
+  - 정상 / amount=0 / amount > INT32 max
+  - description 200자 초과
+  - transfer_out 인데 linkedAssetId 누락
+  - 잘못된 type 문자열
+
+## 테스트 계획
+
+- `npm run lint` / `npx tsc --noEmit` / `npm test` / `npm run build` 전부 통과
+- 단위 테스트 커버리지 신규 헬퍼 90%+
+- 거래 생성/배당 생성/가계부 거래 등록을 수동 회귀 (Zod 메시지가 그대로 사용자에게 노출되는지)
+
+## 제외 사항
+
+- `validateTradedAt`, `validateFxRateForUSD` 같은 필드 단위 헬퍼 — 함수형 유지 (PUT 부분 업데이트 경로에서 그대로 사용됨)
+- budgets / categories / assets / watchlist / rsu / stock-options / deposits / income-profiles 라우트 — 별도 phase
+- 클라이언트 폼 측 Zod 통합 (서버 single source of truth 우선)
+- GET 쿼리 파라미터 Zod (`searchParams.get`) — 후속 phase

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-dom": "^19.2.7",
         "recharts": "^3.7.0",
         "trading-signals": "^7.4.3",
-        "yahoo-finance2": "^3.13.2"
+        "yahoo-finance2": "^3.13.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/dompurify": "^3.0.5",
@@ -33,6 +34,7 @@
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "^0.27.4",
         "eslint": "^8",
         "eslint-config-next": "^15.5.16",
@@ -40,7 +42,9 @@
         "prisma": "^6.19.2",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -85,6 +89,42 @@
         }
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
@@ -92,6 +132,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@deno/shim-deno": {
@@ -1834,6 +1898,356 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1878,6 +2292,17 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1943,6 +2368,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -1952,6 +2384,13 @@
       "dependencies": {
         "@types/trusted-types": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2578,6 +3017,162 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2919,10 +3514,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3266,6 +3890,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3439,6 +4073,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -4038,6 +4679,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4612,6 +5260,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4674,6 +5332,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5245,6 +5913,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5394,6 +6069,13 @@
       "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
       "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
       "license": "ISC"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -6012,6 +6694,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6255,6 +6976,46 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {
@@ -6818,6 +7579,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/ohash": {
@@ -7731,6 +8506,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -8109,6 +8929,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -8134,6 +8961,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8142,6 +8976,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8494,6 +9335,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -8550,6 +9398,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -8683,6 +9541,27 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -9026,6 +9905,81 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
@@ -9038,6 +9992,639 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/webidl-conversions": {
@@ -9160,6 +10747,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9215,9 +10819,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build:mcp": "esbuild src/mcp/server.ts --bundle --platform=node --target=node20 --outfile=dist/mcp/server.cjs --alias:@=./src --external:@prisma/client --external:@modelcontextprotocol/sdk",
     "build:bot": "esbuild src/bot/standalone.ts --bundle --platform=node --target=node20 --outfile=dist/bot/standalone.cjs --alias:@=./src --external:@prisma/client --external:grammy --external:node-cron --external:yahoo-finance2 --external:trading-signals --external:dotenv",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -30,7 +33,8 @@
     "react-dom": "^19.2.7",
     "recharts": "^3.7.0",
     "trading-signals": "^7.4.3",
-    "yahoo-finance2": "^3.13.2"
+    "yahoo-finance2": "^3.13.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
@@ -39,6 +43,7 @@
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.27.4",
     "eslint": "^8",
     "eslint-config-next": "^15.5.16",
@@ -46,6 +51,8 @@
     "prisma": "^6.19.2",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.8"
   }
 }

--- a/src/lib/__tests__/api-errors.test.ts
+++ b/src/lib/__tests__/api-errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { businessErrorResponse, isSafeBusinessError } from '../api-errors'
+
+describe('isSafeBusinessError', () => {
+  it('보유 수량 부족 메시지 매칭', () => {
+    expect(isSafeBusinessError(new Error('보유 수량 부족: 5주 매도 시도, 현재 2주'))).toBe(true)
+  })
+
+  it('보유 수량 초과 메시지 매칭', () => {
+    expect(isSafeBusinessError(new Error('보유 수량(10주)을 초과합니다.'))).toBe(true)
+  })
+
+  it('이미 등록된 티커 메시지 매칭', () => {
+    expect(
+      isSafeBusinessError(new Error('AAPL은(는) 이미 US/USD로 등록되어 있습니다.'))
+    ).toBe(true)
+  })
+
+  it('USD 환율 누락 메시지는 화이트리스트 외부', () => {
+    expect(
+      isSafeBusinessError(new Error('USD 거래에는 유효한 환율이 필요합니다.'))
+    ).toBe(false)
+  })
+
+  it('일반 에러 메시지 차단', () => {
+    expect(isSafeBusinessError(new Error('random error'))).toBe(false)
+  })
+
+  it('"이미" 단독 substring 만으로는 매칭 안 됨 (우연 매칭 차단)', () => {
+    expect(isSafeBusinessError(new Error('이미 처리됨'))).toBe(false)
+  })
+
+  it('"초과합니다" 단독 substring 만으로는 매칭 안 됨', () => {
+    expect(isSafeBusinessError(new Error('한도 초과합니다'))).toBe(false)
+  })
+
+  it('Error 인스턴스 아닌 값은 false', () => {
+    expect(isSafeBusinessError('보유 수량 부족: ...')).toBe(false)
+    expect(isSafeBusinessError(null)).toBe(false)
+    expect(isSafeBusinessError(undefined)).toBe(false)
+    expect(isSafeBusinessError({ message: '보유 수량 부족: ...' })).toBe(false)
+  })
+})
+
+describe('businessErrorResponse', () => {
+  it('화이트리스트 매칭 시 400 + 메시지 응답', async () => {
+    const res = businessErrorResponse(new Error('보유 수량 부족: 5주'))
+    expect(res).not.toBeNull()
+    expect(res?.status).toBe(400)
+    const body = await res?.json()
+    expect(body).toEqual({ error: '보유 수량 부족: 5주' })
+  })
+
+  it('화이트리스트 외부는 null 반환', () => {
+    expect(businessErrorResponse(new Error('random'))).toBeNull()
+    expect(businessErrorResponse('보유 수량 부족: ...')).toBeNull()
+  })
+})

--- a/src/lib/__tests__/dividend-utils.test.ts
+++ b/src/lib/__tests__/dividend-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { validateDividendInput } from '../dividend-utils'
+
+const baseKRW = {
+  accountId: 'acc_1',
+  ticker: '005930',
+  displayName: '삼성전자',
+  payDate: '2024-04-15',
+  amountGross: 1000,
+  amountNet: 846,
+  currency: 'KRW',
+}
+
+const baseUSD = {
+  accountId: 'acc_2',
+  ticker: 'AAPL',
+  displayName: 'Apple Inc.',
+  payDate: '2024-05-15',
+  amountGross: 1.5,
+  amountNet: 1.28,
+  currency: 'USD',
+  fxRate: 1340,
+}
+
+describe('validateDividendInput — 정상', () => {
+  it('KRW 정상', () => {
+    expect(validateDividendInput(baseKRW)).toEqual([])
+  })
+  it('USD 정상', () => {
+    expect(validateDividendInput(baseUSD)).toEqual([])
+  })
+})
+
+describe('validateDividendInput — 필수 필드', () => {
+  it('accountId 누락', () => {
+    const errors = validateDividendInput({ ...baseKRW, accountId: undefined })
+    expect(errors.find((e) => e.field === 'accountId')?.message).toBe('계좌를 선택해주세요.')
+  })
+  it('ticker 공백', () => {
+    const errors = validateDividendInput({ ...baseKRW, ticker: '   ' })
+    expect(errors.find((e) => e.field === 'ticker')?.message).toBe('종목을 선택해주세요.')
+  })
+  it('displayName 누락', () => {
+    const errors = validateDividendInput({ ...baseKRW, displayName: '' })
+    expect(errors.find((e) => e.field === 'displayName')?.message).toBe('종목명을 입력해주세요.')
+  })
+})
+
+describe('validateDividendInput — 형식', () => {
+  it('payDate parse 불가', () => {
+    const errors = validateDividendInput({ ...baseKRW, payDate: 'not-a-date' })
+    expect(errors.find((e) => e.field === 'payDate')?.message).toBe('유효한 지급일을 입력해주세요.')
+  })
+  it('amountGross 0', () => {
+    const errors = validateDividendInput({ ...baseKRW, amountGross: 0 })
+    expect(errors.find((e) => e.field === 'amountGross')?.message).toBe(
+      '세전 금액은 0보다 커야 합니다.'
+    )
+  })
+  it('amountGross 음수', () => {
+    const errors = validateDividendInput({ ...baseKRW, amountGross: -10 })
+    expect(errors.find((e) => e.field === 'amountGross')?.message).toBe(
+      '세전 금액은 0보다 커야 합니다.'
+    )
+  })
+  it('amountNet 음수', () => {
+    const errors = validateDividendInput({ ...baseKRW, amountNet: -1 })
+    expect(errors.find((e) => e.field === 'amountNet')?.message).toBe(
+      '세후 금액은 0 이상이어야 합니다.'
+    )
+  })
+  it('amountNet 0 은 허용', () => {
+    const errors = validateDividendInput({ ...baseKRW, amountNet: 0 })
+    expect(errors.find((e) => e.field === 'amountNet')).toBeUndefined()
+  })
+  it('잘못된 currency', () => {
+    const errors = validateDividendInput({ ...baseKRW, currency: 'JPY' })
+    expect(errors.find((e) => e.field === 'currency')?.message).toBe('통화를 선택해주세요 (USD/KRW).')
+  })
+})
+
+describe('validateDividendInput — USD 환율', () => {
+  it('환율 누락', () => {
+    const errors = validateDividendInput({ ...baseUSD, fxRate: null })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toBe('USD 배당은 유효한 환율이 필요합니다.')
+  })
+  it('환율 0', () => {
+    const errors = validateDividendInput({ ...baseUSD, fxRate: 0 })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toBe('USD 배당은 유효한 환율이 필요합니다.')
+  })
+  it('환율 음수', () => {
+    const errors = validateDividendInput({ ...baseUSD, fxRate: -1300 })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toBe('USD 배당은 유효한 환율이 필요합니다.')
+  })
+  it('환율 NaN (CSV import 호환)', () => {
+    const errors = validateDividendInput({ ...baseUSD, fxRate: NaN })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toBe('USD 배당은 유효한 환율이 필요합니다.')
+  })
+  it('환율 문자열', () => {
+    const errors = validateDividendInput({ ...baseUSD, fxRate: 'bad' })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toBe('USD 배당은 유효한 환율이 필요합니다.')
+  })
+})

--- a/src/lib/__tests__/trade-utils.test.ts
+++ b/src/lib/__tests__/trade-utils.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import { validateTradeInput } from '../trade-utils'
+
+const baseKRW = {
+  accountId: 'acc_1',
+  ticker: '005930',
+  displayName: '삼성전자',
+  market: 'KR',
+  type: 'BUY',
+  shares: 10,
+  price: 70000,
+  currency: 'KRW',
+  tradedAt: '2024-01-15',
+}
+
+const baseUSD = {
+  accountId: 'acc_2',
+  ticker: 'AAPL',
+  displayName: 'Apple Inc.',
+  market: 'US',
+  type: 'BUY',
+  shares: 5,
+  price: 180.5,
+  currency: 'USD',
+  fxRate: 1340,
+  tradedAt: '2024-01-15',
+}
+
+describe('validateTradeInput — 정상', () => {
+  it('KRW BUY 정상', () => {
+    expect(validateTradeInput(baseKRW)).toEqual([])
+  })
+  it('USD BUY 정상', () => {
+    expect(validateTradeInput(baseUSD)).toEqual([])
+  })
+  it('SELL 정상', () => {
+    expect(validateTradeInput({ ...baseKRW, type: 'SELL' })).toEqual([])
+  })
+})
+
+describe('validateTradeInput — 필수 필드', () => {
+  it('accountId 누락', () => {
+    const errors = validateTradeInput({ ...baseKRW, accountId: undefined })
+    expect(errors.find((e) => e.field === 'accountId')?.message).toBe('계좌를 선택해주세요.')
+  })
+  it('ticker 공백', () => {
+    const errors = validateTradeInput({ ...baseKRW, ticker: '   ' })
+    expect(errors.find((e) => e.field === 'ticker')?.message).toBe('종목을 선택해주세요.')
+  })
+  it('displayName 공백', () => {
+    const errors = validateTradeInput({ ...baseKRW, displayName: '' })
+    expect(errors.find((e) => e.field === 'displayName')?.message).toBe('종목명을 입력해주세요.')
+  })
+})
+
+describe('validateTradeInput — 형식', () => {
+  it('잘못된 market', () => {
+    const errors = validateTradeInput({ ...baseKRW, market: 'JP' })
+    expect(errors.find((e) => e.field === 'market')?.message).toBe('시장을 선택해주세요 (US/KR).')
+  })
+  it('잘못된 type', () => {
+    const errors = validateTradeInput({ ...baseKRW, type: 'HOLD' })
+    expect(errors.find((e) => e.field === 'type')?.message).toBe(
+      '거래 유형을 선택해주세요 (BUY/SELL).'
+    )
+  })
+  it('shares 0', () => {
+    const errors = validateTradeInput({ ...baseKRW, shares: 0 })
+    expect(errors.find((e) => e.field === 'shares')?.message).toBe('수량은 1 이상의 정수여야 합니다.')
+  })
+  it('shares 소수', () => {
+    const errors = validateTradeInput({ ...baseKRW, shares: 1.5 })
+    expect(errors.find((e) => e.field === 'shares')?.message).toBe('수량은 1 이상의 정수여야 합니다.')
+  })
+  it('shares 문자열', () => {
+    const errors = validateTradeInput({ ...baseKRW, shares: '10' })
+    expect(errors.find((e) => e.field === 'shares')?.message).toBe('수량은 1 이상의 정수여야 합니다.')
+  })
+  it('price 0', () => {
+    const errors = validateTradeInput({ ...baseKRW, price: 0 })
+    expect(errors.find((e) => e.field === 'price')?.message).toBe('단가는 0보다 큰 숫자여야 합니다.')
+  })
+  it('price 음수', () => {
+    const errors = validateTradeInput({ ...baseKRW, price: -100 })
+    expect(errors.find((e) => e.field === 'price')?.message).toBe('단가는 0보다 큰 숫자여야 합니다.')
+  })
+})
+
+describe('validateTradeInput — 교차 검증', () => {
+  it('USD 환율 누락', () => {
+    const errors = validateTradeInput({ ...baseUSD, fxRate: null })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toContain('환율')
+  })
+  it('USD 환율 0', () => {
+    const errors = validateTradeInput({ ...baseUSD, fxRate: 0 })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toContain('환율')
+  })
+  it('USD 환율 NaN (CSV import 호환)', () => {
+    const errors = validateTradeInput({ ...baseUSD, fxRate: NaN })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toContain('환율')
+  })
+  it('USD 환율 문자열', () => {
+    const errors = validateTradeInput({ ...baseUSD, fxRate: 'bad' })
+    expect(errors.find((e) => e.field === 'fxRate')?.message).toContain('환율')
+  })
+  it('US 시장 + KRW 통화', () => {
+    const errors = validateTradeInput({ ...baseUSD, currency: 'KRW' })
+    expect(errors.find((e) => e.field === 'currency')?.message).toBe(
+      'US 시장은 USD 통화만 가능합니다.'
+    )
+  })
+  it('KR 시장 + USD 통화', () => {
+    const errors = validateTradeInput({ ...baseKRW, currency: 'USD' })
+    expect(errors.find((e) => e.field === 'currency')?.message).toBe(
+      'KR 시장은 KRW 통화만 가능합니다.'
+    )
+  })
+})
+
+describe('validateTradeInput — 거래일', () => {
+  it('미래 날짜', () => {
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    const errors = validateTradeInput({ ...baseKRW, tradedAt: future })
+    expect(errors.find((e) => e.field === 'tradedAt')?.message).toBe('미래 날짜는 입력할 수 없습니다.')
+  })
+  it('1999 년 이전', () => {
+    const errors = validateTradeInput({ ...baseKRW, tradedAt: '1999-12-31' })
+    expect(errors.find((e) => e.field === 'tradedAt')?.message).toBe(
+      '2000-01-01 이후 날짜를 입력해주세요.'
+    )
+  })
+  it('parse 불가 날짜', () => {
+    const errors = validateTradeInput({ ...baseKRW, tradedAt: 'not-a-date' })
+    expect(errors.find((e) => e.field === 'tradedAt')?.message).toBe('유효한 거래일을 입력해주세요.')
+  })
+  it('tradedAt null', () => {
+    const errors = validateTradeInput({ ...baseKRW, tradedAt: null })
+    expect(errors.find((e) => e.field === 'tradedAt')?.message).toBe('유효한 거래일을 입력해주세요.')
+  })
+})

--- a/src/lib/__tests__/transaction-utils.test.ts
+++ b/src/lib/__tests__/transaction-utils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { validateTransactionInput } from '../transaction-utils'
+
+const base = {
+  amount: 12000,
+  description: '점심',
+  categoryId: 'cat_food',
+}
+
+describe('validateTransactionInput — 정상', () => {
+  it('기본 거래', () => {
+    expect(validateTransactionInput(base)).toEqual([])
+  })
+  it('transfer_out + linkedAssetId', () => {
+    expect(
+      validateTransactionInput({
+        ...base,
+        type: 'transfer_out',
+        linkedAssetId: 'asset_1',
+        categoryId: 'cat_transfer',
+      })
+    ).toEqual([])
+  })
+  it('transactedAt 있는 경우', () => {
+    expect(validateTransactionInput({ ...base, transactedAt: '2024-04-01' })).toEqual([])
+  })
+})
+
+describe('validateTransactionInput — amount', () => {
+  it('amount 키 자체 누락 (외부 클라이언트 / curl 호환)', () => {
+    const errors = validateTransactionInput({ description: '점심', categoryId: 'cat_food' })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액을 입력해주세요.')
+  })
+  it('amount 누락', () => {
+    const errors = validateTransactionInput({ ...base, amount: undefined })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액을 입력해주세요.')
+  })
+  it('amount null', () => {
+    const errors = validateTransactionInput({ ...base, amount: null })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액을 입력해주세요.')
+  })
+  it('amount 문자열', () => {
+    const errors = validateTransactionInput({ ...base, amount: '12000' })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액은 1 이상의 정수여야 합니다.')
+  })
+  it('amount 0', () => {
+    const errors = validateTransactionInput({ ...base, amount: 0 })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액은 1 이상의 정수여야 합니다.')
+  })
+  it('amount 음수', () => {
+    const errors = validateTransactionInput({ ...base, amount: -100 })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액은 1 이상의 정수여야 합니다.')
+  })
+  it('amount 소수', () => {
+    const errors = validateTransactionInput({ ...base, amount: 100.5 })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액은 1 이상의 정수여야 합니다.')
+  })
+  it('amount > INT32 max', () => {
+    const errors = validateTransactionInput({ ...base, amount: 3_000_000_000 })
+    expect(errors.find((e) => e.field === 'amount')?.message).toBe('금액이 허용 범위를 초과했습니다.')
+  })
+})
+
+describe('validateTransactionInput — description', () => {
+  it('description 누락', () => {
+    const errors = validateTransactionInput({ ...base, description: undefined })
+    expect(errors.find((e) => e.field === 'description')?.message).toBe('내용을 입력해주세요.')
+  })
+  it('description 공백만', () => {
+    const errors = validateTransactionInput({ ...base, description: '   ' })
+    expect(errors.find((e) => e.field === 'description')?.message).toBe('내용을 입력해주세요.')
+  })
+  it('description 200자 초과', () => {
+    const errors = validateTransactionInput({ ...base, description: 'a'.repeat(201) })
+    expect(errors.find((e) => e.field === 'description')?.message).toBe(
+      '내용은 200자 이내로 입력해주세요.'
+    )
+  })
+})
+
+describe('validateTransactionInput — categoryId', () => {
+  it('categoryId 누락', () => {
+    const errors = validateTransactionInput({ ...base, categoryId: undefined })
+    expect(errors.find((e) => e.field === 'categoryId')?.message).toBe('카테고리를 선택해주세요.')
+  })
+})
+
+describe('validateTransactionInput — transfer 유형', () => {
+  it('잘못된 type', () => {
+    const errors = validateTransactionInput({ ...base, type: 'random' })
+    expect(errors.find((e) => e.field === 'type')?.message).toBe(
+      '유형은 transfer_out 또는 transfer_in만 허용됩니다.'
+    )
+  })
+  it('transfer_out 인데 linkedAssetId 누락', () => {
+    const errors = validateTransactionInput({ ...base, type: 'transfer_out' })
+    expect(errors.find((e) => e.field === 'linkedAssetId')?.message).toBe(
+      '출금/입금 시 연결 자산을 선택해주세요.'
+    )
+  })
+  it('transfer_in 인데 linkedAssetId 빈 문자열', () => {
+    const errors = validateTransactionInput({
+      ...base,
+      type: 'transfer_in',
+      linkedAssetId: '',
+    })
+    expect(errors.find((e) => e.field === 'linkedAssetId')?.message).toBe(
+      '출금/입금 시 연결 자산을 선택해주세요.'
+    )
+  })
+})
+
+describe('validateTransactionInput — transactedAt', () => {
+  it('parse 불가', () => {
+    const errors = validateTransactionInput({ ...base, transactedAt: 'bad-date' })
+    expect(errors.find((e) => e.field === 'transactedAt')?.message).toBe(
+      '유효한 날짜 형식이 아닙니다.'
+    )
+  })
+  it('number 타입', () => {
+    const errors = validateTransactionInput({ ...base, transactedAt: 12345 })
+    expect(errors.find((e) => e.field === 'transactedAt')?.message).toBe(
+      '날짜는 문자열이어야 합니다.'
+    )
+  })
+})

--- a/src/lib/dividend-utils.ts
+++ b/src/lib/dividend-utils.ts
@@ -2,7 +2,9 @@
  * 배당금 유틸리티: 세율 상수, 입력 검증, 세금 자동 계산
  */
 
+import { z } from 'zod'
 import { validateFxRateForUSD } from './trade-utils'
+import { zodErrorsToValidation, type ValidationError } from './zod-utils'
 
 /** US 배당 원천징수 세율 15% */
 export const US_DIVIDEND_TAX_RATE = 0.15
@@ -10,44 +12,48 @@ export const US_DIVIDEND_TAX_RATE = 0.15
 /** KR 배당소득세율 15.4% (소득세 14% + 지방소득세 1.4%) */
 export const KR_DIVIDEND_TAX_RATE = 0.154
 
-export interface DividendValidationError {
-  field: string
-  message: string
-}
+export type DividendValidationError = ValidationError
 
-export function validateDividendInput(body: {
-  accountId?: string
-  ticker?: string
-  displayName?: string
-  payDate?: string
-  amountGross?: number
-  amountNet?: number
-  currency?: string
-  fxRate?: number | null
-}): DividendValidationError[] {
-  const errors: DividendValidationError[] = []
+const DividendInputSchema = z
+  .object({
+    accountId: z
+      .string({ message: '계좌를 선택해주세요.' })
+      .min(1, { message: '계좌를 선택해주세요.' }),
+    ticker: z
+      .string({ message: '종목을 선택해주세요.' })
+      .trim()
+      .min(1, { message: '종목을 선택해주세요.' }),
+    displayName: z
+      .string({ message: '종목명을 입력해주세요.' })
+      .trim()
+      .min(1, { message: '종목명을 입력해주세요.' }),
+    payDate: z
+      .string({ message: '유효한 지급일을 입력해주세요.' })
+      .refine((s) => !isNaN(Date.parse(s)), { message: '유효한 지급일을 입력해주세요.' }),
+    amountGross: z
+      .number({ message: '세전 금액은 0보다 커야 합니다.' })
+      .positive({ message: '세전 금액은 0보다 커야 합니다.' })
+      .finite({ message: '세전 금액은 0보다 커야 합니다.' }),
+    amountNet: z
+      .number({ message: '세후 금액은 0 이상이어야 합니다.' })
+      .nonnegative({ message: '세후 금액은 0 이상이어야 합니다.' })
+      .finite({ message: '세후 금액은 0 이상이어야 합니다.' }),
+    currency: z.enum(['USD', 'KRW'], { message: '통화를 선택해주세요 (USD/KRW).' }),
+    // fxRate 의 형식 검증은 USD 분기 + validateFxRateForUSD 헬퍼가 한국어 메시지로
+    // 통일 처리. type-level 영문 메시지 누출 방지를 위해 unknown 으로 받는다.
+    fxRate: z.unknown().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.currency === 'USD') {
+      const fxError = validateFxRateForUSD(data.fxRate, 'USD 배당')
+      if (fxError) ctx.addIssue({ code: 'custom', path: ['fxRate'], message: fxError })
+    }
+  })
 
-  if (!body.accountId || typeof body.accountId !== 'string') errors.push({ field: 'accountId', message: '계좌를 선택해주세요.' })
-  if (typeof body.ticker !== 'string' || !body.ticker.trim()) errors.push({ field: 'ticker', message: '종목을 선택해주세요.' })
-  if (typeof body.displayName !== 'string' || !body.displayName.trim()) errors.push({ field: 'displayName', message: '종목명을 입력해주세요.' })
-  if (!body.payDate || isNaN(Date.parse(body.payDate))) {
-    errors.push({ field: 'payDate', message: '유효한 지급일을 입력해주세요.' })
-  }
-  if (typeof body.amountGross !== 'number' || !Number.isFinite(body.amountGross) || body.amountGross <= 0) {
-    errors.push({ field: 'amountGross', message: '세전 금액은 0보다 커야 합니다.' })
-  }
-  if (typeof body.amountNet !== 'number' || !Number.isFinite(body.amountNet) || body.amountNet < 0) {
-    errors.push({ field: 'amountNet', message: '세후 금액은 0 이상이어야 합니다.' })
-  }
-  if (!body.currency || !['USD', 'KRW'].includes(body.currency)) {
-    errors.push({ field: 'currency', message: '통화를 선택해주세요 (USD/KRW).' })
-  }
-  if (body.currency === 'USD') {
-    const fxError = validateFxRateForUSD(body.fxRate, 'USD 배당')
-    if (fxError) errors.push({ field: 'fxRate', message: fxError })
-  }
-
-  return errors
+export function validateDividendInput(body: unknown): DividendValidationError[] {
+  const result = DividendInputSchema.safeParse(body)
+  if (result.success) return []
+  return zodErrorsToValidation(result.error)
 }
 
 /**

--- a/src/lib/trade-utils.ts
+++ b/src/lib/trade-utils.ts
@@ -3,6 +3,9 @@
  * 순수 함수로 구성하여 API route에서 호출.
  */
 
+import { z } from 'zod'
+import { zodErrorsToValidation, type ValidationError } from './zod-utils'
+
 interface TradeInput {
   type: string       // "BUY" | "SELL"
   shares: number
@@ -88,10 +91,7 @@ export function calcTotalKRW(
 /**
  * 거래 입력 검증
  */
-export interface TradeValidationError {
-  field: string
-  message: string
-}
+export type TradeValidationError = ValidationError
 
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000
 const MIN_TRADE_DATE = '2000-01-01'
@@ -123,8 +123,10 @@ export function validateFxRateForUSD(fxRate: unknown, label = 'USD 종목'): str
  * 단순한 `Date.now() + 1일` grace는 KST 사용자가 오후~저녁에 내일 날짜(UTC midnight
  * 기준 < now+24h)를 입력하면 통과시키는 결함이 있어, KST 캘린더 날짜로 직접 비교.
  */
-export function validateTradedAt(tradedAt: string | undefined | null): string | null {
-  if (!tradedAt || isNaN(Date.parse(tradedAt))) return '유효한 거래일을 입력해주세요.'
+export function validateTradedAt(tradedAt: unknown): string | null {
+  if (typeof tradedAt !== 'string' || isNaN(Date.parse(tradedAt))) {
+    return '유효한 거래일을 입력해주세요.'
+  }
   const tradedAtKST = toKSTDateString(Date.parse(tradedAt))
   const todayKST = toKSTDateString(Date.now())
   if (tradedAtKST > todayKST) return '미래 날짜는 입력할 수 없습니다.'
@@ -132,50 +134,54 @@ export function validateTradedAt(tradedAt: string | undefined | null): string | 
   return null
 }
 
-export function validateTradeInput(body: {
-  accountId?: string
-  ticker?: string
-  displayName?: string
-  market?: string
-  type?: string
-  shares?: number
-  price?: number
-  currency?: string
-  fxRate?: number | null
-  tradedAt?: string
-}): TradeValidationError[] {
-  const errors: TradeValidationError[] = []
+const TradeInputSchema = z
+  .object({
+    accountId: z
+      .string({ message: '계좌를 선택해주세요.' })
+      .min(1, { message: '계좌를 선택해주세요.' }),
+    ticker: z
+      .string({ message: '종목을 선택해주세요.' })
+      .trim()
+      .min(1, { message: '종목을 선택해주세요.' }),
+    displayName: z
+      .string({ message: '종목명을 입력해주세요.' })
+      .trim()
+      .min(1, { message: '종목명을 입력해주세요.' }),
+    market: z.enum(['US', 'KR'], { message: '시장을 선택해주세요 (US/KR).' }),
+    type: z.enum(['BUY', 'SELL'], { message: '거래 유형을 선택해주세요 (BUY/SELL).' }),
+    shares: z
+      .number({ message: '수량은 1 이상의 정수여야 합니다.' })
+      .int({ message: '수량은 1 이상의 정수여야 합니다.' })
+      .positive({ message: '수량은 1 이상의 정수여야 합니다.' })
+      .finite({ message: '수량은 1 이상의 정수여야 합니다.' }),
+    price: z
+      .number({ message: '단가는 0보다 큰 숫자여야 합니다.' })
+      .positive({ message: '단가는 0보다 큰 숫자여야 합니다.' })
+      .finite({ message: '단가는 0보다 큰 숫자여야 합니다.' }),
+    currency: z.enum(['USD', 'KRW'], { message: '통화를 선택해주세요 (USD/KRW).' }),
+    // fxRate / tradedAt 의 형식 검증은 USD 분기 + validateTradedAt 헬퍼가 한국어 메시지로
+    // 통일 처리하므로 schema 단계에서는 type-level 영문 메시지가 노출되지 않도록 unknown 으로 받는다.
+    // (CSV import 가 Number(...) 변환 결과 NaN 을 전달하는 케이스도 동일 흐름)
+    fxRate: z.unknown().optional(),
+    tradedAt: z.unknown().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.currency === 'USD') {
+      const fxError = validateFxRateForUSD(data.fxRate)
+      if (fxError) ctx.addIssue({ code: 'custom', path: ['fxRate'], message: fxError })
+    }
+    if (data.market === 'US' && data.currency !== 'USD') {
+      ctx.addIssue({ code: 'custom', path: ['currency'], message: 'US 시장은 USD 통화만 가능합니다.' })
+    }
+    if (data.market === 'KR' && data.currency !== 'KRW') {
+      ctx.addIssue({ code: 'custom', path: ['currency'], message: 'KR 시장은 KRW 통화만 가능합니다.' })
+    }
+    const tradedAtError = validateTradedAt(data.tradedAt)
+    if (tradedAtError) ctx.addIssue({ code: 'custom', path: ['tradedAt'], message: tradedAtError })
+  })
 
-  if (!body.accountId) errors.push({ field: 'accountId', message: '계좌를 선택해주세요.' })
-  if (!body.ticker?.trim()) errors.push({ field: 'ticker', message: '종목을 선택해주세요.' })
-  if (!body.displayName?.trim()) errors.push({ field: 'displayName', message: '종목명을 입력해주세요.' })
-  if (!body.market || !['US', 'KR'].includes(body.market)) {
-    errors.push({ field: 'market', message: '시장을 선택해주세요 (US/KR).' })
-  }
-  if (!body.type || !['BUY', 'SELL'].includes(body.type)) {
-    errors.push({ field: 'type', message: '거래 유형을 선택해주세요 (BUY/SELL).' })
-  }
-  if (typeof body.shares !== 'number' || !Number.isFinite(body.shares) || body.shares <= 0 || !Number.isInteger(body.shares)) {
-    errors.push({ field: 'shares', message: '수량은 1 이상의 정수여야 합니다.' })
-  }
-  if (typeof body.price !== 'number' || !Number.isFinite(body.price) || body.price <= 0) {
-    errors.push({ field: 'price', message: '단가는 0보다 큰 숫자여야 합니다.' })
-  }
-  if (!body.currency || !['USD', 'KRW'].includes(body.currency)) {
-    errors.push({ field: 'currency', message: '통화를 선택해주세요 (USD/KRW).' })
-  }
-  if (body.currency === 'USD') {
-    const fxError = validateFxRateForUSD(body.fxRate)
-    if (fxError) errors.push({ field: 'fxRate', message: fxError })
-  }
-  if (body.market === 'US' && body.currency && body.currency !== 'USD') {
-    errors.push({ field: 'currency', message: 'US 시장은 USD 통화만 가능합니다.' })
-  }
-  if (body.market === 'KR' && body.currency && body.currency !== 'KRW') {
-    errors.push({ field: 'currency', message: 'KR 시장은 KRW 통화만 가능합니다.' })
-  }
-  const tradedAtError = validateTradedAt(body.tradedAt)
-  if (tradedAtError) errors.push({ field: 'tradedAt', message: tradedAtError })
-
-  return errors
+export function validateTradeInput(body: unknown): TradeValidationError[] {
+  const result = TradeInputSchema.safeParse(body)
+  if (result.success) return []
+  return zodErrorsToValidation(result.error)
 }

--- a/src/lib/transaction-utils.ts
+++ b/src/lib/transaction-utils.ts
@@ -2,55 +2,66 @@
  * 거래(Transaction) 유틸리티: 입력 검증
  */
 
-export interface TransactionValidationError {
-  field: string
-  message: string
-}
+import { z } from 'zod'
+import { zodErrorsToValidation, type ValidationError } from './zod-utils'
 
-export function validateTransactionInput(body: Record<string, unknown>): TransactionValidationError[] {
-  const errors: TransactionValidationError[] = []
+export type TransactionValidationError = ValidationError
 
-  if (body.amount === undefined || body.amount === null) {
-    errors.push({ field: 'amount', message: '금액을 입력해주세요.' })
-  } else if (typeof body.amount !== 'number' || !Number.isInteger(body.amount) || body.amount <= 0) {
-    errors.push({ field: 'amount', message: '금액은 1 이상의 정수여야 합니다.' })
-  } else if (body.amount > 2_147_483_647) {
-    errors.push({ field: 'amount', message: '금액이 허용 범위를 초과했습니다.' })
-  }
+const INT32_MAX = 2_147_483_647
 
-  if (!body.description || typeof body.description !== 'string' || !body.description.trim()) {
-    errors.push({ field: 'description', message: '내용을 입력해주세요.' })
-  } else if (body.description.trim().length > 200) {
-    errors.push({ field: 'description', message: '내용은 200자 이내로 입력해주세요.' })
-  }
+const TransactionInputSchema = z
+  .object({
+    // amount 는 누락 vs 형식 오류 vs 오버플로우 메시지가 모두 달라 schema 일반 검증 대신
+    // superRefine 에서 인라인 분기로 보존한다. amount 키 자체 누락도 한국어 메시지로
+    // 처리해야 하므로 .optional() 로 schema 통과시킨다.
+    amount: z.unknown().optional(),
+    description: z
+      .string({ message: '내용을 입력해주세요.' })
+      .trim()
+      .min(1, { message: '내용을 입력해주세요.' })
+      .max(200, { message: '내용은 200자 이내로 입력해주세요.' }),
+    categoryId: z
+      .string({ message: '카테고리를 선택해주세요.' })
+      .min(1, { message: '카테고리를 선택해주세요.' }),
+    type: z
+      .enum(['transfer_out', 'transfer_in'], {
+        message: '유형은 transfer_out 또는 transfer_in만 허용됩니다.',
+      })
+      .nullable()
+      .optional(),
+    linkedAssetId: z.string().nullable().optional(),
+    transactedAt: z
+      .string({ message: '날짜는 문자열이어야 합니다.' })
+      .refine((s) => !isNaN(new Date(s).getTime()), { message: '유효한 날짜 형식이 아닙니다.' })
+      .nullable()
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.amount === undefined || data.amount === null) {
+      ctx.addIssue({ code: 'custom', path: ['amount'], message: '금액을 입력해주세요.' })
+    } else if (
+      typeof data.amount !== 'number' ||
+      !Number.isInteger(data.amount) ||
+      data.amount <= 0
+    ) {
+      ctx.addIssue({ code: 'custom', path: ['amount'], message: '금액은 1 이상의 정수여야 합니다.' })
+    } else if (data.amount > INT32_MAX) {
+      ctx.addIssue({ code: 'custom', path: ['amount'], message: '금액이 허용 범위를 초과했습니다.' })
+    }
 
-  if (!body.categoryId || typeof body.categoryId !== 'string') {
-    errors.push({ field: 'categoryId', message: '카테고리를 선택해주세요.' })
-  }
-
-  // type 검증 (transfer 유형)
-  const validTypes = ['transfer_out', 'transfer_in']
-  if (body.type !== undefined && body.type !== null) {
-    if (typeof body.type !== 'string' || !validTypes.includes(body.type)) {
-      errors.push({ field: 'type', message: '유형은 transfer_out 또는 transfer_in만 허용됩니다.' })
-    } else {
-      // transfer 유형은 linkedAssetId 필수
-      if (!body.linkedAssetId || typeof body.linkedAssetId !== 'string') {
-        errors.push({ field: 'linkedAssetId', message: '출금/입금 시 연결 자산을 선택해주세요.' })
+    if (data.type) {
+      if (!data.linkedAssetId || typeof data.linkedAssetId !== 'string') {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['linkedAssetId'],
+          message: '출금/입금 시 연결 자산을 선택해주세요.',
+        })
       }
     }
-  }
+  })
 
-  if (body.transactedAt !== undefined && body.transactedAt !== null) {
-    if (typeof body.transactedAt !== 'string') {
-      errors.push({ field: 'transactedAt', message: '날짜는 문자열이어야 합니다.' })
-    } else {
-      const d = new Date(body.transactedAt)
-      if (isNaN(d.getTime())) {
-        errors.push({ field: 'transactedAt', message: '유효한 날짜 형식이 아닙니다.' })
-      }
-    }
-  }
-
-  return errors
+export function validateTransactionInput(body: unknown): TransactionValidationError[] {
+  const result = TransactionInputSchema.safeParse(body)
+  if (result.success) return []
+  return zodErrorsToValidation(result.error)
 }

--- a/src/lib/zod-utils.ts
+++ b/src/lib/zod-utils.ts
@@ -1,0 +1,17 @@
+import type { ZodError, ZodIssue } from 'zod'
+
+export interface ValidationError {
+  field: string
+  message: string
+}
+
+/**
+ * ZodError 의 issues 를 헬퍼의 표준 ValidationError[] 시그니처로 매핑한다.
+ * field 는 issue.path 의 첫 segment 를 사용 (중첩 경로는 dot join).
+ */
+export function zodErrorsToValidation(err: ZodError): ValidationError[] {
+  return err.issues.map((issue: ZodIssue) => ({
+    field: issue.path.length > 0 ? issue.path.join('.') : '_',
+    message: issue.message,
+  }))
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/lib/**/__tests__/**', 'src/lib/prisma.ts'],
+    },
+  },
+})


### PR DESCRIPTION
## 요약

핵심 입력 경로 3개 (`trade-utils`, `dividend-utils`, `transaction-utils`) 의 `validate*Input` 헬퍼 내부를 Zod schema 기반으로 전환. 외부 시그니처는 그대로라 API 라우트 코드는 무변경. 동시에 vitest 를 도입해 단위 테스트 안전망을 구축하고 25-E 에서 위임한 \`api-errors\` 테스트 빚을 청산.

### 의존성 추가
- 런타임: \`zod\` ^4.4.3
- dev: \`vitest\`, \`@vitest/coverage-v8\`, \`vite-tsconfig-paths\`

### 신규 파일
- \`src/lib/zod-utils.ts\` — \`ZodError → ValidationError[]\` 어댑터
- \`src/lib/__tests__/{api-errors,trade-utils,dividend-utils,transaction-utils}.test.ts\`
- \`vitest.config.mts\` — Node 20 + Vitest 4 의 std-env ESM 충돌 회피로 .mts 사용

### 마이그레이션
- \`validateTradeInput\` / \`validateDividendInput\` / \`validateTransactionInput\` 내부를 Zod schema + \`superRefine\` 으로 전환
- \`fxRate\` / \`tradedAt\` / \`amount\` 는 \`z.unknown().optional()\` 로 받아 schema 단계 type-level 영문 메시지 누출 차단
- \`validateTradedAt\` 시그니처를 \`unknown\` 으로 확장 — \`PUT /api/trades/[id]\` 의 string-narrow 후 호출 패턴 호환

### 검증 순서 보강
- \`CLAUDE.md\` PR 전 검증에 \`npm run test:run\` 추가

Closes #299

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 4 files / 69 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건, 2회차)

## 코드 리뷰 결과
- **1차**: P2=0 / P1=3 (amount/fxRate/tradedAt 영문 메시지 누출) / P0=1 (스펙 불일치)
- **2차**: P2=0 / P1=0 / P0=0 ✅

P1 3건 모두 동일 패턴 — Zod schema type-level 검증이 \`superRefine\` 보다 먼저 실행되어 한국어 메시지가 우회되는 케이스. \`z.unknown().optional()\` 로 통일 처리 + 회귀 테스트 6개 추가.