### PR TITLE
[Phase 25-G-2] 면책 문구 강조 Disclaimer 컴포넌트 통합 (#303)

### DIFF
--- a/docs/specs/303-disclaimer-component.md
+++ b/docs/specs/303-disclaimer-component.md
@@ -1,0 +1,96 @@
+# [Phase 25-G-2] 면책 문구 강조 컴포넌트 통합
+
+## 목적
+
+세금/추정치 면책 문구가 9개 위치에서 모두 `text-[11px] text-dim` (희미한 회색 본문) 으로 페이지에 묻혀 사용자가 인지하기 어렵다. `<Disclaimer>` 단일 컴포넌트로 통일해 amber 톤 박스 + 아이콘으로 시선을 끌고, 향후 면책 톤/문구 변경 시 한 곳에서 관리.
+
+## 배경
+
+현재 면책 문구 사용처 (인라인 9곳):
+
+| 파일 | 내용 |
+|---|---|
+| `src/app/tax/page.tsx:405` | 세금 정보는 참고용이며 법적 조언이 아닙니다. 정확한 세금 계산은 세무사에게 문의하세요. |
+| `src/app/deposits/page.tsx:116` | 증여세 정보는 참고용이며 법적 조언이 아닙니다. |
+| `src/app/dividends/page.tsx:140` | 배당소득세 정보는 참고용이며 법적 조언이 아닙니다. |
+| `src/app/stock-options/page.tsx:102` | 세금 정보는 참고용이며 법적 조언이 아닙니다. 행사 이익만 기준 추정이며, 기존 연봉 합산 시 세율이 달라질 수 있습니다. |
+| `src/app/simulator/page.tsx:84` | 시뮬레이션 결과는 가정된 수익률에 기반한 참고용이며, 실제 수익을 보장하지 않습니다. |
+| `src/app/performance/page.tsx:23` | 수익률은 TWR(시간가중수익률) 기반 참고용이며, 실제 투자 성과와 다를 수 있습니다. |
+| `src/components/tax/IntegratedTaxCard.tsx:205` | 인적공제·특별공제 등이 미반영된 참고용 추정치입니다. 정확한 세금 계산은 세무사에게 문의하세요. |
+| `src/components/rsu/RSUDashboard.tsx:268` | RSU 근로소득세는 회사에서 원천징수됩니다. 이 계산은 참고용이며 법적 조언이 아닙니다. |
+| `src/components/dividend/DividendForm.tsx:415` | 배당소득세 정보는 참고용이며 법적 조언이 아닙니다. |
+
+## 요구사항
+
+- [ ] `src/components/ui/Disclaimer.tsx` 신규 컴포넌트
+- [ ] 9개 사용처를 `<Disclaimer>` 로 일괄 교체 (문구는 children 으로 전달)
+- [ ] 페이지 레이아웃 회귀 없음
+- [ ] `components.md` 의 세금 면책 룰 (`"참고용이며 법적 조언이 아닙니다"`) 그대로 유지
+
+## 기술 설계
+
+### 1. 컴포넌트
+
+```tsx
+// src/components/ui/Disclaimer.tsx
+import { ReactNode } from 'react'
+
+interface DisclaimerProps {
+  children: ReactNode
+  className?: string
+}
+
+export default function Disclaimer({ children, className = '' }: DisclaimerProps) {
+  return (
+    <div
+      role="note"
+      className={`flex gap-2 bg-amber-500/5 border border-amber-500/20 rounded-lg px-4 py-2.5 ${className}`}
+    >
+      <span aria-hidden="true" className="text-amber-400 text-[13px] leading-relaxed shrink-0">
+        ⓘ
+      </span>
+      <p className="text-[12px] text-amber-200/90 leading-relaxed">{children}</p>
+    </div>
+  )
+}
+```
+
+- `role="note"` — 스크린리더가 보조 정보로 인식
+- amber-200 으로 가독성 확보 (디자인 시안의 amber-300/90 보다 한 톤 밝게 — dark 테마에서 충분히 보이게)
+- `className` prop — 호출 측이 mt/mb 같은 spacing 만 덧붙일 수 있도록
+
+### 2. 일괄 교체
+
+각 사용처에서 기존 `<p>` 또는 `<div>` 를 `<Disclaimer>` 로 치환. 부모 컨테이너의 `mt-4`, `mt-6` 같은 외부 spacing 은 `className` 으로 전달.
+
+예시 (tax/page.tsx):
+```tsx
+// before
+<p className="text-[11px] text-dim">
+  세금 정보는 참고용이며 법적 조언이 아닙니다. ...
+</p>
+// after
+<Disclaimer>
+  세금 정보는 참고용이며 법적 조언이 아닙니다. 정확한 세금 계산은 세무사에게 문의하세요.
+</Disclaimer>
+```
+
+mt 가 부모에 있던 경우는 `<Disclaimer className="mt-4">` 로 전달.
+
+### 3. IntegratedTaxCard 예외 처리
+
+`IntegratedTaxCard.tsx:205` 는 `<span>` 안에 다른 텍스트와 함께 있어 인라인 흐름. 분리해서 별도 라인으로 두거나, 카드 내부 박스로 분리. → 별도 라인으로 `<Disclaimer>` 추가.
+
+## 테스트 계획
+
+- 9개 페이지/컴포넌트 모두 렌더링 확인 (lint/tsc/build)
+- 시각적 회귀: 페이지 하단 면책 박스가 amber 톤으로 표시되는지
+- 다크 테마에서 색상 대비 확인 (eye-check)
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+
+## 제외 사항
+
+- 면책 문구 내용 변경 (법무 검토 영역)
+- 텔레그램 봇 면책 (메시지 텍스트, 별도 phase)
+- 모달/툴팁 형 강조 — 인라인 박스로 충분
+- 면책 표시 토글/접기 옵션 — 작은 박스라 불필요

--- a/src/app/deposits/page.tsx
+++ b/src/app/deposits/page.tsx
@@ -4,6 +4,7 @@ import Header from '@/components/layout/Header'
 import ExportButton from '@/components/ui/ExportButton'
 import DepositFilters from '@/components/deposit/DepositFilters'
 import DepositTable from '@/components/deposit/DepositTable'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 export const dynamic = 'force-dynamic'
 
@@ -112,9 +113,7 @@ export default async function DepositsPage(props: DepositsPageProps) {
         offset={clampedOffset}
       />
 
-      <p className="text-[11px] text-dim mt-4">
-        증여세 정보는 참고용이며 법적 조언이 아닙니다.
-      </p>
+      <Disclaimer className="mt-4">증여세 정보는 참고용이며 법적 조언이 아닙니다.</Disclaimer>
     </div>
   )
 }

