### PR TITLE
[Phase 26-A] Prisma TransactionClient 타입 정리 (#310)

### DIFF
--- a/docs/specs/310-prisma-tx-type.md
+++ b/docs/specs/310-prisma-tx-type.md
@@ -1,0 +1,46 @@
+# [Phase 26-A] Prisma TransactionClient 타입 정리
+
+## 목적
+
+`src/app/api/trades/[id]/route.ts` 의 helper `recalcHoldingFromTrades` 가 `tx` 파라미터를 `Parameters<Parameters<typeof prisma.$transaction>[0]>[0]` 라는 우회 패턴으로 받고 있다. Prisma `$transaction` 의 오버로드 시그니처에서 추출하는 형태라 가독성 저하 + 도구가 잘못 해석할 여지가 있음 (실제 Codex 가 false positive P1 으로 잡은 사례). `Prisma.TransactionClient` 로 교체해 의도 명확화.
+
+## 배경
+
+- `tsc --noEmit` 는 통과 (현 패턴이 의미상 같은 타입을 추출)
+- Codex 자동 리뷰가 `TS2344` / `tx is never` false positive 를 반복적으로 잡음
+- Prisma 가 공식적으로 export 하는 `Prisma.TransactionClient` 직접 사용이 표준
+
+## 요구사항
+
+- [ ] `src/app/api/trades/[id]/route.ts`
+  - `Prisma` 타입 import 추가 (`import { Prisma } from '@prisma/client'`)
+  - `recalcHoldingFromTrades` 의 `tx` 파라미터 타입을 `Prisma.TransactionClient` 로 변경
+- [ ] `tsc --noEmit` + `vitest` + `next build` 회귀 없음
+
+## 기술 설계
+
+```ts
+// before
+async function recalcHoldingFromTrades(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  ...
+)
+
+// after
+import { Prisma } from '@prisma/client'
+
+async function recalcHoldingFromTrades(
+  tx: Prisma.TransactionClient,
+  ...
+)
+```
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 거래 수정/삭제 흐름 수동 회귀 (PUT/DELETE 모두 동일 helper 호출)
+
+## 제외 사항
+
+- 다른 `$transaction` 사용처는 모두 인라인 콜백이라 자동 추론 — 변경 불필요
+- helper 함수가 추가될 때마다 동일 패턴 따르도록 신규 코드 가이드는 별도 phase 에서 다룸 (필요 시)

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, validateTradedAt, validateFxRateForUSD } from '@/lib/trade-utils'
 import { businessErrorResponse, isSafeBusinessError } from '@/lib/api-errors'
@@ -19,7 +20,7 @@ interface HoldingSnapshot {
  * 갱신된 holding 스냅샷을 반환한다 (전량 매도 시 null).
  */
 async function recalcHoldingFromTrades(
-  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  tx: Prisma.TransactionClient,
   accountId: string,
   ticker: string,
   displayName: string,


### PR DESCRIPTION
## 요약

\`recalcHoldingFromTrades\` 의 \`tx\` 파라미터 타입을 우회 패턴 (\`Parameters<Parameters<typeof prisma.\$transaction>[0]>[0]\`) → 공식 \`Prisma.TransactionClient\` 로 정리.

### 배경
- Codex 자동 리뷰가 우회 패턴에 대해 false positive P1 (\`TS2344\` / \`tx is never\`) 을 반복적으로 잡음
- 실제 tsc 는 통과하나 가독성/도구 호환성 향상 위해 공식 타입 사용

### 변경
- \`src/app/api/trades/[id]/route.ts\`:
  - \`import { Prisma } from '@prisma/client'\` 추가
  - \`tx: Prisma.TransactionClient\` 로 타입 변경

Closes #310

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 95 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=0 ✅
- 타입 동등성 검증 (Prisma.TransactionClient = Omit<DefaultPrismaClient, ITXClientDenyList> 와 \$transaction 콜백 시그니처 동일)
- helper 의 model accessor 사용 모두 호환
- 다른 라우트에 동일 우회 패턴 없음 (grep 0건)