### PR TITLE
[Phase 25-G-3] Holding diff 토스트 + 토스트 인프라 (#305)

### DIFF
--- a/docs/specs/305-holding-diff-toast.md
+++ b/docs/specs/305-holding-diff-toast.md
@@ -1,0 +1,209 @@
+# [Phase 25-G-3] Holding diff 토스트
+
+## 목적
+
+거래 생성/수정 직후 보유 수량과 평단가가 어떻게 변했는지 토스트로 즉시 알린다. 현재는 `router.push`/`router.refresh` 만 수행해 사용자가 변경을 따로 확인해야 함. 동시에 프로젝트 전반에서 재사용할 토스트 인프라를 도입.
+
+## 배경
+
+- `createTrade` 는 이미 `{ trade, holding }` 반환 구조 — `holdingBefore` 만 추가하면 diff 계산 가능
+- 토스트 시스템 부재 (`setError` 박스만 사용)
+- DELETE 응답은 25-E 에서 `204 No Content` 로 통일됨 → DELETE 토스트는 본 스코프에서 제외
+
+## 요구사항
+
+- [ ] `src/components/ui/Toast.tsx` 토스트 인프라 (Context + Provider + 컴포넌트 + `useToast()` 훅)
+- [ ] `src/app/layout.tsx` 에 `<ToastProvider>` 추가
+- [ ] `src/lib/trade-service.ts` `CreateTradeResult` 에 `holdingBefore` 추가, transaction 시작 시 select
+- [ ] `src/app/api/trades/[id]/route.ts` PUT 응답에 `holdingBefore`/`holdingAfter` 추가
+- [ ] `src/lib/holding-diff.ts` 신규 — `formatHoldingDiff(ticker, type, shares, before, after, currency)` 헬퍼
+- [ ] `TradeForm` 생성 후 토스트 표시
+- [ ] `EditPanel` 수정 후 토스트 표시
+- [ ] `holding-diff` 단위 테스트 (5 케이스: 첫 매수, 추가 매수, 부분 매도, 전량 매도, 수정)
+
+## 기술 설계
+
+### 1. Toast 인프라
+
+```tsx
+// src/components/ui/Toast.tsx
+'use client'
+import { createContext, useCallback, useContext, useEffect, useState, ReactNode } from 'react'
+
+type ToastVariant = 'success' | 'error' | 'info'
+
+interface Toast {
+  id: string
+  variant: ToastVariant
+  title: string
+  description?: string
+}
+
+interface ToastContextValue {
+  show: (toast: Omit<Toast, 'id'>) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const show = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    setToasts((prev) => [...prev, { ...toast, id }].slice(-3)) // 최대 3개
+  }, [])
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <div
+        role="region"
+        aria-label="알림"
+        className="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-[360px] w-[calc(100vw-2rem)]"
+      >
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={() => dismiss(t.id)} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  const [paused, setPaused] = useState(false)
+  useEffect(() => {
+    if (paused) return
+    const t = setTimeout(onDismiss, 4000)
+    return () => clearTimeout(t)
+  }, [paused, onDismiss])
+
+  const accent = {
+    success: 'border-l-emerald-500',
+    error: 'border-l-red-500',
+    info: 'border-l-sky-500',
+  }[toast.variant]
+
+  return (
+    <div
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      className={`bg-bg-raised border border-border ${accent} border-l-4 rounded-lg px-4 py-3 shadow-xl`}
+      role="status"
+    >
+      <p className="text-[13px] font-semibold text-bright">{toast.title}</p>
+      {toast.description && (
+        <p className="text-[12px] text-sub mt-1 leading-relaxed">{toast.description}</p>
+      )}
+    </div>
+  )
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within ToastProvider')
+  return ctx
+}
+```
+
+### 2. API 응답 확장
+
+`trade-service.ts`:
+```ts
+export interface CreateTradeResult {
+  trade: { ... }
+  holding: { shares, avgPrice, avgPriceFx, avgFxRate } | null
+  holdingBefore: { shares, avgPrice, avgPriceFx, avgFxRate } | null  // 신규
+}
+```
+
+transaction 시작 부분에 `tx.holding.findUnique(...)` 한 번 더 추가 (이미 SELL 검증에서 select하므로 변수 재활용 가능).
+
+`PUT /api/trades/[id]`:
+```ts
+// recalcHoldingFromTrades 전에 select holding → holdingBefore
+// 끝나고 select 또는 결과 반환
+return NextResponse.json({ trade: updated, holding: after, holdingBefore: before })
+```
+
+### 3. holding-diff 헬퍼
+
+```ts
+// src/lib/holding-diff.ts
+interface HoldingSnapshot {
+  shares: number
+  avgPrice: number       // KRW 환산
+  avgPriceFx: number | null  // USD 평단가
+  avgFxRate: number | null
+}
+
+export interface HoldingDiff {
+  title: string
+  description: string
+}
+
+export function formatHoldingDiff(args: {
+  ticker: string
+  displayName: string
+  type: 'BUY' | 'SELL'
+  shares: number
+  before: HoldingSnapshot | null
+  after: HoldingSnapshot | null
+  currency: string
+}): HoldingDiff
+```
+
+규칙:
+- 첫 매수 (`before === null`): `"<name> <shares>주 매수 — 신규 보유 (평단 X)"`
+- 추가 매수 (`before.shares > 0 && type === 'BUY'`): `"보유 X → Y주, 평단 A → B"`
+- 부분 매도: `"보유 X → Y주 (평단 변동 없음)"`
+- 전량 매도 (`after === null || after.shares === 0`): `"<name> <shares>주 매도 — 보유 종료"`
+
+USD 종목은 `avgPriceFx` 가 있으면 USD 표시, 없으면 KRW.
+
+### 4. 호출자 통합
+
+```tsx
+// TradeForm.tsx
+const { show } = useToast()
+// ... res 처리 후
+const result = await res.json()
+const diff = formatHoldingDiff({
+  ticker, displayName, type: tradeType,
+  shares: parsedShares,
+  before: result.holdingBefore,
+  after: result.holding,
+  currency,
+})
+show({ variant: 'success', title: diff.title, description: diff.description })
+router.push('/trades')
+```
+
+### 5. 단위 테스트 (`__tests__/holding-diff.test.ts`)
+
+- 첫 매수 KRW / USD
+- 추가 매수 평단 변동
+- 부분 매도 평단 변동 없음
+- 전량 매도
+- 수정 — before/after 모두 있는 케이스 (수량/평단 변동)
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 신규 5+ 케이스
+- 수동 회귀:
+  - 새 거래 생성 → 토스트 표시 → 4초 후 닫힘
+  - 토스트 호버 시 일시정지
+  - 거래 수정 → 토스트 표시
+  - 토스트 3개 초과 시 가장 오래된 것 제거
+
+## 제외 사항
+
+- **DELETE 토스트** — 25-E 204 응답 형식 유지
+- 배당/거래/자산 generic 성공 토스트 — 별도 phase
+- 토스트 액션 버튼 (Undo 등) — 후속 phase
+- 토스트 영구 표시 / 수동 닫기 X 버튼 — 자동 닫힘 + 호버 정지만으로 충분
+- next-themes light 모드 토스트 색상 — `bg-bg-raised`, `border-border` CSS 변수가 자동 대응

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -7,8 +7,16 @@ interface RouteParams {
   params: Promise<{ id: string }>
 }
 
+interface HoldingSnapshot {
+  shares: number
+  avgPrice: number
+  avgPriceFx: number | null
+  avgFxRate: number | null
+}
+
 /**
  * 거래의 계좌+종목에 대해 남은 전체 거래로 Holding을 재계산한다.
+ * 갱신된 holding 스냅샷을 반환한다 (전량 매도 시 null).
  */
 async function recalcHoldingFromTrades(
   tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
@@ -17,7 +25,7 @@ async function recalcHoldingFromTrades(
   displayName: string,
   market: string,
   currency: string
-) {
+): Promise<HoldingSnapshot | null> {
   const remainingTrades = await tx.trade.findMany({
     where: { accountId, ticker },
     orderBy: [{ tradedAt: 'asc' }, { createdAt: 'asc' }],
@@ -27,7 +35,7 @@ async function recalcHoldingFromTrades(
   const holdingState = recalcHolding(remainingTrades)
 
   if (holdingState.shares > 0) {
-    await tx.holding.upsert({
+    const upserted = await tx.holding.upsert({
       where: { accountId_ticker: { accountId, ticker } },
       update: {
         shares: holdingState.shares,
@@ -47,9 +55,16 @@ async function recalcHoldingFromTrades(
         avgFxRate: holdingState.avgFxRate,
       },
     })
-  } else {
-    await tx.holding.deleteMany({ where: { accountId, ticker } })
+    return {
+      shares: upserted.shares,
+      avgPrice: upserted.avgPrice,
+      avgPriceFx: upserted.avgPriceFx,
+      avgFxRate: upserted.avgFxRate,
+    }
   }
+
+  await tx.holding.deleteMany({ where: { accountId, ticker } })
+  return null
 }
 
 export async function PUT(request: NextRequest, props: RouteParams) {
@@ -98,6 +113,18 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       : Math.round(updatedPrice * updatedShares)
 
     const result = await prisma.$transaction(async (tx) => {
+      const priorHolding = await tx.holding.findUnique({
+        where: { accountId_ticker: { accountId: trade.accountId, ticker: trade.ticker } },
+      })
+      const holdingBefore = priorHolding
+        ? {
+            shares: priorHolding.shares,
+            avgPrice: priorHolding.avgPrice,
+            avgPriceFx: priorHolding.avgPriceFx,
+            avgFxRate: priorHolding.avgFxRate,
+          }
+        : null
+
       const updated = await tx.trade.update({
         where: { id: params.id },
         data: {
@@ -110,12 +137,12 @@ export async function PUT(request: NextRequest, props: RouteParams) {
         },
       })
 
-      await recalcHoldingFromTrades(
+      const holding = await recalcHoldingFromTrades(
         tx, trade.accountId, trade.ticker,
         trade.displayName, trade.market, trade.currency
       )
 
-      return updated
+      return { trade: updated, holding, holdingBefore }
     }, { isolationLevel: 'Serializable' })
 
     return NextResponse.json(result)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import BottomTab from '@/components/layout/BottomTab'
 import MainContent from '@/components/layout/MainContent'
 import AuthProvider from '@/components/auth/AuthProvider'
 import ThemeProvider from '@/components/theme/ThemeProvider'
+import { ToastProvider } from '@/components/ui/Toast'
 import ServiceWorkerRegister from '@/components/pwa/ServiceWorkerRegister'
 import { prisma } from '@/lib/prisma'
 
@@ -49,11 +50,13 @@ export default async function RootLayout({
         <ServiceWorkerRegister />
         <ThemeProvider>
           <AuthProvider>
-            <Sidebar accounts={accounts} />
-            <BottomTab accounts={accounts} />
-            <MainContent>
-              {children}
-            </MainContent>
+            <ToastProvider>
+              <Sidebar accounts={accounts} />
+              <BottomTab accounts={accounts} />
+              <MainContent>
+                {children}
+              </MainContent>
+            </ToastProvider>
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/src/components/trade/EditPanel.tsx
+++ b/src/components/trade/EditPanel.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatUSD } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
+import { formatHoldingEditDiff } from '@/lib/holding-diff'
 
 interface Trade {
   id: string
@@ -33,6 +35,7 @@ const ACCOUNT_COLORS: Record<string, string> = {
 
 export default function EditPanel({ trade, onClose }: EditPanelProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -84,6 +87,18 @@ export default function EditPanel({ trade, onClose }: EditPanelProps) {
         const data = await res.json().catch(() => null)
         setError(data?.error ?? '수정에 실패했습니다.')
         return
+      }
+
+      const result = await res.json().catch(() => null)
+      if (result?.holding !== undefined && result?.holdingBefore !== undefined) {
+        const diff = formatHoldingEditDiff({
+          ticker: trade.ticker,
+          displayName: trade.displayName,
+          before: result.holdingBefore,
+          after: result.holding,
+          currency: trade.currency,
+        })
+        show({ variant: 'success', title: diff.title, description: diff.description })
       }
 
       onClose()

--- a/src/components/trade/TradeForm.tsx
+++ b/src/components/trade/TradeForm.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Card from '@/components/ui/Card'
+import { useToast } from '@/components/ui/Toast'
+import { formatHoldingDiff } from '@/lib/holding-diff'
 
 interface Account {
   id: string
@@ -28,6 +30,7 @@ const ACCOUNT_COLORS: Record<string, { border: string; bg: string; text: string 
 
 export default function TradeForm({ accounts }: TradeFormProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -158,6 +161,20 @@ export default function TradeForm({ accounts }: TradeFormProps) {
         const data = await res.json().catch(() => null)
         setError(data?.error ?? '거래 기록에 실패했습니다.')
         return
+      }
+
+      const result = await res.json().catch(() => null)
+      if (result?.holding !== undefined && result?.holdingBefore !== undefined) {
+        const diff = formatHoldingDiff({
+          ticker,
+          displayName,
+          type: tradeType,
+          shares: parsedShares,
+          before: result.holdingBefore,
+          after: result.holding,
+          currency,
+        })
+        show({ variant: 'success', title: diff.title, description: diff.description })
       }
 
       router.push('/trades')

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+
+type ToastVariant = 'success' | 'error' | 'info'
+
+interface Toast {
+  id: string
+  variant: ToastVariant
+  title: string
+  description?: string
+}
+
+interface ToastContextValue {
+  show: (toast: Omit<Toast, 'id'>) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+const MAX_TOASTS = 3
+const AUTO_DISMISS_MS = 4000
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const show = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    setToasts((prev) => [...prev, { ...toast, id }].slice(-MAX_TOASTS))
+  }, [])
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <div
+        role="region"
+        aria-label="알림"
+        className="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-[360px] w-[calc(100vw-2rem)] pointer-events-none"
+      >
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+const ACCENT: Record<ToastVariant, string> = {
+  success: 'border-l-emerald-500',
+  error: 'border-l-red-500',
+  info: 'border-l-sky-500',
+}
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast
+  onDismiss: (id: string) => void
+}) {
+  const [paused, setPaused] = useState(false)
+  const { id } = toast
+
+  useEffect(() => {
+    if (paused) return
+    const handle = setTimeout(() => onDismiss(id), AUTO_DISMISS_MS)
+    return () => clearTimeout(handle)
+  }, [paused, id, onDismiss])
+
+  return (
+    <div
+      role="status"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      className={`pointer-events-auto bg-bg-raised border border-border ${ACCENT[toast.variant]} border-l-4 rounded-lg px-4 py-3 shadow-xl`}
+    >
+      <p className="text-[13px] font-semibold text-bright">{toast.title}</p>
+      {toast.description && (
+        <p className="text-[12px] text-sub mt-1 leading-relaxed">{toast.description}</p>
+      )}
+    </div>
+  )
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within ToastProvider')
+  return ctx
+}

--- a/src/lib/__tests__/holding-diff.test.ts
+++ b/src/lib/__tests__/holding-diff.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { formatHoldingDiff, formatHoldingEditDiff } from '../holding-diff'
+
+describe('formatHoldingDiff — 첫 매수', () => {
+  it('KRW 신규 보유', () => {
+    const r = formatHoldingDiff({
+      ticker: '005930',
+      displayName: '삼성전자',
+      type: 'BUY',
+      shares: 10,
+      before: null,
+      after: { shares: 10, avgPrice: 70000, avgPriceFx: null, avgFxRate: null },
+      currency: 'KRW',
+    })
+    expect(r.title).toBe('삼성전자 10주 매수')
+    expect(r.description).toBe('신규 보유 (평단 70,000원)')
+  })
+
+  it('USD 신규 보유', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      type: 'BUY',
+      shares: 5,
+      before: null,
+      after: { shares: 5, avgPrice: 247000, avgPriceFx: 185, avgFxRate: 1335 },
+      currency: 'USD',
+    })
+    expect(r.title).toBe('Apple 5주 매수')
+    expect(r.description).toBe('신규 보유 (평단 $185.00)')
+  })
+
+  it('before.shares = 0 도 첫 매수로 처리', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      type: 'BUY',
+      shares: 3,
+      before: { shares: 0, avgPrice: 0, avgPriceFx: null, avgFxRate: null },
+      after: { shares: 3, avgPrice: 247000, avgPriceFx: 185, avgFxRate: 1335 },
+      currency: 'USD',
+    })
+    expect(r.description).toBe('신규 보유 (평단 $185.00)')
+  })
+})
+
+describe('formatHoldingDiff — 추가 매수', () => {
+  it('평단 변동', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      type: 'BUY',
+      shares: 5,
+      before: { shares: 10, avgPrice: 240000, avgPriceFx: 180, avgFxRate: 1333 },
+      after: { shares: 15, avgPrice: 244000, avgPriceFx: 183, avgFxRate: 1333 },
+      currency: 'USD',
+    })
+    expect(r.title).toBe('Apple 5주 매수')
+    expect(r.description).toBe('보유 10 → 15주, 평단 $180.00 → $183.00')
+  })
+
+  it('KRW 추가 매수', () => {
+    const r = formatHoldingDiff({
+      ticker: '005930',
+      displayName: '삼성전자',
+      type: 'BUY',
+      shares: 20,
+      before: { shares: 10, avgPrice: 70000, avgPriceFx: null, avgFxRate: null },
+      after: { shares: 30, avgPrice: 72000, avgPriceFx: null, avgFxRate: null },
+      currency: 'KRW',
+    })
+    expect(r.description).toBe('보유 10 → 30주, 평단 70,000원 → 72,000원')
+  })
+})
+
+describe('formatHoldingDiff — 매도', () => {
+  it('부분 매도는 평단 변동 없음', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      type: 'SELL',
+      shares: 3,
+      before: { shares: 15, avgPrice: 244000, avgPriceFx: 183, avgFxRate: 1333 },
+      after: { shares: 12, avgPrice: 244000, avgPriceFx: 183, avgFxRate: 1333 },
+      currency: 'USD',
+    })
+    expect(r.title).toBe('Apple 3주 매도')
+    expect(r.description).toBe('보유 15 → 12주 (평단 변동 없음)')
+  })
+
+  it('전량 매도 — after null', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      type: 'SELL',
+      shares: 15,
+      before: { shares: 15, avgPrice: 244000, avgPriceFx: 183, avgFxRate: 1333 },
+      after: null,
+      currency: 'USD',
+    })
+    expect(r.title).toBe('Apple 15주 매도')
+    expect(r.description).toBe('보유 종료')
+  })
+
+  it('전량 매도 — after.shares = 0', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      type: 'SELL',
+      shares: 15,
+      before: { shares: 15, avgPrice: 244000, avgPriceFx: 183, avgFxRate: 1333 },
+      after: { shares: 0, avgPrice: 0, avgPriceFx: null, avgFxRate: null },
+      currency: 'USD',
+    })
+    expect(r.description).toBe('보유 종료')
+  })
+
+  it('displayName 없으면 ticker 사용', () => {
+    const r = formatHoldingDiff({
+      ticker: 'AAPL',
+      displayName: '',
+      type: 'SELL',
+      shares: 5,
+      before: { shares: 5, avgPrice: 244000, avgPriceFx: 183, avgFxRate: 1333 },
+      after: null,
+      currency: 'USD',
+    })
+    expect(r.title).toBe('AAPL 5주 매도')
+  })
+})
+
+describe('formatHoldingEditDiff', () => {
+  it('수량과 평단 모두 변동', () => {
+    const r = formatHoldingEditDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      before: { shares: 12, avgPrice: 240000, avgPriceFx: 180, avgFxRate: 1333 },
+      after: { shares: 13, avgPrice: 242000, avgPriceFx: 182, avgFxRate: 1333 },
+      currency: 'USD',
+    })
+    expect(r.title).toBe('Apple 거래 수정')
+    expect(r.description).toBe('보유 12 → 13주, 평단 $180.00 → $182.00')
+  })
+
+  it('수량 동일, 평단만 변동', () => {
+    const r = formatHoldingEditDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      before: { shares: 13, avgPrice: 240000, avgPriceFx: 180, avgFxRate: 1333 },
+      after: { shares: 13, avgPrice: 245000, avgPriceFx: 184, avgFxRate: 1333 },
+      currency: 'USD',
+    })
+    expect(r.description).toBe('보유 13주 (수량 변동 없음), 평단 $180.00 → $184.00')
+  })
+
+  it('전량 매도된 거래 수정 → 보유 종료', () => {
+    const r = formatHoldingEditDiff({
+      ticker: 'AAPL',
+      displayName: 'Apple',
+      before: { shares: 5, avgPrice: 240000, avgPriceFx: 180, avgFxRate: 1333 },
+      after: null,
+      currency: 'USD',
+    })
+    expect(r.description).toBe('보유 종료')
+  })
+})

