### PR TITLE
[Phase 26-F] 베스팅 캘린더 iCal 내보내기 (RFC 5545) (#318)

### DIFF
--- a/docs/specs/318-vesting-ical.md
+++ b/docs/specs/318-vesting-ical.md
@@ -1,0 +1,144 @@
+# [Phase 26-F] 베스팅 캘린더 iCal 내보내기 (RFC 5545)
+
+## 목적
+
+RSU + 스톡옵션 베스팅 일정을 ICS 표준 파일로 내보내, 사용자가 Google Calendar / Apple Calendar / Outlook 에 import 할 수 있게 한다. 25-G-4 에서 만든 `/vesting` 페이지의 외부 호환성 확장.
+
+## 배경
+
+- 이미 `src/lib/vesting-events.ts` 에 `toVestingEvents()` 헬퍼 존재 (RSU + 옵션 통합)
+- `/vesting` 페이지는 화면 내 캘린더 + 90일 리스트만 제공 → 외부 캘린더 도구 연동 불가
+- RFC 5545 (ICS) 는 모든 주요 캘린더 도구가 지원하는 표준 포맷
+
+## 요구사항
+
+- [ ] `src/lib/ics.ts` 신규 — RFC 5545 직렬화 헬퍼
+  - `buildICS(events: ICSEvent[], opts?): string`
+  - CRLF 라인 종결, 종일 이벤트 형식, 텍스트 이스케이프
+- [ ] `GET /api/exports/vesting.ics` 신규 라우트
+  - Prisma fetch (`prisma.rSUSchedule`, `prisma.stockOption` + vestings)
+  - `toVestingEvents` → ICS 변환
+  - `text/calendar; charset=utf-8` MIME + `Content-Disposition: attachment`
+- [ ] `/vesting` 페이지 다운로드 버튼
+- [ ] 단위 테스트 (`__tests__/ics.test.ts`)
+  - VCALENDAR/VEVENT 구조, CRLF, 종일 이벤트, 이스케이프, 빈 events, UID 안정성
+
+## 기술 설계
+
+### 1. ICS 이벤트 매핑
+
+| 모델 | SUMMARY | DTSTART (KST 캘린더 날짜) | UID | 비고 |
+|---|---|---|---|---|
+| RSU 베스팅 | `[RSU] {shares}주 베스팅` | YYYYMMDD | `rsu-{id}@myfinance.starryjeju.net` | 종일 |
+| 옵션 베스팅 (pending/exercisable) | `[Option] {ticker} {shares}주 베스팅` | YYYYMMDD | `opt-vest-{id}@...` | 종일 |
+| 옵션 만료 (`expiryDate`) | `[Option 만료] {ticker}` | YYYYMMDD | `opt-expire-{id}@...` | 종일 |
+
+**제외**:
+- 옵션 상태 = `exercised` / `expired` (이미 종료)
+- 옵션 만료 이벤트는 별도 fetch (vesting-events 외 — `expiryDate` 직접 활용)
+
+### 2. ICS 헬퍼 인터페이스
+
+```ts
+// src/lib/ics.ts
+export interface ICSEvent {
+  uid: string                  // 안정된 식별자
+  summary: string
+  date: string                 // YYYY-MM-DD (KST 캘린더)
+  description?: string
+}
+
+export interface BuildICSOptions {
+  prodId?: string              // 기본 '-//myFinance//Vesting Calendar//KO'
+  calName?: string             // 기본 'myFinance 베스팅'
+  dtstamp?: string             // 기본 현재 UTC (YYYYMMDDTHHMMSSZ)
+}
+
+export function buildICS(events: ICSEvent[], opts?: BuildICSOptions): string
+```
+
+**핵심 동작**:
+- CRLF (`\r\n`) 라인 종결 — RFC 5545 필수
+- 종일 이벤트: `DTSTART;VALUE=DATE:20260615`
+- 텍스트 필드 이스케이프: `\` → `\\`, `,` → `\,`, `;` → `\;`, `\n` → `\n` (리터럴)
+- 라인 길이 75 octet 초과 시 줄바꿈 (간단화: 일단 미적용, 한국어 SUMMARY 75자 거의 안 넘음 — TODO 후속)
+
+### 3. 라우트
+
+```ts
+// src/app/api/exports/vesting.ics/route.ts
+export async function GET() {
+  const [rsus, options] = await prisma.$transaction([...])
+  const events = toVestingEvents(rsus, options)
+  const icsEvents = events
+    .filter(e => e.status !== 'exercised' && e.status !== 'expired')
+    .map(e => ({
+      uid: `${e.id}@myfinance.starryjeju.net`,
+      summary: e.type === 'RSU'
+        ? `[RSU] ${e.shares}주 베스팅`
+        : `[Option] ${e.ticker} ${e.shares}주 베스팅`,
+      date: e.date,
+    }))
+  // 옵션 만료 별도 추가
+  for (const opt of options) {
+    icsEvents.push({
+      uid: `opt-expire-${opt.id}@...`,
+      summary: `[Option 만료] ${opt.ticker}`,
+      date: toKSTDateString(opt.expiryDate),
+    })
+  }
+  const ics = buildICS(icsEvents)
+  return new Response(ics, {
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="vesting.ics"',
+    },
+  })
+}
+```
+
+### 4. UI
+
+```tsx
+// src/app/vesting/page.tsx 헤더 영역
+<Header title="베스팅 캘린더">
+  <a
+    href="/api/exports/vesting.ics"
+    download="vesting.ics"
+    className="..."
+  >
+    📅 내보내기
+  </a>
+</Header>
+```
+
+### 5. UID 안정성
+
+- 동일 RSU/옵션 베스팅 = 동일 UID
+- 캘린더 도구가 재import 시 중복 추가 대신 업데이트
+- UID = DB primary key + 고정 도메인
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 (~10 케이스):
+  - 빈 events
+  - 단일 이벤트
+  - 다중 이벤트
+  - 텍스트 이스케이프 (콤마, 세미콜론, 백슬래시, 개행)
+  - CRLF 검증
+  - 종일 이벤트 DATE 형식
+  - 동일 입력 = 동일 출력 (UID 안정성)
+- 수동 회귀:
+  - `.ics` 다운로드 → Google Calendar / Apple Calendar import
+  - 이벤트 종일 표시 확인
+  - UID 동일하므로 재import 시 중복 안 생김
+
+## 제외 사항
+
+- **URL 구독** (webcal://, ICS feed 자동 갱신) — 정적 다운로드만 1차
+- **양방향 동기화** (Google Calendar API)
+- 라인 길이 75 octet 자동 줄바꿈 (한국어 SUMMARY 60자 미만이라 실용 불필요)
+- VALARM (알림) — 이미 봇 스케줄러가 처리
+- 사용자 인증 / 토큰 (personal use)
+- 베스팅 외 이벤트 (배당 지급일 등)

--- a/src/app/api/exports/vesting.ics/route.ts
+++ b/src/app/api/exports/vesting.ics/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { toVestingEvents, toKSTDateString } from '@/lib/vesting-events'
+import { buildICS, type ICSEvent } from '@/lib/ics'
+
+export const dynamic = 'force-dynamic'
+
+const ICS_UID_DOMAIN = 'myfinance.starryjeju.net'
+
+/**
+ * GET /api/exports/vesting.ics
+ *
+ * RSU + 스톡옵션 베스팅 + 옵션 만료일을 RFC 5545 iCalendar 파일로 내보낸다.
+ * Google Calendar / Apple Calendar / Outlook 모두 import 가능.
+ */
+export async function GET() {
+  try {
+    const [rsus, options] = await Promise.all([
+      prisma.rSUSchedule.findMany({
+        include: { account: { select: { name: true } } },
+        orderBy: { vestingDate: 'asc' },
+      }),
+      prisma.stockOption.findMany({
+        include: {
+          account: { select: { name: true } },
+          vestings: { orderBy: { vestingDate: 'asc' } },
+        },
+        orderBy: { grantDate: 'asc' },
+      }),
+    ])
+
+    const vestingEvents = toVestingEvents(rsus, options)
+
+    // 베스팅 이벤트 (이미 종료된 상태 제외)
+    const icsEvents: ICSEvent[] = []
+    for (const ev of vestingEvents) {
+      if (ev.status === 'exercised' || ev.status === 'expired') continue
+      const tickerLabel = ev.ticker ?? ''
+      const tickerPart = tickerLabel ? `${tickerLabel} ` : ''
+      const summary = ev.type === 'RSU'
+        ? `[RSU] ${ev.shares}주 베스팅`
+        : `[Option] ${tickerPart}${ev.shares}주 베스팅`
+      icsEvents.push({
+        uid: `${ev.id}@${ICS_UID_DOMAIN}`,
+        summary,
+        date: ev.date,
+        description: `${ev.accountName} 계좌`,
+      })
+    }
+
+    // 옵션 만료 이벤트 (이미 행사 완료된 옵션 제외)
+    for (const opt of options) {
+      if (opt.remainingShares <= 0) continue
+      icsEvents.push({
+        uid: `opt-expire-${opt.id}@${ICS_UID_DOMAIN}`,
+        summary: `[Option 만료] ${opt.ticker}`,
+        date: toKSTDateString(opt.expiryDate),
+        description: `${opt.account.name} 계좌 · 잔여 ${opt.remainingShares}주`,
+      })
+    }
+
+    const ics = buildICS(icsEvents)
+
+    return new Response(ics, {
+      headers: {
+        'Content-Type': 'text/calendar; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="vesting.ics"',
+      },
+    })
+  } catch (error) {
+    console.error('GET /api/exports/vesting.ics error:', error)
+    return NextResponse.json({ error: '캘린더 내보내기에 실패했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/vesting/page.tsx
+++ b/src/app/vesting/page.tsx
@@ -45,7 +45,15 @@ export default async function VestingPage() {
 
   return (
     <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[1080px] flex flex-col gap-6">
-      <Header title="베스팅 캘린더" />
+      <Header title="베스팅 캘린더">
+        <a
+          href="/api/exports/vesting.ics"
+          download="vesting.ics"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-semibold text-sub border border-border hover:bg-surface hover:text-bright transition-colors"
+        >
+          📅 캘린더 내보내기
+        </a>
+      </Header>
 
       <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
         {summaryCards.map((card) => (

--- a/src/lib/__tests__/ics.test.ts
+++ b/src/lib/__tests__/ics.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { buildICS, escapeICSText, type ICSEvent } from '../ics'
+
+const FIXED_DTSTAMP = '2026-06-18T00:00:00Z'
+
+describe('escapeICSText', () => {
+  it('백슬래시 이스케이프', () => {
+    expect(escapeICSText('a\\b')).toBe('a\\\\b')
+  })
+  it('쉼표 이스케이프', () => {
+    expect(escapeICSText('a,b')).toBe('a\\,b')
+  })
+  it('세미콜론 이스케이프', () => {
+    expect(escapeICSText('a;b')).toBe('a\\;b')
+  })
+  it('개행 이스케이프', () => {
+    expect(escapeICSText('a\nb')).toBe('a\\nb')
+  })
+  it('일반 한국어 유지', () => {
+    expect(escapeICSText('RSU 베스팅')).toBe('RSU 베스팅')
+  })
+})
+
+describe('buildICS — 빈 events', () => {
+  it('유효한 VCALENDAR 구조 반환', () => {
+    const ics = buildICS([], { dtstamp: FIXED_DTSTAMP })
+    expect(ics.startsWith('BEGIN:VCALENDAR\r\n')).toBe(true)
+    expect(ics.endsWith('END:VCALENDAR\r\n')).toBe(true)
+    expect(ics).toContain('VERSION:2.0\r\n')
+    expect(ics).toContain('PRODID:-//myFinance//Vesting Calendar//KO\r\n')
+    expect(ics).not.toContain('BEGIN:VEVENT')
+  })
+})
+
+describe('buildICS — CRLF 라인 종결', () => {
+  it('모든 라인이 \\r\\n 으로 구분', () => {
+    const ics = buildICS([
+      { uid: 'a@x', summary: 'Test', date: '2026-06-15' },
+    ], { dtstamp: FIXED_DTSTAMP })
+    // LF only 라인 없음 (\r\n 외부의 단독 \n 0건)
+    const lfOnly = ics.split('').filter((c, i) => c === '\n' && ics[i - 1] !== '\r').length
+    expect(lfOnly).toBe(0)
+    // 마지막 라인 종결 포함
+    expect(ics.endsWith('\r\n')).toBe(true)
+  })
+})
+
+describe('buildICS — 단일 종일 이벤트', () => {
+  it('VEVENT 블록 생성 + DATE 형식', () => {
+    const ev: ICSEvent = {
+      uid: 'rsu-abc@myfinance.starryjeju.net',
+      summary: '[RSU] 300주 베스팅',
+      date: '2026-06-15',
+    }
+    const ics = buildICS([ev], { dtstamp: FIXED_DTSTAMP })
+    expect(ics).toContain('BEGIN:VEVENT\r\n')
+    expect(ics).toContain('UID:rsu-abc@myfinance.starryjeju.net\r\n')
+    expect(ics).toContain('DTSTART;VALUE=DATE:20260615\r\n')
+    expect(ics).toContain('SUMMARY:[RSU] 300주 베스팅\r\n')
+    expect(ics).toContain('DTSTAMP:20260618T000000Z\r\n')
+    expect(ics).toContain('END:VEVENT\r\n')
+  })
+})
+
+describe('buildICS — 다중 이벤트', () => {
+  it('events 순서 유지', () => {
+    const ics = buildICS([
+      { uid: 'a@x', summary: 'First', date: '2026-06-15' },
+      { uid: 'b@x', summary: 'Second', date: '2026-07-20' },
+    ], { dtstamp: FIXED_DTSTAMP })
+    const firstIdx = ics.indexOf('First')
+    const secondIdx = ics.indexOf('Second')
+    expect(firstIdx).toBeGreaterThan(0)
+    expect(secondIdx).toBeGreaterThan(firstIdx)
+    expect(ics.match(/BEGIN:VEVENT/g)?.length).toBe(2)
+    expect(ics.match(/END:VEVENT/g)?.length).toBe(2)
+  })
+})
+
+describe('buildICS — DESCRIPTION 옵션', () => {
+  it('description 있으면 DESCRIPTION 라인 포함', () => {
+    const ics = buildICS([
+      { uid: 'a@x', summary: 'Test', date: '2026-06-15', description: 'extra info' },
+    ], { dtstamp: FIXED_DTSTAMP })
+    expect(ics).toContain('DESCRIPTION:extra info\r\n')
+  })
+  it('description 없으면 DESCRIPTION 라인 생략', () => {
+    const ics = buildICS([
+      { uid: 'a@x', summary: 'Test', date: '2026-06-15' },
+    ], { dtstamp: FIXED_DTSTAMP })
+    expect(ics).not.toContain('DESCRIPTION:')
+  })
+})
+
+describe('buildICS — 텍스트 이스케이프', () => {
+  it('SUMMARY 의 콤마/세미콜론/백슬래시/개행 이스케이프', () => {
+    const ics = buildICS([
+      { uid: 'a@x', summary: 'a,b;c\\d\ne', date: '2026-06-15' },
+    ], { dtstamp: FIXED_DTSTAMP })
+    expect(ics).toContain('SUMMARY:a\\,b\\;c\\\\d\\ne\r\n')
+  })
+})
+
+describe('buildICS — UID 안정성 (재호출 동일 결과)', () => {
+  it('동일 입력 + 동일 dtstamp → 동일 출력', () => {
+    const ev: ICSEvent = { uid: 'stable@x', summary: 'Test', date: '2026-06-15' }
+    const a = buildICS([ev], { dtstamp: FIXED_DTSTAMP })
+    const b = buildICS([ev], { dtstamp: FIXED_DTSTAMP })
+    expect(a).toBe(b)
+  })
+})
+
+describe('buildICS — 옵션 prodId / calName', () => {
+  it('사용자 지정 prodId 적용', () => {
+    const ics = buildICS([], {
+      prodId: '-//Custom//Test//EN',
+      calName: 'CustomCal',
+      dtstamp: FIXED_DTSTAMP,
+    })
+    expect(ics).toContain('PRODID:-//Custom//Test//EN\r\n')
+    expect(ics).toContain('X-WR-CALNAME:CustomCal\r\n')
+  })
+})

--- a/src/lib/__tests__/ics.test.ts
+++ b/src/lib/__tests__/ics.test.ts
@@ -141,6 +141,19 @@ describe('foldICSLine — RFC 5545 §3.1', () => {
     const folded = foldICSLine(line)
     expect(folded).toBe('a'.repeat(75) + '\r\n ' + 'a'.repeat(5))
   })
+  it('연속 segments 도 75 octets 한계 준수 (leading space + 74)', () => {
+    // 첫 75 + 연속(space + 74) + 연속(space + 1) = 총 150 bytes
+    const line = 'a'.repeat(150)
+    const folded = foldICSLine(line)
+    expect(folded).toBe(
+      'a'.repeat(75) + '\r\n ' + 'a'.repeat(74) + '\r\n ' + 'a'.repeat(1),
+    )
+    // 모든 물리 line 이 75 octets 이하인지 검증 (leading space 포함)
+    const physicalLines = folded.split('\r\n')
+    for (const pl of physicalLines) {
+      expect(new TextEncoder().encode(pl).length).toBeLessThanOrEqual(75)
+    }
+  })
   it('한국어 multi-byte UTF-8 → boundary 보존하여 접기', () => {
     // 한국어 1자 = UTF-8 3 bytes. '가' × 30 = 90 bytes (75 초과)
     const line = '가'.repeat(30)

--- a/src/lib/__tests__/ics.test.ts
+++ b/src/lib/__tests__/ics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildICS, escapeICSText, type ICSEvent } from '../ics'
+import { buildICS, escapeICSText, foldICSLine, type ICSEvent } from '../ics'
 
 const FIXED_DTSTAMP = '2026-06-18T00:00:00Z'
 
@@ -119,5 +119,44 @@ describe('buildICS — 옵션 prodId / calName', () => {
     })
     expect(ics).toContain('PRODID:-//Custom//Test//EN\r\n')
     expect(ics).toContain('X-WR-CALNAME:CustomCal\r\n')
+  })
+})
+
+describe('foldICSLine — RFC 5545 §3.1', () => {
+  it('75 octets 이하 — 그대로 반환', () => {
+    const short = 'a'.repeat(75)
+    expect(foldICSLine(short)).toBe(short)
+  })
+  it('75 초과 ASCII → CRLF + space 로 접기', () => {
+    const line = 'a'.repeat(80)
+    const folded = foldICSLine(line)
+    expect(folded).toBe('a'.repeat(75) + '\r\n ' + 'a'.repeat(5))
+  })
+  it('한국어 multi-byte UTF-8 → boundary 보존하여 접기', () => {
+    // 한국어 1자 = UTF-8 3 bytes. '가' × 30 = 90 bytes (75 초과)
+    const line = '가'.repeat(30)
+    const folded = foldICSLine(line)
+    // 줄 접기 발생
+    expect(folded).toContain('\r\n ')
+    // multi-byte 문자가 잘리지 않음 — decode 했을 때 손상 없이 원본 복원
+    const reassembled = folded.split('\r\n ').join('')
+    expect(reassembled).toBe(line)
+  })
+  it('빈 문자열 — 그대로', () => {
+    expect(foldICSLine('')).toBe('')
+  })
+})
+
+describe('buildICS — 긴 SUMMARY/DESCRIPTION 자동 folding', () => {
+  it('긴 한국어 description 도 RFC 5545 § 3.1 준수', () => {
+    const ev: ICSEvent = {
+      uid: 'long@x',
+      summary: 'Test',
+      date: '2026-06-15',
+      description: '가'.repeat(50), // 150 bytes
+    }
+    const ics = buildICS([ev], { dtstamp: FIXED_DTSTAMP })
+    // 75 octets 단위 fold 적용 → "DESCRIPTION:" + content 가 CRLF+space 로 접힘
+    expect(ics).toMatch(/DESCRIPTION:[^\r]+\r\n /)
   })
 })

--- a/src/lib/__tests__/ics.test.ts
+++ b/src/lib/__tests__/ics.test.ts
@@ -19,6 +19,15 @@ describe('escapeICSText', () => {
   it('일반 한국어 유지', () => {
     expect(escapeICSText('RSU 베스팅')).toBe('RSU 베스팅')
   })
+  it('CRLF (Windows 줄종결) 정규화', () => {
+    expect(escapeICSText('a\r\nb')).toBe('a\\nb')
+  })
+  it('단독 CR 정규화 (raw \\r 이 content line 종결자와 충돌 차단)', () => {
+    expect(escapeICSText('a\rb')).toBe('a\\nb')
+  })
+  it('혼합 줄종결 모두 정규화', () => {
+    expect(escapeICSText('a\r\nb\rc\nd')).toBe('a\\nb\\nc\\nd')
+  })
 })
 
 describe('buildICS — 빈 events', () => {

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -23,11 +23,15 @@ export interface BuildICSOptions {
 const DEFAULT_PROD_ID = '-//myFinance//Vesting Calendar//KO'
 const DEFAULT_CAL_NAME = 'myFinance 베스팅'
 
-/** RFC 5545 텍스트 이스케이프: \, comma, semicolon, newline. */
+/**
+ * RFC 5545 텍스트 이스케이프: \, comma, semicolon, newline.
+ * CRLF/CR/LF 모두 리터럴 `\n` 으로 정규화 — raw CR/LF 가 content line 종결자와
+ * 충돌하지 않도록 보장.
+ */
 export function escapeICSText(value: string): string {
   return value
     .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
+    .replace(/\r\n|\r|\n/g, '\\n')
     .replace(/,/g, '\\,')
     .replace(/;/g, '\\;')
 }

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -1,0 +1,86 @@
+/**
+ * RFC 5545 (iCalendar) 직렬화 헬퍼.
+ * 종일 이벤트 위주 (DTSTART;VALUE=DATE).
+ * CRLF 라인 종결, 텍스트 이스케이프 처리.
+ */
+
+export interface ICSEvent {
+  /** 안정된 식별자. 동일 이벤트는 동일 UID. */
+  uid: string
+  summary: string
+  /** YYYY-MM-DD (KST 또는 사용자 로컬 캘린더 날짜). */
+  date: string
+  description?: string
+}
+
+export interface BuildICSOptions {
+  prodId?: string
+  calName?: string
+  /** ISO 8601 UTC 타임스탬프. 미지정 시 호출 시점 사용 (테스트에서는 명시 권장). */
+  dtstamp?: string
+}
+
+const DEFAULT_PROD_ID = '-//myFinance//Vesting Calendar//KO'
+const DEFAULT_CAL_NAME = 'myFinance 베스팅'
+
+/** RFC 5545 텍스트 이스케이프: \, comma, semicolon, newline. */
+export function escapeICSText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;')
+}
+
+/** YYYY-MM-DD → YYYYMMDD (RFC 5545 DATE 형식). */
+function formatICSDate(date: string): string {
+  return date.replace(/-/g, '')
+}
+
+/** Date → 20260615T120000Z (RFC 5545 DATE-TIME UTC 형식). */
+function formatICSDateTimeUTC(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  )
+}
+
+/**
+ * ICSEvent[] 를 RFC 5545 iCalendar 문자열로 직렬화.
+ * 종일 이벤트(DTSTART;VALUE=DATE)로만 출력.
+ */
+export function buildICS(events: ICSEvent[], opts?: BuildICSOptions): string {
+  const prodId = opts?.prodId ?? DEFAULT_PROD_ID
+  const calName = opts?.calName ?? DEFAULT_CAL_NAME
+  const dtstamp = opts?.dtstamp
+    ? formatICSDateTimeUTC(new Date(opts.dtstamp))
+    : formatICSDateTimeUTC(new Date())
+
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    `PRODID:${escapeICSText(prodId)}`,
+    `X-WR-CALNAME:${escapeICSText(calName)}`,
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+  ]
+
+  for (const ev of events) {
+    lines.push(
+      'BEGIN:VEVENT',
+      `UID:${ev.uid}`,
+      `DTSTAMP:${dtstamp}`,
+      `DTSTART;VALUE=DATE:${formatICSDate(ev.date)}`,
+      `SUMMARY:${escapeICSText(ev.summary)}`,
+    )
+    if (ev.description) {
+      lines.push(`DESCRIPTION:${escapeICSText(ev.description)}`)
+    }
+    lines.push('END:VEVENT')
+  }
+
+  lines.push('END:VCALENDAR')
+
+  return lines.join('\r\n') + '\r\n'
+}

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -32,6 +32,33 @@ export function escapeICSText(value: string): string {
     .replace(/;/g, '\\;')
 }
 
+const MAX_LINE_OCTETS = 75
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+/**
+ * RFC 5545 §3.1 content line folding.
+ * 75 octets 초과 시 CRLF + (space) 로 줄 접기.
+ * UTF-8 multi-byte 문자 중간을 자르지 않도록 boundary 보존.
+ */
+export function foldICSLine(line: string): string {
+  const bytes = textEncoder.encode(line)
+  if (bytes.length <= MAX_LINE_OCTETS) return line
+
+  const segments: string[] = []
+  let start = 0
+  while (start < bytes.length) {
+    let end = Math.min(start + MAX_LINE_OCTETS, bytes.length)
+    // UTF-8 boundary 후퇴: 10xxxxxx 는 continuation byte
+    while (end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+      end--
+    }
+    segments.push(textDecoder.decode(bytes.slice(start, end)))
+    start = end
+  }
+  return segments.join('\r\n ')
+}
+
 /** YYYY-MM-DD → YYYYMMDD (RFC 5545 DATE 형식). */
 function formatICSDate(date: string): string {
   return date.replace(/-/g, '')
@@ -82,5 +109,5 @@ export function buildICS(events: ICSEvent[], opts?: BuildICSOptions): string {
 
   lines.push('END:VCALENDAR')
 
-  return lines.join('\r\n') + '\r\n'
+  return lines.map(foldICSLine).join('\r\n') + '\r\n'
 }

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -44,6 +44,10 @@ const textDecoder = new TextDecoder()
  * RFC 5545 §3.1 content line folding.
  * 75 octets 초과 시 CRLF + (space) 로 줄 접기.
  * UTF-8 multi-byte 문자 중간을 자르지 않도록 boundary 보존.
+ *
+ * RFC 5545 의 75 octets 한계는 "line break 제외" 이므로 leading space (1 byte)
+ * 는 line 의 일부로 카운트된다. 따라서 첫 segment 는 75 octets, 연속 segments 는
+ * 74 octets 까지만 허용 (1 byte 를 leading space 에 예약).
  */
 export function foldICSLine(line: string): string {
   const bytes = textEncoder.encode(line)
@@ -52,7 +56,8 @@ export function foldICSLine(line: string): string {
   const segments: string[] = []
   let start = 0
   while (start < bytes.length) {
-    let end = Math.min(start + MAX_LINE_OCTETS, bytes.length)
+    const limit = segments.length === 0 ? MAX_LINE_OCTETS : MAX_LINE_OCTETS - 1
+    let end = Math.min(start + limit, bytes.length)
     // UTF-8 boundary 후퇴: 10xxxxxx 는 continuation byte
     while (end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
       end--


### PR DESCRIPTION
## 요약

RSU + 스톡옵션 베스팅 일정을 ICS (RFC 5545) 표준 파일로 내보내, Google Calendar / Apple Calendar / Outlook 등 외부 캘린더 도구에 import 할 수 있게 한다. 25-G-4 \`/vesting\` 페이지 후속 (외부 호환성).

### 신규
- \`src/lib/ics.ts\` — RFC 5545 직렬화 헬퍼 (\`buildICS\`, \`escapeICSText\`)
  - CRLF 라인 종결, 종일 이벤트 (\`DTSTART;VALUE=DATE\`)
  - 텍스트 이스케이프 (백슬래시/쉼표/세미콜론/개행)
  - UID 안정성 (재import 시 중복 안 생김)
- \`GET /api/exports/vesting.ics\`
  - RSU + 옵션 베스팅 + 옵션 만료 통합
  - exercised/expired 베스팅 제외, \`remainingShares > 0\` 옵션만 만료 이벤트
  - \`text/calendar; charset=utf-8\` + \`Content-Disposition: attachment\`
- \`/vesting\` 페이지 우상단 "📅 캘린더 내보내기" 다운로드 링크 (Header children)

### 이벤트 매핑
| 종류 | SUMMARY | 비고 |
|---|---|---|
| RSU 베스팅 | \`[RSU] {shares}주 베스팅\` | 종일 |
| 옵션 베스팅 | \`[Option] {ticker} {shares}주 베스팅\` | 종일 |
| 옵션 만료 | \`[Option 만료] {ticker}\` | 종일, \`remainingShares > 0\` 만 |

### 테스트 (14 신규)
- 빈 events / 단일 / 다중 / VEVENT 구조
- CRLF 라인 종결 (LF only 라인 0)
- 종일 이벤트 \`DTSTART;VALUE=DATE\` 형식
- 텍스트 이스케이프 (5종)
- DESCRIPTION 옵션
- UID 안정성 (동일 입력 = 동일 출력)
- 옵션 prodId/calName

Closes #318

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 8 files / 136 tests passed (14 신규)
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=0 ✅
- RFC 5545 표준 준수 (CRLF, DATE 형식, 이스케이프, VCALENDAR/VEVENT 구조)
- UID 안정성 검증
- 인증 (글로벌 미들웨어) / 에러 핸들링 (try-catch + 500)

## 제외 (별도 phase)
- URL 구독 (webcal://, ICS feed 자동 갱신) — 정적 다운로드만 1차
- 양방향 동기화 (Google Calendar API)
- 라인 길이 75 octet 자동 줄바꿈 (한국어 SUMMARY 60자 미만)
- VALARM (봇 알림 스케줄러가 이미 처리)