--- a/src/app/dividends/page.tsx
+++ b/src/app/dividends/page.tsx
@@ -6,6 +6,7 @@ import DividendFilters from '@/components/dividend/DividendFilters'
 import DividendTable from '@/components/dividend/DividendTable'
 import DividendSummary from '@/components/dividend/DividendSummary'
 import DividendCalendar from '@/components/dividend/DividendCalendar'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 export const dynamic = 'force-dynamic'
 
@@ -136,9 +137,7 @@ export default async function DividendsPage(props: DividendsPageProps) {
         offset={clampedOffset}
       />
 
-      <p className="text-[11px] text-dim mt-4">
-        배당소득세 정보는 참고용이며 법적 조언이 아닙니다.
-      </p>
+      <Disclaimer className="mt-4">배당소득세 정보는 참고용이며 법적 조언이 아닙니다.</Disclaimer>
     </div>
   )
 }

--- a/src/app/performance/page.tsx
+++ b/src/app/performance/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import Header from '@/components/layout/Header'
 import PerformanceClient from './PerformanceClient'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,9 +20,9 @@ export default async function PerformancePage() {
         accounts={accounts}
         hasSnapshots={snapshotCount >= 2}
       />
-      <p className="mt-6 text-[11px] text-dim">
+      <Disclaimer className="mt-6">
         수익률은 TWR(시간가중수익률) 기반 참고용이며, 실제 투자 성과와 다를 수 있습니다.
-      </p>
+      </Disclaimer>
     </div>
   )
 }

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -3,6 +3,7 @@ import Header from '@/components/layout/Header'
 import SimulatorClient from './SimulatorClient'
 import { GIFT_SOURCES } from '@/lib/tax/gift-tax'
 import { DEFAULT_FX_RATE_USD_KRW } from '@/lib/format'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 export const dynamic = 'force-dynamic'
 
@@ -80,9 +81,9 @@ export default async function SimulatorPage() {
     <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[1100px]">
       <Header title="복리 시뮬레이터" sub="계좌별 미래 자산 예측 · 시나리오 비교" />
       <SimulatorClient accounts={accountData} />
-      <p className="mt-6 text-[11px] text-dim">
+      <Disclaimer className="mt-6">
         시뮬레이션 결과는 가정된 수익률에 기반한 참고용이며, 실제 수익을 보장하지 않습니다.
-      </p>
+      </Disclaimer>
     </div>
   )
 }

