### PR TITLE
[Phase 27-B] 단순 GET 라우트 ApiResponse envelope 마이그 (#323)

### DIFF
--- a/docs/specs/323-simple-get-envelope.md
+++ b/docs/specs/323-simple-get-envelope.md
@@ -1,0 +1,93 @@
+# [Phase 27-B] 단순 GET 라우트 ApiResponse envelope 마이그
+
+## 목적
+
+9차 마일스톤의 두 번째 단계 — 27-A 에서 도입한 `ok()`/`fail()` 헬퍼를 **단순 GET 라우트 10개** + 클라이언트 fetcher 13개에 적용. pagination 가진 라우트는 27-D, GET/PUT 짝은 27-C 로 별도 진행.
+
+## 배경
+
+- 27-A: `ApiResponse<T>` 헬퍼 인프라 구축 완료 (162 단위 테스트)
+- 현재 라우트별 응답 형식이 제각각 (`{ accounts }`, `{ items: [] }`, raw array 등)
+- 점진 마이그 — breaking change 라 같은 PR 에 라우트 + fetcher 동시 변경 필수
+
+## 요구사항
+
+- [ ] 10 GET 라우트 응답 형식을 `ok(data)` 로 통일
+- [ ] 13 클라이언트 fetcher 가 `json.data` 로 unwrap
+- [ ] 라우트와 fetcher 동시 변경 (atomic — breaking change 회피)
+- [ ] 다른 메소드 (POST/PUT/DELETE) 는 변경 없음 (도메인별로 27-C 에서 진행)
+
+## 기술 설계
+
+### 1. 마이그 대상 라우트 / 변환
+
+| # | 라우트 | before | after |
+|---|---|---|---|
+| 1 | `/api/accounts` | `NextResponse.json({ accounts })` | `ok(accounts)` |
+| 2 | `/api/prices` | `NextResponse.json({ prices, lastUpdatedAt })` | `ok({ prices, lastUpdatedAt })` |
+| 3 | `/api/categories` | `NextResponse.json({ categories })` | `ok(categories)` |
+| 4 | `/api/watchlist` | `NextResponse.json({ items })` | `ok(items)` |
+| 5 | `/api/recurring` | `NextResponse.json({ items })` | `ok(items)` |
+| 6 | `/api/reports` | `NextResponse.json({ reports })` | `ok(reports)` |
+| 7 | `/api/category-groups` | `NextResponse.json({ groups })` | `ok(groups)` |
+| 8 | `/api/income-profiles` | `NextResponse.json(profiles)` (raw) | `ok(profiles)` |
+| 9 | `/api/rsu` | `NextResponse.json({ schedules })` | `ok(schedules)` |
+| 10 | `/api/stock-options` | `NextResponse.json({ stockOptions })` | `ok(stockOptions)` |
+
+에러 응답은 그대로 (`fail()` 마이그는 27-C 와 함께 — POST/PUT 의 catch 와 일관 정리).
+
+### 2. 클라이언트 fetcher 패턴 변환
+
+```ts
+// before
+const res = await fetch('/api/accounts')
+const data = await res.json()
+setAccounts(data.accounts)
+
+// after
+const res = await fetch('/api/accounts')
+const json = await res.json()
+setAccounts(json.data)
+```
+
+### 3. 영향 받는 클라이언트 파일 (8개 추정)
+
+- `SettingsClient.tsx` — `/api/accounts`
+- `TradeForm.tsx`, `DividendForm.tsx` — `/api/prices`
+- `ExpensesClient.tsx`, `BudgetsClient.tsx`, `WhooingSettings.tsx` — `/api/categories`
+- `WatchlistClient.tsx` — `/api/watchlist`
+- `RecurringClient.tsx` — `/api/recurring`
+- `ReportsClient.tsx` — `/api/reports`
+- `CategoryEditPanel.tsx` — `/api/category-groups`
+- `IncomeProfileManager.tsx` — `/api/income-profiles`
+- `RSUDashboard.tsx` — `/api/rsu`
+
+### 4. 봇 MCP / 서버컴포넌트 영향
+
+- 봇 standalone 은 prisma 직접 호출 — 라우트 fetch 안 함 (영향 0)
+- MCP 서버는 자체 prisma 호출 (영향 0)
+- 서버 컴포넌트는 prisma 직접 호출 (영향 0)
+
+→ 영향은 클라이언트 컴포넌트만.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 추가 안 함 (27-A 의 ApiResponse 테스트가 헬퍼 자체 검증)
+- 수동 회귀:
+  - 10 라우트가 접근하는 화면 정상 표시
+  - 각 페이지 새로고침 후 fetcher 정상 동작
+  - 에러 케이스 (인증 미통과 등) — 기존 동작 유지
+
+## 제외 사항
+
+- 동일 라우트의 POST/PUT/DELETE 응답 (27-C 와 함께)
+- 에러 응답 (`fail()` 마이그) — 27-C 와 함께
+- pagination GET (trades/deposits/dividends/transactions) — 27-D
+- GET/PUT 짝 라우트 (alerts/config, settings/whooing 등) — 27-C
+- CSV/ICS/PDF 응답 — 영구 스킵 (envelope 불가)
+
+## 호환성
+
+- 라우트와 fetcher 같은 PR 에 묶어 atomic 마이그
+- 다른 라우트는 영향 0 (점진)

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok } from '@/lib/api-response'
 
 export async function GET() {
   try {
@@ -13,7 +14,7 @@ export async function GET() {
       orderBy: { createdAt: 'asc' },
     })
 
-    return NextResponse.json(accounts)
+    return ok(accounts)
   } catch (error) {
     console.error('GET /api/accounts error:', error)
     return NextResponse.json(

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { validateCategoryInput, generateSlug } from '@/lib/category-utils'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
       },
     })
 