--- a/src/lib/holding-diff.ts
+++ b/src/lib/holding-diff.ts
@@ -1,0 +1,118 @@
+/**
+ * 거래 전후 Holding 변화를 사용자 친화 문장으로 포맷.
+ * 토스트 알림에 사용.
+ */
+
+export interface HoldingSnapshot {
+  shares: number
+  avgPrice: number              // KRW 환산
+  avgPriceFx: number | null     // USD 평단가 (USD 종목만)
+  avgFxRate: number | null
+}
+
+export interface HoldingDiff {
+  title: string
+  description: string
+}
+
+interface FormatArgs {
+  ticker: string
+  displayName: string
+  type: 'BUY' | 'SELL'
+  shares: number
+  before: HoldingSnapshot | null
+  after: HoldingSnapshot | null
+  currency: string
+}
+
+function formatPrice(holding: HoldingSnapshot, currency: string): string {
+  if (currency === 'USD' && holding.avgPriceFx != null) {
+    return `$${holding.avgPriceFx.toFixed(2)}`
+  }
+  return `${Math.round(holding.avgPrice).toLocaleString('ko-KR')}원`
+}
+
+function priceUnchanged(before: HoldingSnapshot, after: HoldingSnapshot, currency: string): boolean {
+  if (currency === 'USD' && before.avgPriceFx != null && after.avgPriceFx != null) {
+    return Math.abs(before.avgPriceFx - after.avgPriceFx) < 0.005
+  }
+  return Math.abs(before.avgPrice - after.avgPrice) < 0.5
+}
+
+export function formatHoldingDiff(args: FormatArgs): HoldingDiff {
+  const { ticker, displayName, type, shares, before, after, currency } = args
+  const name = displayName || ticker
+
+  // 전량 매도 (after === null 또는 shares=0)
+  if (!after || after.shares === 0) {
+    return {
+      title: `${name} ${shares}주 매도`,
+      description: '보유 종료',
+    }
+  }
+
+  // 첫 매수 (before === null 또는 shares=0)
+  if (!before || before.shares === 0) {
+    return {
+      title: `${name} ${shares}주 매수`,
+      description: `신규 보유 (평단 ${formatPrice(after, currency)})`,
+    }
+  }
+
+  const priceParts = priceUnchanged(before, after, currency)
+    ? '평단 변동 없음'
+    : `평단 ${formatPrice(before, currency)} → ${formatPrice(after, currency)}`
+
+  if (type === 'BUY') {
+    return {
+      title: `${name} ${shares}주 매수`,
+      description: `보유 ${before.shares} → ${after.shares}주, ${priceParts}`,
+    }
+  }
+
+  // SELL (부분)
+  return {
+    title: `${name} ${shares}주 매도`,
+    description: `보유 ${before.shares} → ${after.shares}주 (${priceParts})`,
+  }
+}
+
+/**
+ * 거래 수정 후 변경된 holding 을 알리는 별도 포맷 (BUY/SELL 구분 없음).
+ */
+export function formatHoldingEditDiff(args: {
+  ticker: string
+  displayName: string
+  before: HoldingSnapshot | null
+  after: HoldingSnapshot | null
+  currency: string
+}): HoldingDiff {
+  const { ticker, displayName, before, after, currency } = args
+  const name = displayName || ticker
+
+  if (!after || after.shares === 0) {
+    return {
+      title: `${name} 거래 수정`,
+      description: '보유 종료',
+    }
+  }
+
+  if (!before || before.shares === 0) {
+    return {
+      title: `${name} 거래 수정`,
+      description: `보유 ${after.shares}주, 평단 ${formatPrice(after, currency)}`,
+    }
+  }
+
+  const shareParts = before.shares === after.shares
+    ? `보유 ${after.shares}주 (수량 변동 없음)`
+    : `보유 ${before.shares} → ${after.shares}주`
+  const priceParts = priceUnchanged(before, after, currency)
+    ? '평단 변동 없음'
+    : `평단 ${formatPrice(before, currency)} → ${formatPrice(after, currency)}`
+
+  return {
+    title: `${name} 거래 수정`,
+    description: `${shareParts}, ${priceParts}`,
+  }
+}

