### PR TITLE
[Phase 26-D] Generic 성공 토스트 확장 (22 컴포넌트) (#316)

### DIFF
--- a/docs/specs/316-generic-toast.md
+++ b/docs/specs/316-generic-toast.md
@@ -1,0 +1,105 @@
+# [Phase 26-D] Generic 성공 토스트 확장
+
+## 목적
+
+25-G-3 에서 도입한 Toast 인프라를 거래/배당/자산/카테고리 등 다른 mutation 컴포넌트에도 확장 적용. 사용자가 생성/수정/삭제 성공을 명확하게 인지하도록 한다.
+
+## 배경
+
+- Toast 인프라 (`<ToastProvider>` + `useToast()`) 이미 존재 (25-G-3)
+- 현재 적용 컴포넌트: TradeForm + TradeEditPanel (holding diff 토스트)
+- 나머지 22개 mutation 컴포넌트는 `router.refresh` + 모달 닫기만 — 사용자 피드백 없음
+- DELETE 응답 형식 (25-E 204) 은 그대로 유지 — 클라이언트는 `res.ok` 만 확인 후 토스트 표시
+
+## 요구사항
+
+- [ ] **9 DeleteModal** 에 성공 토스트 추가:
+  - DividendDeleteModal — "배당이 삭제되었습니다"
+  - DepositDeleteModal — "입금이 삭제되었습니다"
+  - AssetDeleteModal — "자산이 삭제되었습니다"
+  - CategoryDeleteModal — "카테고리가 삭제되었습니다"
+  - TransactionDeleteModal — "내역이 삭제되었습니다"
+  - RecurringDeleteModal — "반복 거래가 삭제되었습니다"
+  - DeleteModal (Trade) — "거래가 삭제되었습니다"
+  - RSUDeleteModal — "RSU가 삭제되었습니다"
+  - StockOptionDeleteModal — "스톡옵션이 삭제되었습니다"
+- [ ] **13 Form/EditPanel** 에 성공 토스트 추가:
+  - DividendForm (POST) — "배당이 등록되었습니다"
+  - DividendEditPanel (PUT) — "배당이 수정되었습니다"
+  - DepositForm (POST) — "입금이 등록되었습니다"
+  - DepositEditPanel (PUT) — "입금이 수정되었습니다"
+  - AssetForm (POST/PUT) — 모드별 분기
+  - CategoryForm (POST) — "카테고리가 추가되었습니다"
+  - CategoryEditPanel (PUT) — "카테고리가 수정되었습니다"
+  - RSUForm (POST/PUT) — 모드별 분기
+  - StockOptionForm (POST/PUT) — 모드별 분기
+  - IncomeProfileForm (POST/PUT) — "소득정보가 저장되었습니다"
+  - TransactionForm (POST/PUT) — 모드별 분기
+  - RecurringForm (POST/PUT) — "반복거래가 저장되었습니다"
+  - WatchlistForm (POST/PUT) — 모드별 분기
+
+총 **22 컴포넌트**.
+
+## 제외
+
+- **TradeForm / TradeEditPanel** — 이미 holding diff 토스트 적용 (25-G-3). 중복 노이즈 회피.
+- **Category Reorder** (CategoryTable.tsx) — 드래그-드롭 자동 저장, 빈번
+- **BudgetManager 인라인 편집** — 값 변경마다 자동 저장, 빈번
+- **실패 토스트** — 기존 `setError` 박스 유지 (폼 컨텍스트 가까이 표시가 더 적합)
+- **자연어 거래 입력** (텔레그램, AI) — UI 외부
+
+## 기술 설계
+
+### 1. 적용 패턴
+
+모든 컴포넌트가 동일 패턴:
+
+```tsx
+'use client'
+import { useToast } from '@/components/ui/Toast'
+
+const { show } = useToast()
+
+// handleSubmit / handleDelete 내부
+if (res.ok) {
+  show({ variant: 'success', title: '배당이 삭제되었습니다' })
+  onClose() // or router.push / router.refresh
+}
+```
+
+### 2. 모드별 메시지 (Form 이 생성/수정 겸용)
+
+```tsx
+const isEdit = !!props.entity?.id
+show({
+  variant: 'success',
+  title: isEdit ? '자산이 수정되었습니다' : '자산이 등록되었습니다',
+})
+```
+
+### 3. 에러 처리 변경 없음
+
+기존 `setError(...)` 박스 유지. 토스트는 성공 케이스만.
+
+### 4. 영향 검증
+
+- 폼별로 `useToast` import 추가
+- 성공 분기 (res.ok 후) 에 `show(...)` 1줄 추가
+- 페이지 전환 시 토스트는 layout 레벨이라 유지됨 (25-G-3 검증 완료)
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트는 추가하지 않음 — 패턴이 단순하고 UI 검증 위주
+- 수동 회귀:
+  - 9 DeleteModal 모두 삭제 후 토스트 표시 확인
+  - 13 Form/EditPanel 모두 생성/수정 후 토스트 표시 확인
+  - 4초 후 자동 닫힘 + 호버 정지 (Toast 인프라 동작)
+  - 페이지 전환 후에도 토스트 표시 유지
+
+## 제외 사항 (재정리)
+
+- 실패 토스트 — `setError` 박스 유지
+- 토스트 메시지 i18n — 한국어 고정
+- 자동 저장 컴포넌트 (Category reorder, BudgetManager) — 노이즈 우려
+- TradeForm/EditPanel — holding diff 토스트로 충분

--- a/src/components/asset/AssetDeleteModal.tsx
+++ b/src/components/asset/AssetDeleteModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatKRW } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 import type { AssetRow } from './AssetTable'
 
 interface AssetDeleteModalProps {
@@ -12,6 +13,7 @@ interface AssetDeleteModalProps {
 
 export default function AssetDeleteModal({ asset, onClose }: AssetDeleteModalProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -21,6 +23,7 @@ export default function AssetDeleteModal({ asset, onClose }: AssetDeleteModalPro
     try {
       const res = await fetch(`/api/assets/${asset.id}`, { method: 'DELETE' })
       if (res.ok) {
+        show({ variant: 'success', title: '자산이 삭제되었습니다' })
         onClose()
         router.refresh()
       } else {

--- a/src/components/asset/AssetForm.tsx
+++ b/src/components/asset/AssetForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useToast } from '@/components/ui/Toast'
 import type { AssetRow } from './AssetTable'
 
 const CATEGORIES = [
@@ -24,6 +25,8 @@ interface AssetFormProps {
 
 export default function AssetForm({ mode, asset, onClose }: AssetFormProps) {
   const router = useRouter()
+  const { show } = useToast()
+  const isEdit = mode === 'edit'
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -87,6 +90,10 @@ export default function AssetForm({ mode, asset, onClose }: AssetFormProps) {
         setError(data?.error ?? '저장에 실패했습니다.')
         return
       }
+      show({
+        variant: 'success',
+        title: isEdit ? '자산이 수정되었습니다' : '자산이 추가되었습니다',
+      })
       onClose()
       router.refresh()
     } catch {
@@ -98,7 +105,6 @@ export default function AssetForm({ mode, asset, onClose }: AssetFormProps) {
 
   const inputClasses = 'w-full bg-surface-dim border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-bright placeholder-dim focus:outline-none focus:bg-surface focus:border-border-hover transition-colors'
   const labelClasses = 'block text-[12px] font-semibold text-sub mb-1.5'
-  const isEdit = mode === 'edit'
   const selectStyle = {
     backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`,
     backgroundRepeat: 'no-repeat',

--- a/src/components/category/CategoryDeleteModal.tsx
+++ b/src/components/category/CategoryDeleteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useToast } from '@/components/ui/Toast'
 import type { CategoryRow } from './CategoryTable'
 
 interface CategoryDeleteModalProps {
@@ -11,6 +12,7 @@ interface CategoryDeleteModalProps {
 
 export default function CategoryDeleteModal({ category, onClose }: CategoryDeleteModalProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -33,6 +35,7 @@ export default function CategoryDeleteModal({ category, onClose }: CategoryDelet
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '카테고리가 삭제되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/category/CategoryEditPanel.tsx
+++ b/src/components/category/CategoryEditPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { CATEGORY_TYPES, CATEGORY_TYPE_LABELS } from '@/lib/category-utils'
+import { useToast } from '@/components/ui/Toast'
 import type { CategoryRow } from './CategoryTable'
 
 interface CategoryEditPanelProps {
@@ -12,6 +13,7 @@ interface CategoryEditPanelProps {
 
 export default function CategoryEditPanel({ category, onClose }: CategoryEditPanelProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -78,6 +80,7 @@ export default function CategoryEditPanel({ category, onClose }: CategoryEditPan
         return
       }
 
+      show({ variant: 'success', title: '카테고리가 수정되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/category/CategoryForm.tsx
+++ b/src/components/category/CategoryForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { CATEGORY_TYPES, CATEGORY_TYPE_LABELS } from '@/lib/category-utils'
+import { useToast } from '@/components/ui/Toast'
 
 interface CategoryFormProps {
   onClose: () => void
@@ -10,6 +11,7 @@ interface CategoryFormProps {
 
 export default function CategoryForm({ onClose }: CategoryFormProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -62,6 +64,7 @@ export default function CategoryForm({ onClose }: CategoryFormProps) {
         return
       }
 
+      show({ variant: 'success', title: '카테고리가 추가되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/deposit/DepositDeleteModal.tsx
+++ b/src/components/deposit/DepositDeleteModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatKRW, formatDate } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 import type { DepositRow } from './DepositTable'
 
 interface DepositDeleteModalProps {
@@ -12,6 +13,7 @@ interface DepositDeleteModalProps {
 
 export default function DepositDeleteModal({ deposit, onClose }: DepositDeleteModalProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -34,6 +36,7 @@ export default function DepositDeleteModal({ deposit, onClose }: DepositDeleteMo
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '입금이 삭제되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/deposit/DepositEditPanel.tsx
+++ b/src/components/deposit/DepositEditPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { DEPOSIT_SOURCES } from '@/lib/deposit-utils'
+import { useToast } from '@/components/ui/Toast'
 import type { DepositRow } from './DepositTable'
 
 interface DepositEditPanelProps {
@@ -18,6 +19,7 @@ const ACCOUNT_COLORS: Record<string, string> = {
 
 export default function DepositEditPanel({ deposit, onClose }: DepositEditPanelProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -76,6 +78,7 @@ export default function DepositEditPanel({ deposit, onClose }: DepositEditPanelP
         return
       }
 
+      show({ variant: 'success', title: '입금이 수정되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/deposit/DepositForm.tsx
+++ b/src/components/deposit/DepositForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Card from '@/components/ui/Card'
 import { DEPOSIT_SOURCES } from '@/lib/deposit-utils'
+import { useToast } from '@/components/ui/Toast'
 
 interface Account {
   id: string
@@ -22,6 +23,7 @@ const ACCOUNT_COLORS: Record<string, { border: string; bg: string; text: string 
 
 export default function DepositForm({ accounts }: DepositFormProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -62,6 +64,7 @@ export default function DepositForm({ accounts }: DepositFormProps) {
         return
       }
 
+      show({ variant: 'success', title: '입금이 등록되었습니다' })
       router.push('/deposits')
       router.refresh()
     } catch {

--- a/src/components/dividend/DividendDeleteModal.tsx
+++ b/src/components/dividend/DividendDeleteModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatKRW, formatUSD, formatDate } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 import type { DividendRow } from './DividendTable'
 
 interface DividendDeleteModalProps {
@@ -12,6 +13,7 @@ interface DividendDeleteModalProps {
 
 export default function DividendDeleteModal({ dividend, onClose }: DividendDeleteModalProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -34,6 +36,7 @@ export default function DividendDeleteModal({ dividend, onClose }: DividendDelet
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '배당이 삭제되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/dividend/DividendEditPanel.tsx
+++ b/src/components/dividend/DividendEditPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatUSD } from '@/lib/format'
 import { calcDividendTax, calcAmountKRW } from '@/lib/dividend-utils'
+import { useToast } from '@/components/ui/Toast'
 import type { DividendRow } from './DividendTable'
 
 interface DividendEditPanelProps {
@@ -19,6 +20,7 @@ const ACCOUNT_COLORS: Record<string, string> = {
 
 export default function DividendEditPanel({ dividend, onClose }: DividendEditPanelProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -105,6 +107,7 @@ export default function DividendEditPanel({ dividend, onClose }: DividendEditPan
         return
       }
 
+      show({ variant: 'success', title: '배당이 수정되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/dividend/DividendForm.tsx
+++ b/src/components/dividend/DividendForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import Card from '@/components/ui/Card'
 import { calcDividendTax, calcAmountKRW } from '@/lib/dividend-utils'
 import Disclaimer from '@/components/ui/Disclaimer'
+import { useToast } from '@/components/ui/Toast'
 
 interface Account {
   id: string
@@ -29,6 +30,7 @@ const ACCOUNT_COLORS: Record<string, { border: string; bg: string; text: string 
 
 export default function DividendForm({ accounts }: DividendFormProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -142,6 +144,7 @@ export default function DividendForm({ accounts }: DividendFormProps) {
         return
       }
 
+      show({ variant: 'success', title: '배당이 등록되었습니다' })
       router.push('/dividends')
       router.refresh()
     } catch {

--- a/src/components/expense/RecurringDeleteModal.tsx
+++ b/src/components/expense/RecurringDeleteModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { formatKRW } from '@/lib/format'
 import { formatFrequency } from '@/lib/recurring-utils'
+import { useToast } from '@/components/ui/Toast'
 import type { RecurringRow } from './RecurringTable'
 
 interface RecurringDeleteModalProps {
@@ -12,6 +13,7 @@ interface RecurringDeleteModalProps {
 }
 
 export default function RecurringDeleteModal({ item, onClose, onDeleted }: RecurringDeleteModalProps) {
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -31,6 +33,7 @@ export default function RecurringDeleteModal({ item, onClose, onDeleted }: Recur
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '반복 거래가 삭제되었습니다' })
       onDeleted()
       onClose()
     } catch {

--- a/src/components/expense/RecurringForm.tsx
+++ b/src/components/expense/RecurringForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useToast } from '@/components/ui/Toast'
 import type { RecurringRow } from './RecurringTable'
 
 interface CategoryOption {
@@ -30,6 +31,7 @@ type Frequency = 'monthly' | 'weekly' | 'yearly'
 const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
 
 export default function RecurringForm({ mode, item, prefill, categories, onClose, onSaved }: RecurringFormProps) {
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -89,6 +91,7 @@ export default function RecurringForm({ mode, item, prefill, categories, onClose
         setError(data?.error ?? '저장에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '반복거래가 저장되었습니다' })
       onSaved()
       onClose()
     } catch {

--- a/src/components/expense/TransactionDeleteModal.tsx
+++ b/src/components/expense/TransactionDeleteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { formatKRW, formatDate } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 
 interface TransactionForDelete {
   id: string
@@ -25,6 +26,7 @@ export default function TransactionDeleteModal({
   onClose,
   onDeleted,
 }: TransactionDeleteModalProps) {
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -47,6 +49,7 @@ export default function TransactionDeleteModal({
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '내역이 삭제되었습니다' })
       onDeleted()
       onClose()
     } catch {

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { useToast } from '@/components/ui/Toast'
 
 interface CategorySuggestion {
   categoryId: string
@@ -70,6 +71,7 @@ export default function TransactionForm({
   onClose,
   onSaved,
 }: TransactionFormProps) {
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -190,6 +192,10 @@ export default function TransactionForm({
         return
       }
 
+      show({
+        variant: 'success',
+        title: mode === 'edit' ? '내역이 수정되었습니다' : '내역이 등록되었습니다',
+      })
       onSaved()
       onClose()
     } catch {

--- a/src/components/rsu/RSUDeleteModal.tsx
+++ b/src/components/rsu/RSUDeleteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { formatKRW, formatDate } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 
 interface RSUDeleteModalProps {
   item: { id: string; vestingDate: string; shares: number; basisValue: number }
@@ -10,6 +11,7 @@ interface RSUDeleteModalProps {
 }
 
 export default function RSUDeleteModal({ item, onClose, onDeleted }: RSUDeleteModalProps) {
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -29,6 +31,7 @@ export default function RSUDeleteModal({ item, onClose, onDeleted }: RSUDeleteMo
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: 'RSU가 삭제되었습니다' })
       onDeleted()
       onClose()
     } catch {

--- a/src/components/rsu/RSUForm.tsx
+++ b/src/components/rsu/RSUForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useToast } from '@/components/ui/Toast'
 
 interface AccountOption {
   id: string
@@ -28,6 +29,8 @@ interface RSUFormProps {
 }
 
 export default function RSUForm({ mode, item, accounts, onClose, onSaved }: RSUFormProps) {
+  const { show } = useToast()
+  const isEdit = mode === 'edit'
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -77,6 +80,10 @@ export default function RSUForm({ mode, item, accounts, onClose, onSaved }: RSUF
         setError(data?.error ?? '저장에 실패했습니다.')
         return
       }
+      show({
+        variant: 'success',
+        title: isEdit ? 'RSU가 수정되었습니다' : 'RSU가 추가되었습니다',
+      })
       onSaved()
       onClose()
     } catch {
@@ -88,7 +95,6 @@ export default function RSUForm({ mode, item, accounts, onClose, onSaved }: RSUF
 
   const inputClasses = 'w-full bg-surface-dim border border-border rounded-lg px-3.5 py-2.5 text-[13px] text-bright placeholder-dim focus:outline-none focus:bg-surface focus:border-border-hover transition-colors'
   const labelClasses = 'block text-[12px] font-semibold text-sub mb-1.5'
-  const isEdit = mode === 'edit'
 
   return (
     <>

--- a/src/components/stock-option/StockOptionDeleteModal.tsx
+++ b/src/components/stock-option/StockOptionDeleteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { formatKRW } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 
 interface StockOptionDeleteModalProps {
   item: { id: string; displayName: string; strikePrice: number; totalShares: number }
@@ -10,6 +11,7 @@ interface StockOptionDeleteModalProps {
 }
 
 export default function StockOptionDeleteModal({ item, onClose, onDeleted }: StockOptionDeleteModalProps) {
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -29,6 +31,7 @@ export default function StockOptionDeleteModal({ item, onClose, onDeleted }: Sto
         setError(data?.error ?? '삭제에 실패했습니다.')
         return
       }
+      show({ variant: 'success', title: '스톡옵션이 삭제되었습니다' })
       onDeleted()
       onClose()
     } catch {

--- a/src/components/stock-option/StockOptionForm.tsx
+++ b/src/components/stock-option/StockOptionForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useToast } from '@/components/ui/Toast'
 
 interface AccountOption { id: string; name: string }
 
@@ -25,6 +26,7 @@ interface StockOptionFormProps {
 }
 
 export default function StockOptionForm({ mode, item, accounts, onClose, onSaved }: StockOptionFormProps) {
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -79,6 +81,10 @@ export default function StockOptionForm({ mode, item, accounts, onClose, onSaved
         setError(data?.error ?? '저장에 실패했습니다.')
         return
       }
+      show({
+        variant: 'success',
+        title: mode === 'edit' ? '스톡옵션이 수정되었습니다' : '스톡옵션이 추가되었습니다',
+      })
       onSaved()
       onClose()
     } catch {

--- a/src/components/tax/IncomeProfileForm.tsx
+++ b/src/components/tax/IncomeProfileForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatKRW } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 
 interface IncomeProfileFormProps {
   /** 수정 모드 시 기존 데이터 */
@@ -32,6 +33,7 @@ const inputClasses = 'w-full bg-surface-dim border border-border rounded-lg px-3
 
 export default function IncomeProfileForm({ initial, onCancel }: IncomeProfileFormProps) {
   const router = useRouter()
+  const { show } = useToast()
   const isEdit = !!initial
 
   const currentYear = new Date().getFullYear()
@@ -107,6 +109,7 @@ export default function IncomeProfileForm({ initial, onCancel }: IncomeProfileFo
         return
       }
 
+      show({ variant: 'success', title: '소득정보가 저장되었습니다' })
       onCancel?.()
       router.refresh()
     } catch {

--- a/src/components/trade/DeleteModal.tsx
+++ b/src/components/trade/DeleteModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatKRW, formatUSD, formatDate } from '@/lib/format'
+import { useToast } from '@/components/ui/Toast'
 
 interface Trade {
   id: string
@@ -24,6 +25,7 @@ interface DeleteModalProps {
 
 export default function DeleteModal({ trade, onClose }: DeleteModalProps) {
   const router = useRouter()
+  const { show } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -51,6 +53,7 @@ export default function DeleteModal({ trade, onClose }: DeleteModalProps) {
         return
       }
 
+      show({ variant: 'success', title: '거래가 삭제되었습니다' })
       onClose()
       router.refresh()
     } catch {

--- a/src/components/watchlist/WatchlistForm.tsx
+++ b/src/components/watchlist/WatchlistForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useToast } from '@/components/ui/Toast'
 import type { WatchlistRow } from './WatchlistTable'
 
 interface WatchlistFormProps {
@@ -13,6 +14,7 @@ interface WatchlistFormProps {
 const STRATEGIES = ['swing', 'momentum', 'value', 'scalp'] as const
 
 export default function WatchlistForm({ mode, item, onClose, onSaved }: WatchlistFormProps) {
+  const { show } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -61,6 +63,10 @@ export default function WatchlistForm({ mode, item, onClose, onSaved }: Watchlis
         setError(data?.error ?? '저장에 실패했습니다.')
         return
       }
+      show({
+        variant: 'success',
+        title: mode === 'edit' ? '관심종목이 수정되었습니다' : '관심종목이 추가되었습니다',
+      })
       onSaved()
       onClose()
     } catch {


### PR DESCRIPTION
## 요약

25-G-3 의 Toast 인프라(\`useToast\`)를 22개 mutation 컴포넌트에 확장 적용. 사용자가 생성/수정/삭제 성공을 명확히 인지하도록 한다.

### 변경 (23 파일 / +188 -2)
- **9 DeleteModal**: Dividend, Deposit, Asset, Category, Transaction, Recurring, Trade, RSU, StockOption
  - "X가 삭제되었습니다"
- **13 Form/EditPanel**:
  - 분리형 (생성/수정): DividendForm + EditPanel, DepositForm + EditPanel, CategoryForm + EditPanel
  - 모드 분기: AssetForm, RSUForm, StockOptionForm, TransactionForm, WatchlistForm (\`mode === 'edit'\`)
  - 단일 메시지: IncomeProfileForm (\"저장되었습니다\"), RecurringForm (\"저장되었습니다\")
- **isEdit hoisting**: AssetForm/RSUForm 의 중복 \`isEdit\` 선언 제거 (handleSubmit 안에서도 참조 가능하도록 상단으로 이동)

### 디자인 결정
- 성공만 토스트 — 실패는 기존 \`setError\` 박스 유지 (폼 컨텍스트 가까이)
- DELETE 응답 형식 (25-E 204) 그대로 유지 — \`res.ok\` 만 확인
- TradeForm/EditPanel 스킵 (25-G-3 holding diff 토스트 기존 적용, 중복 노이즈 회피)
- Category reorder, BudgetManager 스킵 (자동 저장 노이즈 우려)

Closes #316

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 122 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=3 (모두 선택 사항: 동사 일관성, 스펙 미세 차이, 스타일 균일화) ✅
- 22 컴포넌트 모두 \`res.ok\` 성공 분기에 \`show()\` 위치 검증
- ToastProvider layout 레벨이라 \`router.refresh/push\` 후에도 토스트 유지

## 후속 후보 (별도 phase)
- 동사 일관성 가이드 (추가/등록/저장 통일)
- 인라인 \`mode === 'edit'\` 비교 → \`isEdit\` 변수로 통일