### PR TITLE
[Phase 27-C-1] Watchlist + Recurring + Settings + IncomeProfile envelope 마이그 (#325)

### DIFF
--- a/docs/specs/325-envelope-c1.md
+++ b/docs/specs/325-envelope-c1.md
@@ -1,0 +1,86 @@
+# [Phase 27-C-1] Watchlist + Recurring + Settings + IncomeProfile envelope 마이그
+
+## 목적
+
+9차 마일스톤의 세 번째 단계 — 27-A 의 `ok` / `fail` / `noContent` 헬퍼를 **위험도 낮은 4개 도메인** (watchlist, recurring, settings, income-profiles) 의 POST/PUT/PATCH/DELETE + 일부 GET 에 적용. 27-C 의 5 sub-PR 중 첫 번째.
+
+## 배경
+
+- 27-B 에서 단순 GET 10 라우트 + 13 fetcher 마이그 완료
+- 27-C 는 도메인별 5 sub-PR 로 분할 (계획 확정)
+- C-1 은 **가장 단순한 4 도메인** — 패턴 검증 + 다음 sub-phase 의 기반
+
+## 요구사항
+
+- [ ] 7 라우트 파일의 모든 메소드 응답을 envelope 으로 마이그
+  - `watchlist` POST + `watchlist/[id]` PUT/DELETE
+  - `recurring` POST + `recurring/[id]` PUT/PATCH/DELETE
+  - `alerts/config` GET/PUT
+  - `settings/whooing` GET/PUT
+  - `settings/whooing/mappings` GET/PUT
+  - `income-profiles` POST + `income-profiles/[id]` PUT/DELETE
+- [ ] 에러 응답도 `fail(message, status)` 로 통일
+- [ ] 클라이언트 fetcher 가 envelope 형식에 맞춰 unwrap
+- [ ] atomic (라우트 + fetcher 같은 PR)
+
+## 기술 설계
+
+### 1. 라우트 변환 패턴
+
+| 케이스 | before | after |
+|---|---|---|
+| POST 성공 (201) | `NextResponse.json(item, { status: 201 })` | `ok(item, { status: 201 })` |
+| PUT 성공 | `NextResponse.json(updated)` | `ok(updated)` |
+| PATCH 성공 | `NextResponse.json({ id, isActive })` | `ok({ id, isActive })` |
+| DELETE 성공 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| GET 성공 | `NextResponse.json({ configs })` | `ok(configs)` |
+| 에러 응답 | `NextResponse.json({ error }, { status: N })` | `fail(error, N)` |
+
+### 2. 영향 라우트 (16 메소드 / 7 파일)
+
+| 파일 | 메소드 | 응답 |
+|---|---|---|
+| `watchlist/route.ts` | POST | `ok(item, { status: 201 })` |
+| `watchlist/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `recurring/route.ts` | POST | `ok(item, { status: 201 })` |
+| `recurring/[id]/route.ts` | PUT, PATCH, DELETE | `ok(item)`, `ok({id, isActive})`, `noContent()` |
+| `alerts/config/route.ts` | GET, PUT | `ok(configs)`, `ok(updated)` |
+| `settings/whooing/route.ts` | GET, PUT | `ok({...})`, `ok({...})` |
+| `settings/whooing/mappings/route.ts` | GET, PUT | `ok(mappings)`, `ok(updated)` |
+| `income-profiles/route.ts` | POST | `ok(profile, { status: 201 })` |
+| `income-profiles/[id]/route.ts` | PUT, DELETE | `ok(profile)`, `noContent()` |
+
+### 3. 클라이언트 fetcher
+
+POST/PUT/PATCH 응답 본문을 사용하는 곳만:
+- `WatchlistForm`: POST/PUT 결과 — 사용 여부 확인 (대부분 `res.ok` 만 봄)
+- `RecurringForm`: POST/PUT 결과
+- `RecurringClient`: PATCH 결과 (`isActive` 토글)
+- `IncomeProfileForm`: POST/PUT 결과
+- `WhooingSettings`: GET 응답 사용 (이미 사용 중) + PUT 결과
+- alerts/config 호출자
+
+DELETE 호출자는 `res.ok` 만 보므로 변경 없음 (DELETE 인 만큼).
+에러 응답 클라이언트 처리도 변경 없음 (envelope 의 `error` 필드 동일).
+
+### 4. 추가 작업
+
+- 모든 catch 블록의 `NextResponse.json({ error: ... }, { status: 500 })` → `fail(message, 500)`
+- 비즈니스 에러 헬퍼 (`businessErrorResponse`) 사용처는 그대로 유지 (envelope 형식 호환 — 후속 검토)
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 추가 안 함 (27-A 헬퍼 검증으로 충분)
+- 수동 회귀:
+  - 관심종목 추가/수정/삭제
+  - 반복 거래 추가/수정/일시정지/삭제
+  - 후잉 설정 저장
+  - 근로소득 프로필 추가/수정/삭제
+  - 알림 설정 변경
+
+## 제외 사항
+
+- POST 응답 본문을 사용하지 않는 호출자는 unwrap 변경 불필요
+- 같은 도메인의 단순 GET 은 27-B 에서 완료
+- 다른 도메인 (category/budget/asset, dividend/deposit/transaction, rsu/stock-option, trade) — 27-C-2 ~ C-5

--- a/src/app/api/alerts/config/route.ts
+++ b/src/app/api/alerts/config/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,13 +12,10 @@ export async function GET() {
     const configs = await prisma.alertConfig.findMany({
       orderBy: { key: 'asc' },
     })
-    return NextResponse.json({ configs })
+    return ok(configs)
   } catch (error) {
     console.error('GET /api/alerts/config error:', error)
-    return NextResponse.json(
-      { error: '알림 설정을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('알림 설정을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -31,42 +29,27 @@ export async function PUT(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { key, value } = body as { key?: unknown; value?: unknown }
 
     if (!key || typeof key !== 'string') {
-      return NextResponse.json(
-        { error: '설정 키를 지정해주세요.' },
-        { status: 400 }
-      )
+      return fail('설정 키를 지정해주세요.', 400)
     }
     if (value === undefined || value === null || String(value).trim() === '') {
-      return NextResponse.json(
-        { error: '값을 입력해주세요.' },
-        { status: 400 }
-      )
+      return fail('값을 입력해주세요.', 400)
     }
 
     const existing = await prisma.alertConfig.findUnique({
       where: { key },
     })
     if (!existing) {
-      return NextResponse.json(
-        { error: `존재하지 않는 설정입니다: ${key}` },
-        { status: 404 }
-      )
+      return fail(`존재하지 않는 설정입니다: ${key}`, 404)
     }
 
     const updated = await prisma.alertConfig.update({
@@ -74,12 +57,9 @@ export async function PUT(request: NextRequest) {
       data: { value: String(value) },
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/alerts/config error:', error)
-    return NextResponse.json(
-      { error: '알림 설정 변경에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('알림 설정 변경에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/income-profiles/[id]/route.ts
+++ b/src/app/api/income-profiles/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import {
@@ -6,18 +6,19 @@ import {
   calcTaxableFromGross,
   type IncomeProfileInput,
 } from '@/lib/tax/income-profile-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 function handlePrismaError(error: unknown, context: string) {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     if (error.code === 'P2025') {
-      return NextResponse.json({ error: '프로필을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('프로필을 찾을 수 없습니다.', 404)
     }
     if (error.code === 'P2002') {
-      return NextResponse.json({ error: '해당 연도 프로필이 이미 존재합니다.' }, { status: 409 })
+      return fail('해당 연도 프로필이 이미 존재합니다.', 409)
     }
   }
   console.error(`${context} error:`, error)
-  return NextResponse.json({ error: `${context}에 실패했습니다.` }, { status: 500 })
+  return fail(`${context}에 실패했습니다.`, 500)
 }
 
 /** PUT /api/income-profiles/[id] — 수정 */
@@ -30,12 +31,12 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const errors = validateIncomeProfileInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { year, inputType, prepaidTax, note } = body as IncomeProfileInput
@@ -66,7 +67,7 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
       },
     })
 
-    return NextResponse.json(profile)
+    return ok(profile)
   } catch (error) {
     return handlePrismaError(error, '근로소득 프로필 수정')
   }
@@ -78,7 +79,7 @@ export async function DELETE(_request: NextRequest, props: { params: Promise<{ i
   try {
     const { id } = params
     await prisma.incomeProfile.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     return handlePrismaError(error, '근로소득 프로필 삭제')
   }

--- a/src/app/api/income-profiles/route.ts
+++ b/src/app/api/income-profiles/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import {
@@ -6,7 +6,7 @@ import {
   calcTaxableFromGross,
   type IncomeProfileInput,
 } from '@/lib/tax/income-profile-utils'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,10 +19,7 @@ export async function GET() {
     return ok(profiles)
   } catch (error) {
     console.error('GET /api/income-profiles error:', error)
-    return NextResponse.json(
-      { error: '근로소득 프로필 조회에 실패했습니다.' },
-      { status: 500 },
-    )
+    return fail('근로소득 프로필 조회에 실패했습니다.', 500)
   }
 }
 
@@ -33,12 +30,12 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const errors = validateIncomeProfileInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { year, inputType, prepaidTax, note } = body as IncomeProfileInput
@@ -69,18 +66,12 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(profile, { status: 201 })
+    return ok(profile, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-      return NextResponse.json(
-        { error: '해당 연도 프로필이 이미 존재합니다. 수정을 이용해주세요.' },
-        { status: 409 },
-      )
+      return fail('해당 연도 프로필이 이미 존재합니다. 수정을 이용해주세요.', 409)
     }
     console.error('POST /api/income-profiles error:', error)
-    return NextResponse.json(
-      { error: '근로소득 프로필 생성에 실패했습니다.' },
-      { status: 500 },
-    )
+    return fail('근로소득 프로필 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/recurring/[id]/route.ts
+++ b/src/app/api/recurring/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateRecurringInput } from '@/lib/recurring-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -17,15 +18,15 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     const errors = validateRecurringInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const nextRunAt = body.nextRunAt
@@ -46,14 +47,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       },
     })
 
-    return NextResponse.json(item)
+    return ok(item)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2025') return NextResponse.json({ error: '존재하지 않는 반복 거래입니다.' }, { status: 404 })
-      if (error.code === 'P2003') return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      if (error.code === 'P2025') return fail('존재하지 않는 반복 거래입니다.', 404)
+      if (error.code === 'P2003') return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/recurring/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '반복 거래 수정에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 수정에 실패했습니다.', 500)
   }
 }
 
@@ -68,11 +69,11 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     if (typeof body.isActive !== 'boolean') {
-      return NextResponse.json({ error: 'isActive는 boolean이어야 합니다.' }, { status: 400 })
+      return fail('isActive는 boolean이어야 합니다.', 400)
     }
 
     const item = await prisma.recurringTransaction.update({
@@ -80,13 +81,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       data: { isActive: body.isActive },
     })
 
-    return NextResponse.json({ id: item.id, isActive: item.isActive })
+    return ok({ id: item.id, isActive: item.isActive })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 반복 거래입니다.' }, { status: 404 })
+      return fail('존재하지 않는 반복 거래입니다.', 404)
     }
     console.error('[api/recurring/[id]] PATCH 실패:', error)
-    return NextResponse.json({ error: '상태 변경에 실패했습니다.' }, { status: 500 })
+    return fail('상태 변경에 실패했습니다.', 500)
   }
 }
 
@@ -97,12 +98,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     await prisma.recurringTransaction.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 반복 거래입니다.' }, { status: 404 })
+      return fail('존재하지 않는 반복 거래입니다.', 404)
     }
     console.error('[api/recurring/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '반복 거래 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/recurring/route.ts
+++ b/src/app/api/recurring/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateRecurringInput } from '@/lib/recurring-utils'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -38,7 +38,7 @@ export async function GET() {
     return ok(serialized)
   } catch (error) {
     console.error('[api/recurring] GET 실패:', error)
-    return NextResponse.json({ error: '반복 거래 조회에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 조회에 실패했습니다.', 500)
   }
 }
 
@@ -51,15 +51,15 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     const errors = validateRecurringInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const category = await prisma.category.findUnique({
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
       select: { id: true },
     })
     if (!category) {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
 
     const nextRunAt = body.nextRunAt
@@ -87,12 +87,12 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(item, { status: 201 })
+    return ok(item, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/recurring] POST 실패:', error)
-    return NextResponse.json({ error: '반복 거래 생성에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/settings/whooing/mappings/route.ts
+++ b/src/app/api/settings/whooing/mappings/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,10 +12,10 @@ export async function GET() {
     const mappings = await prisma.whooingCategoryMap.findMany({
       include: { category: { select: { name: true, icon: true } } },
     })
-    return NextResponse.json({ mappings })
+    return ok(mappings)
   } catch (error) {
     console.error('[api/settings/whooing/mappings] GET 실패:', error)
-    return NextResponse.json({ error: '매핑 조회에 실패했습니다.' }, { status: 500 })
+    return fail('매핑 조회에 실패했습니다.', 500)
   }
 }
 
@@ -25,10 +26,10 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     if (!Array.isArray(body.mappings)) {
-      return NextResponse.json({ error: 'mappings 배열이 필요합니다.' }, { status: 400 })
+      return fail('mappings 배열이 필요합니다.', 400)
     }
 
     const mappings = body.mappings as { categoryId: string; whooingLeft: string; whooingRight?: string }[]
@@ -52,9 +53,9 @@ export async function PUT(request: NextRequest) {
       include: { category: { select: { name: true, icon: true } } },
     })
 
-    return NextResponse.json({ mappings: updated })
+    return ok(updated)
   } catch (error) {
     console.error('[api/settings/whooing/mappings] PUT 실패:', error)
-    return NextResponse.json({ error: '매핑 저장에 실패했습니다.' }, { status: 500 })
+    return fail('매핑 저장에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/settings/whooing/route.ts
+++ b/src/app/api/settings/whooing/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,14 +12,14 @@ const SINGLETON_ID = 'whooing-config'
 export async function GET() {
   try {
     const config = await prisma.whooingConfig.findUnique({ where: { id: SINGLETON_ID } })
-    return NextResponse.json({
+    return ok({
       webhookUrl: config?.webhookUrl ?? null,
       isActive: config?.isActive ?? false,
       defaultRight: config?.defaultRight ?? null,
     })
   } catch (error) {
     console.error('[api/settings/whooing] GET 실패:', error)
-    return NextResponse.json({ error: '후잉 설정 조회에 실패했습니다.' }, { status: 500 })
+    return fail('후잉 설정 조회에 실패했습니다.', 500)
   }
 }
 
@@ -28,7 +29,7 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const existing = await prisma.whooingConfig.findUnique({ where: { id: SINGLETON_ID } })
 
@@ -44,13 +45,13 @@ export async function PUT(request: NextRequest) {
       create: { id: SINGLETON_ID, ...data },
     })
 
-    return NextResponse.json({
+    return ok({
       webhookUrl: config.webhookUrl,
       isActive: config.isActive,
       defaultRight: config.defaultRight,
     })
   } catch (error) {
     console.error('[api/settings/whooing] PUT 실패:', error)
-    return NextResponse.json({ error: '후잉 설정 저장에 실패했습니다.' }, { status: 500 })
+    return fail('후잉 설정 저장에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/watchlist/[id]/route.ts
+++ b/src/app/api/watchlist/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,22 +14,22 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const data: Record<string, unknown> = {}
     if (typeof body.displayName === 'string') {
       const name = body.displayName.trim()
-      if (!name) return NextResponse.json({ error: '종목명을 입력해주세요.' }, { status: 400 })
+      if (!name) return fail('종목명을 입력해주세요.', 400)
       data.displayName = name
     }
     if (typeof body.market === 'string') {
       const validMarkets = ['US', 'KR']
-      if (!validMarkets.includes(body.market.trim())) return NextResponse.json({ error: '시장은 US 또는 KR만 허용됩니다.' }, { status: 400 })
+      if (!validMarkets.includes(body.market.trim())) return fail('시장은 US 또는 KR만 허용됩니다.', 400)
       data.market = body.market.trim()
     }
     if (typeof body.strategy === 'string') {
       const validStrategies = ['swing', 'momentum', 'value', 'scalp']
-      if (!validStrategies.includes(body.strategy)) return NextResponse.json({ error: '유효한 전략을 선택해주세요.' }, { status: 400 })
+      if (!validStrategies.includes(body.strategy)) return fail('유효한 전략을 선택해주세요.', 400)
       data.strategy = body.strategy
     }
     if (body.memo !== undefined) data.memo = typeof body.memo === 'string' ? body.memo.trim() || null : null
@@ -40,17 +41,17 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const low = data.entryLow as number | null | undefined
     const high = data.entryHigh as number | null | undefined
     if (low !== undefined && high !== undefined && low !== null && high !== null && low > high) {
-      return NextResponse.json({ error: '매수 구간 하한은 상한보다 작아야 합니다.' }, { status: 400 })
+      return fail('매수 구간 하한은 상한보다 작아야 합니다.', 400)
     }
 
     const updated = await prisma.watchlist.update({ where: { id }, data })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 관심종목입니다.' }, { status: 404 })
+      return fail('존재하지 않는 관심종목입니다.', 404)
     }
     console.error('[api/watchlist/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '관심종목 수정에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 수정에 실패했습니다.', 500)
   }
 }
 
@@ -61,12 +62,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     await prisma.watchlist.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 관심종목입니다.' }, { status: 404 })
+      return fail('존재하지 않는 관심종목입니다.', 404)
     }
     console.error('[api/watchlist/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '관심종목 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -33,7 +33,7 @@ export async function GET() {
     return ok(serialized)
   } catch (error) {
     console.error('[api/watchlist] GET 실패:', error)
-    return NextResponse.json({ error: '관심종목 조회에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 조회에 실패했습니다.', 500)
   }
 }
 
@@ -43,17 +43,17 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const ticker = typeof body.ticker === 'string' ? body.ticker.trim() : ''
     const displayName = typeof body.displayName === 'string' ? body.displayName.trim() : ''
     const market = typeof body.market === 'string' ? body.market.trim() : ''
 
-    if (!ticker) return NextResponse.json({ error: '종목 티커를 입력해주세요.' }, { status: 400 })
-    if (!displayName) return NextResponse.json({ error: '종목명을 입력해주세요.' }, { status: 400 })
+    if (!ticker) return fail('종목 티커를 입력해주세요.', 400)
+    if (!displayName) return fail('종목명을 입력해주세요.', 400)
 
     const validMarkets = ['US', 'KR']
-    if (!validMarkets.includes(market)) return NextResponse.json({ error: '시장은 US 또는 KR만 허용됩니다.' }, { status: 400 })
+    if (!validMarkets.includes(market)) return fail('시장은 US 또는 KR만 허용됩니다.', 400)
 
     const validStrategies = ['swing', 'momentum', 'value', 'scalp']
     const strategy = typeof body.strategy === 'string' && validStrategies.includes(body.strategy) ? body.strategy : 'swing'
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
     const entryHigh = typeof body.entryHigh === 'number' && body.entryHigh > 0 ? body.entryHigh : null
 
     if (entryLow !== null && entryHigh !== null && entryLow > entryHigh) {
-      return NextResponse.json({ error: '매수 구간 하한은 상한보다 작아야 합니다.' }, { status: 400 })
+      return fail('매수 구간 하한은 상한보다 작아야 합니다.', 400)
     }
 
     const item = await prisma.watchlist.create({
@@ -79,12 +79,12 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(item, { status: 201 })
+    return ok(item, { status: 201 })
   } catch (error) {
     if ((error as { code?: string }).code === 'P2002') {
-      return NextResponse.json({ error: '이미 등록된 종목입니다.' }, { status: 409 })
+      return fail('이미 등록된 종목입니다.', 409)
     }
     console.error('[api/watchlist] POST 실패:', error)
-    return NextResponse.json({ error: '관심종목 추가에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 추가에 실패했습니다.', 500)
   }
 }

--- a/src/components/settings/AlertConfigEditor.tsx
+++ b/src/components/settings/AlertConfigEditor.tsx
@@ -18,7 +18,7 @@ export default function AlertConfigEditor() {
   useEffect(() => {
     fetch('/api/alerts/config')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => { if (data?.configs) setConfigs(data.configs) })
+      .then((json) => { if (Array.isArray(json?.data)) setConfigs(json.data) })
       .catch(() => {})
   }, [])
 

--- a/src/components/settings/WhooingSettings.tsx
+++ b/src/components/settings/WhooingSettings.tsx
@@ -38,17 +38,19 @@ export default function WhooingSettings() {
       fetch('/api/settings/whooing').then((r) => r.ok ? r.json() : null),
       fetch('/api/settings/whooing/mappings').then((r) => r.ok ? r.json() : null),
       fetch('/api/categories').then((r) => r.ok ? r.json() : null),
-    ]).then(([cfg, maps, cats]) => {
+    ]).then(([cfgRes, mapsRes, cats]) => {
+      const cfg = cfgRes?.data
+      const mapsArr = mapsRes?.data
       if (cfg) {
         setConfig(cfg)
         setWebhookUrl(cfg.webhookUrl ?? '')
         setDefaultRight(cfg.defaultRight ?? '')
         setIsActive(cfg.isActive)
       }
-      if (maps?.mappings) {
-        setMappings(maps.mappings)
+      if (Array.isArray(mapsArr)) {
+        setMappings(mapsArr)
         const local: Record<string, { left: string; right: string }> = {}
-        for (const m of maps.mappings as CategoryMapping[]) {
+        for (const m of mapsArr as CategoryMapping[]) {
           local[m.categoryId] = { left: m.whooingLeft, right: m.whooingRight ?? '' }
         }
         setLocalMappings(local)
@@ -68,8 +70,8 @@ export default function WhooingSettings() {
         body: JSON.stringify({ webhookUrl: webhookUrl.trim() || null, isActive, defaultRight: defaultRight.trim() || null }),
       })
       if (res.ok) {
-        const data = await res.json()
-        setConfig(data)
+        const json = await res.json()
+        if (json?.data) setConfig(json.data)
       }
     } finally {
       setSaving(false)
@@ -88,8 +90,8 @@ export default function WhooingSettings() {
         body: JSON.stringify({ mappings: arr }),
       })
       if (res.ok) {
-        const data = await res.json()
-        setMappings(data.mappings)
+        const json = await res.json()
+        if (Array.isArray(json?.data)) setMappings(json.data)
       }
     } finally {
       setSavingMappings(false)


### PR DESCRIPTION
## 요약

9차 마일스톤의 세 번째 단계 (27-C-1) — 위험도 낮은 4 도메인 7 라우트 16 메소드를 27-A 의 ok/fail/noContent 헬퍼로 일괄 마이그. 27-C 의 5 sub-PR 중 첫 번째.

### 라우트 (16 메소드 / 7 파일)
- watchlist: POST, [id] PUT/DELETE
- recurring: POST, [id] PUT/PATCH/DELETE
- alerts/config: GET/PUT
- settings/whooing: GET/PUT
- settings/whooing/mappings: GET/PUT
- income-profiles: POST, [id] PUT/DELETE

### 변환 패턴
| 케이스 | before | after |
|---|---|---|
| 성공 | \`NextResponse.json(data)\` | \`ok(data)\` |
| 201 Created | \`NextResponse.json(item, { status: 201 })\` | \`ok(item, { status: 201 })\` |
| 204 No Content | \`new NextResponse(null, { status: 204 })\` | \`noContent()\` |
| 에러 | \`NextResponse.json({ error }, { status })\` | \`fail(error, status)\` |

### 클라이언트
- AlertConfigEditor: GET unwrap
- WhooingSettings: 3개 fetcher (cfg/maps/PUT 응답) unwrap
- **Form 컴포넌트는 응답 본문 미사용** → 변경 없음 (\`res.ok\` + \`data?.error\` 만 사용)

Closes #325

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 162 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=0 ✅
- 7 라우트 16 메소드 누락 없음
- 봇/MCP/SSR 영향 0 확인
- 다중 필드 검증 errors 배열 클라이언트 미사용 확인 → 단일 메시지 안전

## 후속
- 27-C-2 (Category + Budget + Asset)
- 27-C-3 (Dividend + Deposit + Transaction)
- 27-C-4 (RSU + StockOption)
- 27-C-5 (Trade)