--- a/src/lib/trade-service.ts
+++ b/src/lib/trade-service.ts
@@ -43,6 +43,13 @@ export interface CreateTradeResult {
     avgPriceFx: number | null
     avgFxRate: number | null
   } | null
+  /** 거래 적용 전 holding 스냅샷 (없으면 신규 보유). 토스트 diff 계산용. */
+  holdingBefore: {
+    shares: number
+    avgPrice: number
+    avgPriceFx: number | null
+    avgFxRate: number | null
+  } | null
 }
 
 export async function createTrade(input: CreateTradeInput): Promise<CreateTradeResult> {
@@ -94,13 +101,23 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
   }
 
   const result = await prisma.$transaction(async (tx) => {
+    // 거래 적용 전 holding 스냅샷 (토스트 diff 계산용)
+    const priorHolding = await tx.holding.findUnique({
+      where: { accountId_ticker: { accountId, ticker } },
+    })
+    const holdingBefore = priorHolding
+      ? {
+          shares: priorHolding.shares,
+          avgPrice: priorHolding.avgPrice,
+          avgPriceFx: priorHolding.avgPriceFx,
+          avgFxRate: priorHolding.avgFxRate,
+        }
+      : null
+
     // SELL: 보유수량 확인
     if (type === 'SELL') {
-      const holding = await tx.holding.findUnique({
-        where: { accountId_ticker: { accountId, ticker } },
-      })
-      if (!holding || holding.shares < shares) {
-        const current = holding?.shares ?? 0
+      if (!priorHolding || priorHolding.shares < shares) {
+        const current = priorHolding?.shares ?? 0
         throw new Error(`보유 수량(${current}주)을 초과합니다.`)
       }
     }
@@ -194,7 +211,7 @@ export async function createTrade(input: CreateTradeInput): Promise<CreateTradeR
       await tx.holding.deleteMany({ where: { accountId, ticker } })
     }
 
-    return { trade, holding }
+    return { trade, holding, holdingBefore }
   }, { isolationLevel: 'Serializable' })
 
   return result