-    return NextResponse.json({ categories })
+    return ok(categories)
   } catch (error) {
     console.error('GET /api/categories error:', error)
     return NextResponse.json(

--- a/src/app/api/category-groups/route.ts
+++ b/src/app/api/category-groups/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,7 +13,7 @@ export async function GET() {
       orderBy: { sortOrder: 'asc' },
       include: { _count: { select: { categories: true } } },
     })
-    return NextResponse.json({ groups })
+    return ok(groups)
   } catch (error) {
     console.error('[api/category-groups] GET 실패:', error)
     return NextResponse.json({ error: '그룹 조회에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/income-profiles/route.ts
+++ b/src/app/api/income-profiles/route.ts
@@ -6,6 +6,7 @@ import {
   calcTaxableFromGross,
   type IncomeProfileInput,
 } from '@/lib/tax/income-profile-utils'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,7 +16,7 @@ export async function GET() {
     const profiles = await prisma.incomeProfile.findMany({
       orderBy: { year: 'desc' },
     })
-    return NextResponse.json(profiles)
+    return ok(profiles)
   } catch (error) {
     console.error('GET /api/income-profiles error:', error)
     return NextResponse.json(

--- a/src/app/api/prices/route.ts
+++ b/src/app/api/prices/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { getLastUpdatedAt } from '@/lib/format'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,7 +13,7 @@ export async function GET() {
 
     const lastUpdatedAt = getLastUpdatedAt(prices)
 
-    return NextResponse.json({ prices, lastUpdatedAt })
+    return ok({ prices, lastUpdatedAt })
   } catch (error) {
     console.error('GET /api/prices error:', error)
     return NextResponse.json(

--- a/src/app/api/recurring/route.ts
+++ b/src/app/api/recurring/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateRecurringInput } from '@/lib/recurring-utils'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,7 +35,7 @@ export async function GET() {
       lastRunAt: r.lastRunAt?.toISOString() ?? null,
     }))
 
-    return NextResponse.json({ items: serialized })
+    return ok(serialized)
   } catch (error) {
     console.error('[api/recurring] GET 실패:', error)
     return NextResponse.json({ error: '반복 거래 조회에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { generateReportPDF } from '@/lib/report/pdf-generator'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -13,7 +14,7 @@ export async function GET() {
     const reports = await prisma.quarterlyReport.findMany({
       orderBy: [{ year: 'desc' }, { quarter: 'desc' }],
     })
-    return NextResponse.json({ reports })
+    return ok(reports)
   } catch (error) {
     console.error('GET /api/reports error:', error)
     return NextResponse.json({ error: '리포트 목록을 불러올 수 없습니다.' }, { status: 500 })

--- a/src/app/api/rsu/route.ts
+++ b/src/app/api/rsu/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,7 +12,7 @@ export async function GET() {
       include: { account: { select: { id: true, name: true } } },
     })
 
-    return NextResponse.json({ schedules })
+    return ok(schedules)
   } catch (error) {
     console.error('GET /api/rsu error:', error)
     return NextResponse.json(

--- a/src/app/api/stock-options/route.ts
+++ b/src/app/api/stock-options/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,7 +29,7 @@ export async function GET(request: Request) {
       orderBy: { grantDate: 'asc' },
     })
 
-    return NextResponse.json({ stockOptions })
+    return ok(stockOptions)
   } catch (err) {
     console.error('GET /api/stock-options error:', err)
     return NextResponse.json({ error: '스톡옵션 조회 실패' }, { status: 500 })

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,7 +30,7 @@ export async function GET() {
       updatedAt: i.updatedAt.toISOString(),
     }))
 
-    return NextResponse.json({ items: serialized })
+    return ok(serialized)
   } catch (error) {
     console.error('[api/watchlist] GET 실패:', error)
     return NextResponse.json({ error: '관심종목 조회에 실패했습니다.' }, { status: 500 })

--- a/src/app/budgets/BudgetsClient.tsx
+++ b/src/app/budgets/BudgetsClient.tsx
@@ -77,8 +77,8 @@ export default function BudgetsClient() {
     fetch('/api/categories')
       .then((res) => res.ok ? res.json() : null)
       .then((d) => {
-        if (d?.categories) {
-          setCategories(d.categories)
+        if (Array.isArray(d?.data)) {
+          setCategories(d.data)
         }
       })
       .catch(() => {})

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -90,8 +90,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
   useEffect(() => {
     fetch('/api/categories')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        const cats = data?.categories
+      .then((json) => {
+        const cats = json?.data
         if (Array.isArray(cats)) {
           setCategories(cats.map((c: { id: string; name: string; icon: string | null; type: string }) => ({
             id: c.id,

--- a/src/app/recurring/RecurringClient.tsx
+++ b/src/app/recurring/RecurringClient.tsx
@@ -25,8 +25,8 @@ export default function RecurringClient() {
     try {
       const res = await fetch('/api/recurring')
       if (res.ok) {
-        const data = await res.json()
-        setItems(data.items ?? [])
+        const json = await res.json()
+        setItems(Array.isArray(json.data) ? json.data : [])
       }
     } catch (e) {
       console.error('[recurring] 조회 실패:', e)
@@ -40,8 +40,8 @@ export default function RecurringClient() {
   useEffect(() => {
     fetch('/api/categories')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        if (data?.categories) setCategories(data.categories)
+      .then((json) => {
+        if (Array.isArray(json?.data)) setCategories(json.data)
       })
       .catch(() => {})
   }, [])

--- a/src/app/reports/ReportsClient.tsx
+++ b/src/app/reports/ReportsClient.tsx
@@ -28,7 +28,7 @@ export default function ReportsClient() {
         if (!r.ok) throw new Error('API error')
         return r.json()
       })
-      .then((d) => setReports(d.reports ?? []))
+      .then((d) => setReports(Array.isArray(d?.data) ? d.data : []))
       .catch(console.error)
       .finally(() => setLoading(false))
   }

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -33,8 +33,8 @@ export default function SettingsClient() {
     try {
       const res = await fetch('/api/accounts')
       if (res.ok) {
-        const data = await res.json()
-        setAccounts(Array.isArray(data) ? data : [])
+        const json = await res.json()
+        setAccounts(Array.isArray(json.data) ? json.data : [])
       }
     } catch (e) {
       console.error('[settings] 계좌 조회 실패:', e)

--- a/src/app/watchlist/WatchlistClient.tsx
+++ b/src/app/watchlist/WatchlistClient.tsx
@@ -15,8 +15,8 @@ export default function WatchlistClient() {
     try {
       const res = await fetch('/api/watchlist')
       if (res.ok) {
-        const data = await res.json()
-        setItems(data.items ?? [])
+        const json = await res.json()
+        setItems(Array.isArray(json.data) ? json.data : [])
       }
     } catch (e) {
       console.error('[watchlist] 조회 실패:', e)

--- a/src/components/category/CategoryEditPanel.tsx
+++ b/src/components/category/CategoryEditPanel.tsx
@@ -30,8 +30,8 @@ export default function CategoryEditPanel({ category, onClose }: CategoryEditPan
   useEffect(() => {
     fetch('/api/category-groups')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        if (data?.groups) setGroups(data.groups)
+      .then((json) => {
+        if (Array.isArray(json?.data)) setGroups(json.data)
       })
       .catch(() => {})
   }, [])

--- a/src/components/dividend/DividendForm.tsx
+++ b/src/components/dividend/DividendForm.tsx
@@ -74,8 +74,8 @@ export default function DividendForm({ accounts }: DividendFormProps) {
     if (!isUSD) return
     fetch('/api/prices')
       .then((r) => r.json())
-      .then((data) => {
-        const fx = data.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
+      .then((json) => {
+        const fx = json?.data?.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
         if (fx) setFxRate(String(Math.round(fx.price)))
       })
       .catch(() => {})

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -45,8 +45,8 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
     try {
       const res = await fetch('/api/rsu')
       if (res.ok) {
-        const data = await res.json()
-        setSchedules(data.schedules ?? [])
+        const json = await res.json()
+        setSchedules(Array.isArray(json.data) ? json.data : [])
       }
     } catch {}
   }

--- a/src/components/settings/IncomeProfileManager.tsx
+++ b/src/components/settings/IncomeProfileManager.tsx
@@ -21,7 +21,10 @@ export default function IncomeProfileManager() {
   const fetchProfiles = useCallback(async () => {
     try {
       const res = await fetch('/api/income-profiles')
-      if (res.ok) setProfiles(await res.json())
+      if (res.ok) {
+        const json = await res.json()
+        setProfiles(Array.isArray(json?.data) ? json.data : [])
+      }
     } catch {}
   }, [])
 

--- a/src/components/settings/WhooingSettings.tsx
+++ b/src/components/settings/WhooingSettings.tsx
@@ -53,8 +53,8 @@ export default function WhooingSettings() {
         }
         setLocalMappings(local)
       }
-      if (cats?.categories) {
-        setCategories(cats.categories)
+      if (Array.isArray(cats?.data)) {
+        setCategories(cats.data)
       }
     }).catch(() => {})
   }, [])

--- a/src/components/trade/TradeForm.tsx
+++ b/src/components/trade/TradeForm.tsx
@@ -80,8 +80,8 @@ export default function TradeForm({ accounts }: TradeFormProps) {
     if (!isUSD) return
     fetch('/api/prices')
       .then((r) => r.json())
-      .then((data) => {
-        const fx = data.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
+      .then((json) => {
+        const fx = json?.data?.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
         if (fx) setFxRate(String(Math.round(fx.price)))
       })
       .catch(() => {})


### PR DESCRIPTION
## 요약

9차 마일스톤의 두 번째 단계 — 27-A 에서 도입한 \`ok()\` 헬퍼를 **단순 GET 라우트 10개** + 클라이언트 fetcher 13곳에 일괄 적용.

### 변경 (23 파일 / +140 -34)

**10 GET 라우트** (응답: \`NextResponse.json({key})\` → \`ok(data)\`):
- \`accounts\`, \`prices\`, \`categories\`, \`watchlist\`, \`recurring\`, \`reports\`
- \`category-groups\`, \`income-profiles\`, \`rsu\`, \`stock-options\`

**13 fetcher unwrap** (\`data.xxx\` → \`json.data\`, \`Array.isArray\` 가드):
- SettingsClient (accounts), TradeForm/DividendForm (prices)
- ExpensesClient/BudgetsClient/RecurringClient/WhooingSettings (categories)
- WatchlistClient (items), RecurringClient (items)
- ReportsClient (reports), IncomeProfileManager (profiles)
- CategoryEditPanel (groups), RSUDashboard (schedules)

### 호환성
- **atomic 변경**: 라우트와 fetcher 동일 PR 에 묶임 (breaking change 회피)
- POST/PUT/DELETE 응답은 변경 없음 → **27-C** 에서
- pagination 라우트 (trades/deposits/dividends/transactions) → **27-D**
- 봇 standalone / MCP / 서버 컴포넌트는 prisma 직접 호출 → 영향 0

Closes #323

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 9 files / 162 tests passed (회귀 없음)
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=1 (선택, fetcher unwrap 패턴 미세 일관성) ✅
- atomic 변경 검증 (10 라우트 ↔ 13 fetcher)
- 누락된 fetcher 없음 (grep 0건)