--- a/src/app/stock-options/page.tsx
+++ b/src/app/stock-options/page.tsx
@@ -3,6 +3,7 @@ import Header from '@/components/layout/Header'
 import StockOptionDashboard from '@/components/stock-option/StockOptionDashboard'
 import ExerciseSimulator from '@/components/stock-option/ExerciseSimulator'
 import StockOptionCRUD from '@/components/stock-option/StockOptionCRUD'
+import Disclaimer from '@/components/ui/Disclaimer'
 import { calcStockOptionOverview } from '@/lib/stock-option-utils'
 import type { StockOptionWithVestings } from '@/lib/stock-option-utils'
 
@@ -98,9 +99,9 @@ export default async function StockOptionsPage() {
         </>
       )}
 
-      <p className="text-[11px] text-dim">
+      <Disclaimer>
         세금 정보는 참고용이며 법적 조언이 아닙니다. 행사 이익만 기준 추정이며, 기존 연봉 합산 시 세율이 달라질 수 있습니다.
-      </p>
+      </Disclaimer>
     </div>
   )
 }

--- a/src/app/tax/page.tsx
+++ b/src/app/tax/page.tsx
@@ -8,6 +8,7 @@ import SellTaxSimulator from '@/components/tax/SellTaxSimulator'
 import DividendTaxCard from '@/components/tax/DividendTaxCard'
 import IncomeProfileCard from '@/components/tax/IncomeProfileCard'
 import IntegratedTaxCard from '@/components/tax/IntegratedTaxCard'
+import Disclaimer from '@/components/ui/Disclaimer'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
 import { calcRealizedGains, calcCapitalGainsSummary } from '@/lib/tax/capital-gains-tax'
 import { calcRSUTaxSummary } from '@/lib/tax/income-tax'
@@ -401,9 +402,9 @@ export default async function TaxPage(props: TaxPageProps) {
         <IncomeProfileCard profiles={incomeProfiles} />
       </div>
 
-      <p className="text-[11px] text-dim">
+      <Disclaimer>
         세금 정보는 참고용이며 법적 조언이 아닙니다. 정확한 세금 계산은 세무사에게 문의하세요.
-      </p>
+      </Disclaimer>
     </div>
   )
 }

--- a/src/components/dividend/DividendForm.tsx
+++ b/src/components/dividend/DividendForm.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Card from '@/components/ui/Card'
 import { calcDividendTax, calcAmountKRW } from '@/lib/dividend-utils'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 interface Account {
   id: string
@@ -411,9 +412,7 @@ export default function DividendForm({ accounts }: DividendFormProps) {
         )}
 
         {/* 면책 문구 */}