### PR DESCRIPTION
## 요약

거래 생성/수정 직후 보유 수량과 평단가가 어떻게 변했는지 토스트로 즉시 알림. 동시에 프로젝트 전반에서 재사용할 토스트 인프라 신규 도입.

### 신규
- \`src/components/ui/Toast.tsx\` — Context + Provider + \`useToast()\` 훅
  - 자동 닫힘 4초, 호버 시 일시정지, 최대 3개 큐 FIFO
  - light/dark 자동 대응 (\`bg-bg-raised\`, \`border-border\` CSS 변수)
- \`src/lib/holding-diff.ts\` — \`formatHoldingDiff\` (BUY/SELL) + \`formatHoldingEditDiff\` (수정용)
  - 첫 매수, 추가 매수, 부분 매도, 전량 매도, 수정 케이스별 다른 문구
- \`src/lib/__tests__/holding-diff.test.ts\` — 12 케이스

### 변경
- \`src/app/layout.tsx\` — \`<ToastProvider>\` 마운트
- \`src/lib/trade-service.ts\` — \`CreateTradeResult\` 에 \`holdingBefore\` 추가 (transaction 시작 시 snapshot)
- \`src/app/api/trades/[id]/route.ts\` PUT — 응답 형식 \`{ trade, holding, holdingBefore }\`
  - \`recalcHoldingFromTrades\` 가 snapshot 반환하도록 시그니처 변경 (round-trip 절약, DELETE 호환)
- \`src/components/trade/TradeForm.tsx\` / \`EditPanel.tsx\` — 응답 diff 로 토스트 표시 후 navigate

### 토스트 메시지 예시
- \`AAPL 5주 매수\` / 신규 보유 (평단 $185.00)
- \`AAPL 5주 매수\` / 보유 10 → 15주, 평단 $180 → $183
- \`AAPL 3주 매도\` / 보유 15 → 12주 (평단 변동 없음)
- \`AAPL 15주 매도\` / 보유 종료

Closes #305

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 5 files / 81 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건, 2회차)

## 코드 리뷰 결과
- **1차**: P2=0 / P1=1 (Toast 타이머 리셋) / P0=1 (PUT 중복 findUnique)
- **2차**: P2=0 / P1=0 / P0=0 ✅

## 제외 (별도 phase 후보)
- DELETE 토스트 — 25-E 의 204 응답 형식 유지
- 배당/거래/자산 generic 성공 토스트