### PR TITLE
[Phase 26-B] Notice 컴포넌트 통합 (#312)

### DIFF
--- a/docs/specs/312-notice-component.md
+++ b/docs/specs/312-notice-component.md
@@ -1,0 +1,103 @@
+# [Phase 26-B] Notice 컴포넌트 (variant 안내 박스) 통합
+
+## 목적
+
+5개 위치에 흩어진 yellow/amber 톤 안내 박스를 `<Notice variant>` 단일 컴포넌트로 통일. 25-G-2 의 Disclaimer (면책 전용) 와 별개로 일반 안내/경고/오류용. 향후 동일 패턴 추가 시 한 곳에서 관리.
+
+## 배경
+
+| 파일 | 톤 | 의미 |
+|---|---|---|
+| `src/components/tax/RSUTaxCard.tsx:94` | yellow | 경고 (베스팅 전 예상치) |
+| `src/components/stock-option/ExerciseSimulator.tsx:123` | yellow | 경고 (행사 이익 기준 추정) |
+| `src/components/stock-option/StockOptionDashboard.tsx:187` | yellow | 경고 (만료까지 N일) |
+| `src/components/simulator/SimulatorSummary.tsx:125` | yellow | 경고 (증여세 한도 도달) |
+| `src/components/trade/import/StepMapping.tsx:131` | amber | 오류 (필수 필드 미매핑) |
+
+기존 4곳은 모두 `bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-2` 동일 패턴. dark only — light 모드 대비 부족.
+
+## 요구사항
+
+- [ ] `src/components/ui/Notice.tsx` 신규 컴포넌트
+  - props: `variant: 'warning' | 'error' | 'info'`, `children: ReactNode`, `className?: string`
+  - variant 별 컬러 (light/dark `dark:` prefix 양쪽 대응)
+  - `role="note"` (warning/info), `role="alert"` (error)
+- [ ] 4 warning + 1 error 사용처 일괄 교체
+- [ ] light/dark 모드 대비 충분 (WCAG AA 이상)
+
+## 기술 설계
+
+### 컴포넌트
+
+```tsx
+// src/components/ui/Notice.tsx
+import { ReactNode } from 'react'
+
+type Variant = 'warning' | 'error' | 'info'
+
+interface Props {
+  variant?: Variant
+  children: ReactNode
+  className?: string
+}
+
+const STYLES: Record<Variant, { bg: string; text: string; role: 'note' | 'alert' }> = {
+  warning: {
+    bg: 'bg-yellow-50 border border-yellow-300 dark:bg-yellow-500/5 dark:border-yellow-500/20',
+    text: 'text-yellow-800 dark:text-yellow-200/90',
+    role: 'note',
+  },
+  error: {
+    bg: 'bg-red-50 border border-red-300 dark:bg-red-500/10 dark:border-red-500/20',
+    text: 'text-red-800 dark:text-red-300',
+    role: 'alert',
+  },
+  info: {
+    bg: 'bg-sky-50 border border-sky-300 dark:bg-sky-500/5 dark:border-sky-500/20',
+    text: 'text-sky-800 dark:text-sky-200/90',
+    role: 'note',
+  },
+}
+
+export default function Notice({ variant = 'warning', children, className = '' }: Props) {
+  const s = STYLES[variant]
+  return (
+    <div role={s.role} className={`${s.bg} rounded-lg px-3 py-2 ${className}`}>
+      <p className={`text-[11px] leading-relaxed ${s.text}`}>{children}</p>
+    </div>
+  )
+}
+```
+
+- 본문 `<p>` 사용 (Disclaimer 는 div — children 에 블록 들어올 가능성 차이). Notice 는 인라인 텍스트만 가정.
+- 외부 spacing 은 className 전달 (Disclaimer 동일 패턴)
+- 아이콘 없음 (기존 4곳 디자인에 아이콘 없었고 짧은 텍스트라 시각적 노이즈 최소화)
+
+### 적용
+
+```tsx
+// RSUTaxCard / ExerciseSimulator / StockOptionDashboard / SimulatorSummary
+<Notice variant="warning">베스팅 전 예상치입니다...</Notice>
+
+// StepMapping
+<Notice variant="error" className="mt-4">필수 필드 미매핑: {fields}</Notice>
+```
+
+mt 같은 외부 spacing 만 `className` 으로 전달.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: 5 화면 모두 렌더링 + light/dark 토글
+- 대비비 확인:
+  - warning light: yellow-800 (#854d0e) on yellow-50 (#fefce8) ≈ 9.7:1 (WCAG AAA)
+  - error light: red-800 (#991b1b) on red-50 (#fef2f2) ≈ 8.9:1 (WCAG AAA)
+  - info light: sky-800 (#075985) on sky-50 (#f0f9ff) ≈ 8.8:1 (WCAG AAA)
+
+## 제외 사항
+
+- 아이콘 추가 — 후속 phase. 현재는 텍스트 자체로 충분
+- KidsClient 의 대형 안내 영역 (p-5 text-center) — 별도 디자인이라 Notice 범위 밖
+- 닫기 버튼/dismiss — 정적 안내라 불필요
+- success variant — 현재 사용처 없음. 추가 시 같은 패턴
+- Disclaimer 와 통합 — Disclaimer 는 면책 전용 (amber 톤 + ⓘ 아이콘 + 별도 의미). 분리 유지.

--- a/src/components/simulator/SimulatorSummary.tsx
+++ b/src/components/simulator/SimulatorSummary.tsx
@@ -2,6 +2,7 @@
 
 import { formatKRW } from '@/lib/format'
 import type { AccountSimulation } from '@/lib/simulator/compound-engine'
+import Notice from '@/components/ui/Notice'
 
 const ACCOUNT_COLORS: Record<string, string> = {
   세진: '#34d399',
@@ -116,19 +117,15 @@ export default function SimulatorSummary({ simulations, years }: SimulatorSummar
                   <>
                     <div className="h-px bg-surface-dim" />
                     {sim.giftLimitMonth === 0 ? (
-                      <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-1.5">
-                        <span className="text-[11px] text-red-400">
-                          증여세 비과세 한도 (2,000만원) 초과
-                        </span>
-                      </div>
+                      <Notice variant="error">
+                        증여세 비과세 한도 (2,000만원) 초과
+                      </Notice>
                     ) : (
-                      <div className="bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-1.5">
-                        <span className="text-[11px] text-yellow-400/70">
-                          현재 적립 속도 기준 약 {Math.floor(sim.giftLimitMonth / 12)}년{' '}
-                          {sim.giftLimitMonth % 12 > 0 ? `${sim.giftLimitMonth % 12}개월` : ''} 후
-                          증여세 비과세 한도 도달 예상
-                        </span>
-                      </div>
+                      <Notice variant="warning">
+                        현재 적립 속도 기준 약 {Math.floor(sim.giftLimitMonth / 12)}년{' '}
+                        {sim.giftLimitMonth % 12 > 0 ? `${sim.giftLimitMonth % 12}개월` : ''} 후
+                        증여세 비과세 한도 도달 예상
+                      </Notice>
                     )}
                   </>
                 )}

--- a/src/components/stock-option/ExerciseSimulator.tsx
+++ b/src/components/stock-option/ExerciseSimulator.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react'
 import { formatKRW } from '@/lib/format'
 import { simulateExercise, calcIncomeTaxOnExercise } from '@/lib/stock-option-utils'
 import type { StockOptionWithVestings } from '@/lib/stock-option-utils'
+import Notice from '@/components/ui/Notice'
 
 interface ExerciseSimulatorProps {
   stockOptions: StockOptionWithVestings[]
@@ -120,12 +121,10 @@ export default function ExerciseSimulator({ stockOptions, currentPrice }: Exerci
                   </span>
                 </div>
 
-                <div className="mt-1 bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-2">
-                  <span className="text-[11px] text-yellow-400/70">
-                    행사 이익만 기준 추정입니다. 기존 연봉 합산 시 세율이 높아질 수 있습니다.
-                    정확한 계산은 근로소득 프로필 등록 후 통합 세금 시뮬레이션을 이용하세요.
-                  </span>
-                </div>
+                <Notice variant="warning" className="mt-1">
+                  행사 이익만 기준 추정입니다. 기존 연봉 합산 시 세율이 높아질 수 있습니다.
+                  정확한 계산은 근로소득 프로필 등록 후 통합 세금 시뮬레이션을 이용하세요.
+                </Notice>
               </>
             )}
           </div>

--- a/src/components/stock-option/StockOptionDashboard.tsx
+++ b/src/components/stock-option/StockOptionDashboard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatKRW, formatUSD, formatDate } from '@/lib/format'
 import type { StockOptionOverview } from '@/lib/stock-option-utils'
+import Notice from '@/components/ui/Notice'
 
 interface StockOptionDashboardProps {
   overview: StockOptionOverview
@@ -184,11 +185,9 @@ export default function StockOptionDashboard({ overview, currentPrice, currency 
 
             {/* 만료일 경고 */}
             {opt.daysToExpiry <= 365 && opt.daysToExpiry > 0 && (
-              <div className="mt-3 bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-2">
-                <span className="text-[11px] text-yellow-400/70">
-                  만료까지 {opt.daysToExpiry}일 남았습니다.
-                </span>
-              </div>
+              <Notice variant="warning" className="mt-3">
+                만료까지 {opt.daysToExpiry}일 남았습니다.
+              </Notice>
             )}
           </div>
         </div>

--- a/src/components/tax/RSUTaxCard.tsx
+++ b/src/components/tax/RSUTaxCard.tsx
@@ -2,6 +2,7 @@
 
 import { formatKRW, formatDate, formatPercent } from '@/lib/format'
 import type { RSUTaxEstimate } from '@/lib/tax/income-tax'
+import Notice from '@/components/ui/Notice'
 
 interface RSUTaxCardProps {
   estimates: RSUTaxEstimate[]
@@ -91,11 +92,9 @@ export default function RSUTaxCard({ estimates, totalGrossIncome, totalTax }: RS
               </div>
             )}
             {e.status === 'pending' && e.grossIncome > 0 && (
-              <div className="mt-3 bg-yellow-500/5 border border-yellow-500/10 rounded-lg px-3 py-2">
-                <span className="text-[11px] text-yellow-400/70">
-                  베스팅 전 예상치입니다. 실제 세금은 베스팅일 종가에 따라 변동됩니다.
-                </span>
-              </div>
+              <Notice variant="warning" className="mt-3">
+                베스팅 전 예상치입니다. 실제 세금은 베스팅일 종가에 따라 변동됩니다.
+              </Notice>
             )}
           </div>
         </div>

--- a/src/components/trade/import/StepMapping.tsx
+++ b/src/components/trade/import/StepMapping.tsx
@@ -12,6 +12,7 @@ import {
   TRADE_FIELD_LABELS as LABELS,
   REQUIRED_FIELDS as REQUIRED,
 } from '@/types/csv-import'
+import Notice from '@/components/ui/Notice'
 
 interface StepMappingProps {
   headers: string[]
@@ -128,11 +129,9 @@ export default function StepMapping({
         </div>
 
         {missingRequired.length > 0 && (
-          <div className="mt-4 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2">
-            <p className="text-[11px] text-amber-400">
-              필수 필드 미매핑: {missingRequired.map((f) => LABELS[f]).join(', ')}
-            </p>
-          </div>
+          <Notice variant="error" className="mt-4">
+            필수 필드 미매핑: {missingRequired.map((f) => LABELS[f]).join(', ')}
+          </Notice>
         )}
       </Card>
 

--- a/src/components/ui/Notice.tsx
+++ b/src/components/ui/Notice.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from 'react'
+
+type Variant = 'warning' | 'error' | 'info'
+
+interface Props {
+  variant?: Variant
+  children: ReactNode
+  /** 외부 spacing (mt/mb) 전달용. 컴포넌트 자체는 외부 마진 없음. */
+  className?: string
+}
+
+const STYLES: Record<
+  Variant,
+  { container: string; text: string; role: 'note' | 'alert' }
+> = {
+  warning: {
+    container:
+      'bg-yellow-50 border border-yellow-300 dark:bg-yellow-500/5 dark:border-yellow-500/20',
+    text: 'text-yellow-800 dark:text-yellow-200/90',
+    role: 'note',
+  },
+  error: {
+    container:
+      'bg-red-50 border border-red-300 dark:bg-red-500/10 dark:border-red-500/20',
+    text: 'text-red-800 dark:text-red-300',
+    role: 'alert',
+  },
+  info: {
+    container:
+      'bg-sky-50 border border-sky-300 dark:bg-sky-500/5 dark:border-sky-500/20',
+    text: 'text-sky-800 dark:text-sky-200/90',
+    role: 'note',
+  },
+}
+
+/**
+ * 일반 안내/경고/오류 박스. light/dark 양쪽 충분한 대비 보장.
+ * 면책 전용 박스는 별도의 <Disclaimer> 사용.
+ */
+export default function Notice({
+  variant = 'warning',
+  children,
+  className = '',
+}: Props) {
+  const s = STYLES[variant]
+  return (
+    <div role={s.role} className={`${s.container} rounded-lg px-3 py-2 ${className}`}>
+      <p className={`text-[11px] leading-relaxed ${s.text}`}>{children}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## 요약

5+1개 위치에 흩어진 yellow/amber/red 톤 안내 박스를 \`<Notice variant>\` 단일 컴포넌트로 통합. 25-G-2 Disclaimer (면책 전용) 와 별개의 일반 안내 + 향후 동일 패턴 추가 시 한 곳에서 관리.

### 신규 컴포넌트
\`src/components/ui/Notice.tsx\`
- \`variant: 'warning' | 'error' | 'info'\`
- light/dark \`dark:\` prefix 양쪽 대응 (WCAG AAA)
- \`role="note"\` (warning/info), \`role="alert"\` (error — 동적 변경 대비)

### 일괄 교체 (5+1)
| 파일 | 변환 |
|---|---|
| \`RSUTaxCard.tsx:94\` | yellow → warning |
| \`ExerciseSimulator.tsx:124\` | yellow → warning |
| \`StockOptionDashboard.tsx:188\` | yellow → warning |
| \`SimulatorSummary.tsx:120, 126\` | red + yellow 짝 → error + warning |
| \`StepMapping.tsx:131\` | amber → error |

### 디자인 결정
- Disclaimer 와 분리 유지 (면책 전용 vs 일반 안내)
- 아이콘 없음 (짧은 텍스트 + 시각적 노이즈 최소화)
- 외부 spacing 은 \`className\` prop

Closes #312

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 95 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=0 ✅
- WCAG AAA 대비 검증 (warning 9.7:1, error 8.9:1, info 8.8:1)
- role 의미 적절성 확인

## 후속 후보 (별도 phase)
- 폼 인라인 에러 박스 ~20곳 → \`<FormError>\` 별도 컴포넌트 (padding 다름)