-        <p className="text-[11px] text-dim leading-relaxed">
-          배당소득세 정보는 참고용이며 법적 조언이 아닙니다.
-        </p>
+        <Disclaimer>배당소득세 정보는 참고용이며 법적 조언이 아닙니다.</Disclaimer>
 
         {/* 에러 */}
         {error && (

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -5,6 +5,7 @@ import Card from '@/components/ui/Card'
 import { formatKRW, formatDate } from '@/lib/format'
 import RSUForm from './RSUForm'
 import RSUDeleteModal from './RSUDeleteModal'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 interface RSUSchedule {
   id: string
@@ -264,9 +265,9 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
         </div>
       )}
 
-      <div className="text-[11px] text-dim mt-4 px-1">
+      <Disclaimer className="mt-4">
         RSU 근로소득세는 회사에서 원천징수됩니다. 이 계산은 참고용이며 법적 조언이 아닙니다.
-      </div>
+      </Disclaimer>
 
       {/* RSU 추가/수정 폼 */}
       {showForm && (

--- a/src/components/tax/IntegratedTaxCard.tsx
+++ b/src/components/tax/IntegratedTaxCard.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 import { formatKRW } from '@/lib/format'
 import { calcIntegratedTax } from '@/lib/tax/integrated-tax'
+import Disclaimer from '@/components/ui/Disclaimer'
 
 interface IntegratedTaxCardProps {
   /** 선택 연도 */
@@ -197,14 +198,12 @@ export default function IntegratedTaxCard({
       )}
 
       {/* 안내 */}
-      <div className="bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-2">
-        <span className="text-[11px] text-yellow-400/70">
-          {result.stockOptionGain > 0
-            ? '스톡옵션 행사 이익은 현재 주가 기준 예상치이며, 실제 행사 시점의 시가에 따라 달라집니다. '
-            : ''}
-          인적공제·특별공제 등이 미반영된 참고용 추정치입니다. 정확한 세금 계산은 세무사에게 문의하세요.
-        </span>
-      </div>
+      <Disclaimer>
+        {result.stockOptionGain > 0
+          ? '스톡옵션 행사 이익은 현재 주가 기준 예상치이며, 실제 행사 시점의 시가에 따라 달라집니다. '
+          : ''}
+        인적공제·특별공제 등이 미반영된 참고용 추정치입니다. 정확한 세금 계산은 세무사에게 문의하세요.
+      </Disclaimer>
     </div>
   )
 }

--- a/src/components/ui/Disclaimer.tsx
+++ b/src/components/ui/Disclaimer.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react'
+
+interface DisclaimerProps {
+  children: ReactNode
+  /** 외부 spacing (mt/mb) 전달용. 컴포넌트 자체는 외부 마진 없음. */
+  className?: string
+}
+
+/**
+ * 세금/추정치 면책 박스. amber 톤 + ⓘ 아이콘.
+ * children 으로 블록 요소도 안전하게 받을 수 있도록 본문은 div 로 둔다.
+ */
+export default function Disclaimer({ children, className = '' }: DisclaimerProps) {
+  return (
+    <div
+      role="note"
+      className={`flex gap-2 bg-amber-500/5 border border-amber-500/20 rounded-lg px-4 py-2.5 ${className}`}
+    >
+      <span aria-hidden="true" className="text-amber-400 text-[13px] leading-relaxed shrink-0">
+        ⓘ
+      </span>
+      <div className="text-[12px] text-amber-200/90 leading-relaxed">{children}</div>
+    </div>
+  )
+}

--- a/src/components/ui/Disclaimer.tsx
+++ b/src/components/ui/Disclaimer.tsx
@@ -9,17 +9,23 @@ interface DisclaimerProps {
 /**
  * 세금/추정치 면책 박스. amber 톤 + ⓘ 아이콘.
  * children 으로 블록 요소도 안전하게 받을 수 있도록 본문은 div 로 둔다.
+ * light/dark 양쪽에서 충분한 대비를 갖도록 dark: prefix 로 색상 분리.
  */
 export default function Disclaimer({ children, className = '' }: DisclaimerProps) {
   return (
     <div
       role="note"
-      className={`flex gap-2 bg-amber-500/5 border border-amber-500/20 rounded-lg px-4 py-2.5 ${className}`}
+      className={`flex gap-2 bg-amber-50 border border-amber-300 dark:bg-amber-500/5 dark:border-amber-500/20 rounded-lg px-4 py-2.5 ${className}`}
     >
-      <span aria-hidden="true" className="text-amber-400 text-[13px] leading-relaxed shrink-0">
+      <span
+        aria-hidden="true"
+        className="text-amber-600 dark:text-amber-400 text-[13px] leading-relaxed shrink-0"
+      >
         ⓘ
       </span>
-      <div className="text-[12px] text-amber-200/90 leading-relaxed">{children}</div>
+      <div className="text-[12px] text-amber-800 dark:text-amber-200/90 leading-relaxed">
+        {children}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 요약

세금/추정치 면책 문구가 9개 위치에서 모두 \`text-[11px] text-dim\` (희미한 회색 본문) 으로 페이지에 묻혀 있었음. \`<Disclaimer>\` 단일 컴포넌트로 통일해 amber 톤 박스 + ⓘ 아이콘으로 시선을 끌고, 향후 면책 톤/문구 변경 시 한 곳에서 관리.

### 신규 컴포넌트
\`src/components/ui/Disclaimer.tsx\`
- amber-500/5 배경 + amber-500/20 보더 + ⓘ 아이콘 (text-amber-400)
- 본문 text-[12px] text-amber-200/90 (기존 11px → 12px 가독성 ↑)
- \`role="note"\` (스크린리더), \`aria-hidden\` icon
- children 으로 블록 요소도 안전하게 받을 수 있도록 본문은 div

### 일괄 교체 (9개)
| 페이지 | 컴포넌트 |
|---|---|
| \`app/tax\`, \`deposits\`, \`dividends\`, \`stock-options\`, \`simulator\`, \`performance\` | \`tax/IntegratedTaxCard\`, \`rsu/RSUDashboard\`, \`dividend/DividendForm\` |

부모 spacing 은 \`className="mt-4|mt-6"\` 으로 전달.

Closes #303

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 69 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=3 (모두 선택 사항, 2건 반영: JSDoc + p→div 미래 안전) ✅

## 후속 후보 (별도 phase)
- 코드베이스 내 yellow 톤 안내 박스 4곳 (RSUTaxCard, ExerciseSimulator, StockOptionDashboard, SimulatorSummary) — \`<Notice variant="warning">\` 같은 일반 안내 컴포넌트로 통합 검토