### PR TITLE
[Phase 27-C-2] Category + Budget + Asset envelope 마이그 (#327)

### DIFF
--- a/docs/specs/327-envelope-c2.md
+++ b/docs/specs/327-envelope-c2.md
@@ -1,0 +1,80 @@
+# [Phase 27-C-2] Category + Budget + Asset envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 두 번째 — 자금 분류 관련 3 도메인 (categories/category-groups, budgets, assets) 의 모든 메소드를 `ok`/`fail`/`noContent` 헬퍼로 마이그. budgets GET, assets GET 같은 GET/POST 짝 라우트도 함께 (응답 형식이 복잡해 atomic 변경 필수).
+
+## 배경
+
+- 27-C-1 (Watchlist/Recurring/Settings/IncomeProfile) 완료 (PR #326)
+- 27-C-2 은 두 번째 sub-PR — 27-C-1 보다 약간 큰 규모 (9 라우트 + 7 fetcher)
+- 카테고리 reorder (POST) 도 함께 envelope 화
+
+## 요구사항
+
+- [ ] 9 라우트 파일의 모든 메소드 응답을 envelope 으로
+  - `categories` (POST) + `categories/[id]` (PUT/DELETE) + `categories/reorder` (POST)
+  - `category-groups` (POST) + `category-groups/[id]` (PUT/DELETE)
+  - `budgets` (GET/POST) + `budgets/[id]` (DELETE)
+  - `assets` (GET/POST) + `assets/[id]` (PUT/DELETE)
+- [ ] 에러 응답도 `fail()` 로 통일
+- [ ] 클라이언트 fetcher 7개 unwrap
+- [ ] atomic (라우트 + fetcher 같은 PR)
+
+## 기술 설계
+
+### 1. 라우트 변환 (16 메소드 / 9 파일)
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `categories/route.ts` | POST | `ok(category, { status: 201 })` |
+| `categories/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `categories/reorder/route.ts` | POST | `noContent()` (이미 204 응답) |
+| `category-groups/route.ts` | POST | `ok(group, { status: 201 })` |
+| `category-groups/[id]/route.ts` | PUT, DELETE | `ok(group)`, `noContent()` |
+| `budgets/route.ts` | GET | `ok({ year, month, totalBudget, ... })` |
+| `budgets/route.ts` | POST (upsert) | `ok(budget, { status: created ? 201 : 200 })` |
+| `budgets/route.ts` (copy 액션) | POST | `ok({ copied, targetYear, targetMonth })` |
+| `budgets/[id]/route.ts` | DELETE | `noContent()` |
+| `assets/route.ts` | GET | `ok({ assets, totalAssets, totalLiabilities, netAssets })` |
+| `assets/route.ts` | POST | `ok(asset, { status: 201 })` |
+| `assets/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+
+### 2. 클라이언트 fetcher unwrap (7개)
+
+- `CategoryForm` (POST), `CategoryEditPanel` (PUT) — 응답 본문 미사용 → 변경 없음
+- `CategoryDeleteModal` (DELETE) → 변경 없음
+- `CategoryTable` (reorder POST) — `res.ok` 만 → 변경 없음
+- `BudgetManager` (GET 응답 본문 사용 — 복잡) — **변경 필요**
+- `BudgetManager` (POST upsert + copy 응답) — 본문 사용 여부 확인
+- `AssetForm` (POST/PUT 응답) — 본문 사용 여부 확인
+- `AssetDeleteModal` (DELETE) → 변경 없음
+- 서버 컴포넌트가 `/api/assets` GET 직접 호출하지 않는지 (prisma 사용 권장)
+
+### 3. 변환 패턴 (27-C-1 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+### 4. 다중 필드 에러
+
+`{ error: errors[0].message, errors }` 패턴 (categories POST, budgets POST 등) → `fail(errors[0].message, 400)`. 클라이언트가 `errors` 배열 미사용 (27-C-1 grep 확인됨).
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 카테고리 추가/수정/삭제/순서 변경
+  - 카테고리 그룹 추가/수정/삭제
+  - 예산 페이지 조회, 추가, 삭제, 월별 복사
+  - 자산 페이지 조회, 추가, 수정, 삭제
+
+## 제외 사항
+
+- 같은 도메인의 단순 GET 은 27-B 에서 완료 (`/api/categories` GET, `/api/category-groups` GET)
+- 다른 도메인 (dividend/deposit/transaction, rsu/stock-option, trade) — 27-C-3/4/5
+- pagination 라우트 (trades/deposits/dividends/transactions) — 27-D

--- a/src/app/api/assets/[id]/route.ts
+++ b/src/app/api/assets/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 function parseStrictDate(str: string): Date | null {
   const match = str.match(/^(\d{4})-(\d{2})-(\d{2})/)
@@ -19,18 +20,18 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
 
     const existing = await prisma.asset.findUnique({ where: { id } })
     if (!existing) {
-      return NextResponse.json({ error: '자산을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('자산을 찾을 수 없습니다.', 404)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { name, value, note, interestRate, maturityDate, owner, category, isLiability } =
@@ -41,34 +42,31 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
     const data: Record<string, unknown> = {}
     if (name !== undefined) {
       if (typeof name !== 'string' || !name.trim()) {
-        return NextResponse.json({ error: '유효한 자산명을 입력해주세요.' }, { status: 400 })
+        return fail('유효한 자산명을 입력해주세요.', 400)
       }
       data.name = name.trim()
     }
     if (owner !== undefined) {
       if (typeof owner !== 'string' || !owner.trim()) {
-        return NextResponse.json({ error: '유효한 소유자를 입력해주세요.' }, { status: 400 })
+        return fail('유효한 소유자를 입력해주세요.', 400)
       }
       data.owner = owner.trim()
     }
     if (category !== undefined && typeof category === 'string') {
       if (!VALID_CATEGORIES.includes(category)) {
-        return NextResponse.json(
-          { error: `유효한 카테고리: ${VALID_CATEGORIES.join(', ')}` },
-          { status: 400 }
-        )
+        return fail(`유효한 카테고리: ${VALID_CATEGORIES.join(', ')}`, 400)
       }
       data.category = category
     }
     if (isLiability !== undefined) {
       if (typeof isLiability !== 'boolean') {
-        return NextResponse.json({ error: 'isLiability는 boolean이어야 합니다.' }, { status: 400 })
+        return fail('isLiability는 boolean이어야 합니다.', 400)
       }
       data.isLiability = isLiability
     }
     if (value !== undefined) {
       if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-        return NextResponse.json({ error: '유효한 금액을 입력해주세요.' }, { status: 400 })
+        return fail('유효한 금액을 입력해주세요.', 400)
       }
       data.value = Math.round(value)
     }
@@ -79,7 +77,7 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
       } else if (typeof interestRate === 'number' && Number.isFinite(interestRate)) {
         data.interestRate = interestRate
       } else {
-        return NextResponse.json({ error: '이율은 숫자여야 합니다.' }, { status: 400 })
+        return fail('이율은 숫자여야 합니다.', 400)
       }
     }
     if (maturityDate !== undefined) {
@@ -88,21 +86,21 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
       } else if (typeof maturityDate === 'string') {
         const d = parseStrictDate(maturityDate)
         if (!d) {
-          return NextResponse.json({ error: '유효한 만기일을 입력해주세요. (YYYY-MM-DD)' }, { status: 400 })
+          return fail('유효한 만기일을 입력해주세요. (YYYY-MM-DD)', 400)
         }
         data.maturityDate = d
       }
     }
 
     if (Object.keys(data).length === 0) {
-      return NextResponse.json({ error: '변경할 항목이 없습니다.' }, { status: 400 })
+      return fail('변경할 항목이 없습니다.', 400)
     }
 
     const updated = await prisma.asset.update({ where: { id }, data })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/assets/[id] error:', error)
-    return NextResponse.json({ error: '자산 수정에 실패했습니다.' }, { status: 500 })
+    return fail('자산 수정에 실패했습니다.', 500)
   }
 }
 
@@ -113,13 +111,13 @@ export async function DELETE(_request: NextRequest, props: { params: Promise<{ i
 
     const existing = await prisma.asset.findUnique({ where: { id } })
     if (!existing) {
-      return NextResponse.json({ error: '자산을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('자산을 찾을 수 없습니다.', 404)
     }
 
     await prisma.asset.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     console.error('DELETE /api/assets/[id] error:', error)
-    return NextResponse.json({ error: '자산 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('자산 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest) {
       .filter((a) => a.isLiability)
       .reduce((sum, a) => sum + a.value, 0)
 
-    return NextResponse.json({
+    return ok({
       assets,
       totalAssets,
       totalLiabilities,
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('GET /api/assets error:', error)
-    return NextResponse.json({ error: '자산 목록을 불러올 수 없습니다.' }, { status: 500 })
+    return fail('자산 목록을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -57,40 +58,37 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { name, category, owner, value, isLiability, interestRate, maturityDate, note } =
       body as Record<string, unknown>
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
-      return NextResponse.json({ error: '자산명을 입력해주세요.' }, { status: 400 })
+      return fail('자산명을 입력해주세요.', 400)
     }
     if (!category || typeof category !== 'string' || !VALID_CATEGORIES.includes(category)) {
-      return NextResponse.json(
-        { error: `유효한 카테고리를 선택해주세요: ${VALID_CATEGORIES.join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`유효한 카테고리를 선택해주세요: ${VALID_CATEGORIES.join(', ')}`, 400)
     }
     if (!owner || typeof owner !== 'string' || (owner as string).trim().length === 0) {
-      return NextResponse.json({ error: '소유자를 입력해주세요.' }, { status: 400 })
+      return fail('소유자를 입력해주세요.', 400)
     }
     if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-      return NextResponse.json({ error: '유효한 금액을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 금액을 입력해주세요.', 400)
     }
     if (isLiability !== undefined && typeof isLiability !== 'boolean') {
-      return NextResponse.json({ error: 'isLiability는 boolean이어야 합니다.' }, { status: 400 })
+      return fail('isLiability는 boolean이어야 합니다.', 400)
     }
 
     // optional 필드 검증 (제공된 경우 타입/값 확인)
     let validatedInterestRate: number | null = null
     if (interestRate !== undefined && interestRate !== null) {
       if (typeof interestRate !== 'number' || !Number.isFinite(interestRate)) {
-        return NextResponse.json({ error: '이율은 숫자여야 합니다.' }, { status: 400 })
+        return fail('이율은 숫자여야 합니다.', 400)
       }
       validatedInterestRate = interestRate
     }
@@ -98,11 +96,11 @@ export async function POST(request: NextRequest) {
     let validatedMaturityDate: Date | null = null
     if (maturityDate !== undefined && maturityDate !== null) {
       if (typeof maturityDate !== 'string') {
-        return NextResponse.json({ error: '만기일은 YYYY-MM-DD 형식이어야 합니다.' }, { status: 400 })
+        return fail('만기일은 YYYY-MM-DD 형식이어야 합니다.', 400)
       }
       const d = parseStrictDate(maturityDate)
       if (!d) {
-        return NextResponse.json({ error: '유효하지 않은 만기일입니다.' }, { status: 400 })
+        return fail('유효하지 않은 만기일입니다.', 400)
       }
       validatedMaturityDate = d
     }
@@ -120,9 +118,9 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(asset, { status: 201 })
+    return ok(asset, { status: 201 })
   } catch (error) {
     console.error('POST /api/assets error:', error)
-    return NextResponse.json({ error: '자산 등록에 실패했습니다.' }, { status: 500 })
+    return fail('자산 등록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/budgets/[id]/route.ts
+++ b/src/app/api/budgets/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,12 +14,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     await prisma.budget.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 예산입니다.' }, { status: 404 })
+      return fail('존재하지 않는 예산입니다.', 404)
     }
     console.error('[api/budgets/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '예산 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('예산 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/budgets/route.ts
+++ b/src/app/api/budgets/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateBudgetInput } from '@/lib/budget-utils'
 import { yearMonthSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -21,11 +22,11 @@ export async function GET(request: NextRequest) {
     })
     if (!ymResult.success) {
       const errs = zodErrorsToValidation(ymResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { year, month } = ymResult.data
     if (year === undefined || month === undefined) {
-      return NextResponse.json({ error: 'year, month 파라미터가 필요합니다.' }, { status: 400 })
+      return fail('year, month 파라미터가 필요합니다.', 400)
     }
 
     // 예산 조회
@@ -158,7 +159,7 @@ export async function GET(request: NextRequest) {
       spentByGroup[gId].total += amt
     })
 
-    return NextResponse.json({
+    return ok({
       year,
       month,
       totalBudget,
@@ -168,7 +169,7 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[api/budgets] GET 실패:', error)
-    return NextResponse.json({ error: '예산 조회에 실패했습니다.' }, { status: 500 })
+    return fail('예산 조회에 실패했습니다.', 500)
   }
 }
 
@@ -184,10 +185,10 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     // 복사 액션
@@ -198,7 +199,7 @@ export async function POST(request: NextRequest) {
     // 일반 upsert
     const errors = validateBudgetInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const amount = body.amount as number
@@ -209,14 +210,14 @@ export async function POST(request: NextRequest) {
 
     // categoryId와 groupId 동시 설정 불가
     if (categoryId && groupId) {
-      return NextResponse.json({ error: '카테고리와 그룹을 동시에 지정할 수 없습니다.' }, { status: 400 })
+      return fail('카테고리와 그룹을 동시에 지정할 수 없습니다.', 400)
     }
 
     // 그룹 존재 확인
     if (groupId) {
       const grp = await prisma.categoryGroup.findUnique({ where: { id: groupId }, select: { id: true } })
       if (!grp) {
-        return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 400 })
+        return fail('존재하지 않는 그룹입니다.', 400)
       }
     }
 
@@ -227,10 +228,10 @@ export async function POST(request: NextRequest) {
         select: { id: true, type: true },
       })
       if (!cat) {
-        return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+        return fail('존재하지 않는 카테고리입니다.', 400)
       }
       if (cat.type !== 'expense') {
-        return NextResponse.json({ error: '예산은 소비 카테고리에만 설정할 수 있습니다.' }, { status: 400 })
+        return fail('예산은 소비 카테고리에만 설정할 수 있습니다.', 400)
       }
     }
 
@@ -252,13 +253,13 @@ export async function POST(request: NextRequest) {
       return { budget: created, created: true }
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    return NextResponse.json(result.budget, { status: result.created ? 201 : 200 })
+    return ok(result.budget, { status: result.created ? 201 : 200 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/budgets] POST 실패:', error)
-    return NextResponse.json({ error: '예산 저장에 실패했습니다.' }, { status: 500 })
+    return fail('예산 저장에 실패했습니다.', 500)
   }
 }
 
@@ -273,7 +274,7 @@ async function handleCopy(body: Record<string, unknown>) {
     !Number.isInteger(targetYear) || !Number.isInteger(targetMonth) ||
     sourceMonth < 1 || sourceMonth > 12 || targetMonth < 1 || targetMonth > 12
   ) {
-    return NextResponse.json({ error: '유효한 sourceYear, sourceMonth, targetYear, targetMonth를 입력해주세요.' }, { status: 400 })
+    return fail('유효한 sourceYear, sourceMonth, targetYear, targetMonth를 입력해주세요.', 400)
   }
 
   const sourceBudgets = await prisma.budget.findMany({
@@ -281,7 +282,7 @@ async function handleCopy(body: Record<string, unknown>) {
   })
 
   if (sourceBudgets.length === 0) {
-    return NextResponse.json({ error: '복사할 예산이 없습니다.' }, { status: 400 })
+    return fail('복사할 예산이 없습니다.', 400)
   }
 
   const copied = await prisma.$transaction(async (tx) => {
@@ -310,5 +311,5 @@ async function handleCopy(body: Record<string, unknown>) {
     return count
   }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-  return NextResponse.json({ copied, targetYear, targetMonth })
+  return ok({ copied, targetYear, targetMonth })
 }

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { CATEGORY_TYPES } from '@/lib/category-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -14,17 +15,17 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       where: { id: params.id },
     })
     if (!existing) {
-      return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('카테고리를 찾을 수 없습니다.', 404)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { name, type, icon, keywords, sortOrder, groupId } = body as Record<string, unknown>
@@ -33,39 +34,39 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     // type 검증 (트랜잭션 전에)
     if (isTypeChange) {
       if (typeof type !== 'string' || !(CATEGORY_TYPES as readonly string[]).includes(type)) {
-        return NextResponse.json({ error: '유효한 유형을 선택해주세요.' }, { status: 400 })
+        return fail('유효한 유형을 선택해주세요.', 400)
       }
     }
 
     // name 검증
     if (name !== undefined) {
       if (typeof name !== 'string' || !name.trim()) {
-        return NextResponse.json({ error: '카테고리 이름을 입력해주세요.' }, { status: 400 })
+        return fail('카테고리 이름을 입력해주세요.', 400)
       }
       if (name.trim().length > 50) {
-        return NextResponse.json({ error: '이름은 50자 이내로 입력해주세요.' }, { status: 400 })
+        return fail('이름은 50자 이내로 입력해주세요.', 400)
       }
     }
 
     if (icon !== undefined && icon !== null && typeof icon !== 'string') {
-      return NextResponse.json({ error: '아이콘은 문자열이어야 합니다.' }, { status: 400 })
+      return fail('아이콘은 문자열이어야 합니다.', 400)
     }
 
     if (keywords !== undefined && keywords !== null) {
       if (!Array.isArray(keywords)) {
-        return NextResponse.json({ error: '키워드는 배열이어야 합니다.' }, { status: 400 })
+        return fail('키워드는 배열이어야 합니다.', 400)
       }
       if (keywords.some((k: unknown) => typeof k !== 'string')) {
-        return NextResponse.json({ error: '키워드는 문자열 배열이어야 합니다.' }, { status: 400 })
+        return fail('키워드는 문자열 배열이어야 합니다.', 400)
       }
     }
 
     if (sortOrder !== undefined && sortOrder !== null) {
       if (typeof sortOrder !== 'number' || !Number.isInteger(sortOrder)) {
-        return NextResponse.json({ error: '정렬 순서는 정수여야 합니다.' }, { status: 400 })
+        return fail('정렬 순서는 정수여야 합니다.', 400)
       }
       if (sortOrder < 0 || sortOrder > 999) {
-        return NextResponse.json({ error: '정렬 순서는 0~999 범위여야 합니다.' }, { status: 400 })
+        return fail('정렬 순서는 0~999 범위여야 합니다.', 400)
       }
     }
 
@@ -103,7 +104,7 @@ export async function PUT(request: NextRequest, props: RouteParams) {
         }
         return tx.category.update({ where: { id: params.id }, data: updateDataWithType })
       }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
-      return NextResponse.json(updated)
+      return ok(updated)
     }
 
     const updated = await prisma.category.update({
@@ -111,32 +112,29 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       data: baseUpdateData,
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Error) {
       if (error.message === 'NOT_FOUND') {
-        return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+        return fail('카테고리를 찾을 수 없습니다.', 404)
       }
       if (error.message === 'HAS_LINKED_DATA') {
-        return NextResponse.json(
-          { error: '거래 또는 예산이 연결된 카테고리의 유형은 변경할 수 없습니다.' },
-          { status: 400 }
-        )
+        return fail('거래 또는 예산이 연결된 카테고리의 유형은 변경할 수 없습니다.', 400)
       }
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === 'P2002') {
-        return NextResponse.json({ error: '이미 존재하는 카테고리 이름입니다.' }, { status: 409 })
+        return fail('이미 존재하는 카테고리 이름입니다.', 409)
       }
       if (error.code === 'P2025') {
-        return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+        return fail('카테고리를 찾을 수 없습니다.', 404)
       }
       if (error.code === 'P2003') {
-        return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 400 })
+        return fail('존재하지 않는 그룹입니다.', 400)
       }
     }
     console.error('PUT /api/categories/[id] error:', error)
-    return NextResponse.json({ error: '카테고리 수정에 실패했습니다.' }, { status: 500 })
+    return fail('카테고리 수정에 실패했습니다.', 500)
   }
 }
 
@@ -148,35 +146,29 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
       include: { _count: { select: { transactions: true, budgets: true } } },
     })
     if (!existing) {
-      return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('카테고리를 찾을 수 없습니다.', 404)
     }
 
     if (existing._count.transactions > 0) {
-      return NextResponse.json(
-        { error: `${existing._count.transactions}건의 거래가 연결되어 삭제할 수 없습니다.` },
-        { status: 400 }
-      )
+      return fail(`${existing._count.transactions}건의 거래가 연결되어 삭제할 수 없습니다.`, 400)
     }
 
     if (existing._count.budgets > 0) {
-      return NextResponse.json(
-        { error: `${existing._count.budgets}건의 예산이 연결되어 삭제할 수 없습니다.` },
-        { status: 400 }
-      )
+      return fail(`${existing._count.budgets}건의 예산이 연결되어 삭제할 수 없습니다.`, 400)
     }
 
     await prisma.category.delete({ where: { id: params.id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === 'P2003') {
-        return NextResponse.json({ error: '연결된 데이터가 있어 삭제할 수 없습니다.' }, { status: 400 })
+        return fail('연결된 데이터가 있어 삭제할 수 없습니다.', 400)
       }
       if (error.code === 'P2025') {
-        return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+        return fail('카테고리를 찾을 수 없습니다.', 404)
       }
     }
     console.error('DELETE /api/categories/[id] error:', error)
-    return NextResponse.json({ error: '카테고리 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('카테고리 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
+import { fail, noContent } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,17 +16,17 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { items } = body as { items?: unknown }
 
     if (!Array.isArray(items) || items.length === 0) {
-      return NextResponse.json({ error: 'items 배열이 필요합니다.' }, { status: 400 })
+      return fail('items 배열이 필요합니다.', 400)
     }
 
     const validItems: ReorderItem[] = []
@@ -39,10 +40,7 @@ export async function POST(request: NextRequest) {
         (item as ReorderItem).sortOrder > 999 ||
         !Number.isInteger((item as ReorderItem).sortOrder)
       ) {
-        return NextResponse.json(
-          { error: '각 항목은 id(string)와 sortOrder(0-999 정수)가 필요합니다.' },
-          { status: 400 }
-        )
+        return fail('각 항목은 id(string)와 sortOrder(0-999 정수)가 필요합니다.', 400)
       }
       validItems.push({ id: (item as ReorderItem).id, sortOrder: (item as ReorderItem).sortOrder })
     }
@@ -50,7 +48,7 @@ export async function POST(request: NextRequest) {
     // id 유니크 검증
     const uniqueIds = new Set(validItems.map((item) => item.id))
     if (uniqueIds.size !== validItems.length) {
-      return NextResponse.json({ error: '중복된 카테고리 ID가 있습니다.' }, { status: 400 })
+      return fail('중복된 카테고리 ID가 있습니다.', 400)
     }
 
     await prisma.$transaction(
@@ -62,18 +60,12 @@ export async function POST(request: NextRequest) {
       )
     )
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json(
-        { error: '존재하지 않는 카테고리가 포함되어 있습니다.' },
-        { status: 404 }
-      )
+      return fail('존재하지 않는 카테고리가 포함되어 있습니다.', 404)
     }
     console.error('POST /api/categories/reorder error:', error)
-    return NextResponse.json(
-      { error: '정렬 순서 변경에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('정렬 순서 변경에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { validateCategoryInput, generateSlug } from '@/lib/category-utils'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,10 +28,7 @@ export async function GET(request: NextRequest) {
     return ok(categories)
   } catch (error) {
     console.error('GET /api/categories error:', error)
-    return NextResponse.json(
-      { error: '카테고리를 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('카테고리를 불러올 수 없습니다.', 500)
   }
 }
 
@@ -41,15 +38,15 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const errors = validateCategoryInput(body as Record<string, unknown>)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { name, type, icon, keywords, sortOrder, groupId } = body as Record<string, unknown>
@@ -78,34 +75,31 @@ export async function POST(request: NextRequest) {
             groupId: typeof groupId === 'string' ? groupId : null,
           },
         })
-        return NextResponse.json(category, { status: 201 })
+        return ok(category, { status: 201 })
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError) {
           if (error.code === 'P2002') {
             const target = (error.meta?.target as string[]) ?? []
             if (target.includes('name')) {
-              return NextResponse.json({ error: '이미 존재하는 카테고리 이름입니다.' }, { status: 409 })
+              return fail('이미 존재하는 카테고리 이름입니다.', 409)
             }
             // slug 충돌 → 다음 attempt에서 suffix 추가
             if (attempt === MAX_SLUG_RETRIES - 1) {
-              return NextResponse.json({ error: '카테고리 생성에 실패했습니다. 다시 시도해주세요.' }, { status: 409 })
+              return fail('카테고리 생성에 실패했습니다. 다시 시도해주세요.', 409)
             }
             continue
           }
           if (error.code === 'P2003') {
-            return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 400 })
+            return fail('존재하지 않는 그룹입니다.', 400)
           }
         }
         throw error
       }
     }
 
-    return NextResponse.json({ error: '카테고리 생성에 실패했습니다.' }, { status: 500 })
+    return fail('카테고리 생성에 실패했습니다.', 500)
   } catch (error) {
     console.error('POST /api/categories error:', error)
-    return NextResponse.json(
-      { error: '카테고리 생성에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('카테고리 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/category-groups/[id]/route.ts
+++ b/src/app/api/category-groups/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -16,14 +17,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     const data: Record<string, unknown> = {}
     if (typeof body.name === 'string') {
       const name = body.name.trim()
-      if (!name) return NextResponse.json({ error: '그룹 이름을 입력해주세요.' }, { status: 400 })
-      if (name.length > 50) return NextResponse.json({ error: '이름은 50자 이내로 입력해주세요.' }, { status: 400 })
+      if (!name) return fail('그룹 이름을 입력해주세요.', 400)
+      if (name.length > 50) return fail('이름은 50자 이내로 입력해주세요.', 400)
       data.name = name
     }
     if (body.icon !== undefined) {
@@ -38,14 +39,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       data,
     })
 
-    return NextResponse.json(group)
+    return ok(group)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2025') return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 404 })
-      if (error.code === 'P2002') return NextResponse.json({ error: '이미 존재하는 그룹 이름입니다.' }, { status: 409 })
+      if (error.code === 'P2025') return fail('존재하지 않는 그룹입니다.', 404)
+      if (error.code === 'P2002') return fail('이미 존재하는 그룹 이름입니다.', 409)
     }
     console.error('[api/category-groups/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '그룹 수정에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 수정에 실패했습니다.', 500)
   }
 }
 
@@ -64,16 +65,16 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       const parts: string[] = []
       if (catCount > 0) parts.push(`${catCount}개의 카테고리`)
       if (budgetCount > 0) parts.push(`${budgetCount}개의 예산`)
-      return NextResponse.json({ error: `${parts.join(', ')}이 연결되어 삭제할 수 없습니다.` }, { status: 400 })
+      return fail(`${parts.join(', ')}이 연결되어 삭제할 수 없습니다.`, 400)
     }
 
     await prisma.categoryGroup.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 404 })
+      return fail('존재하지 않는 그룹입니다.', 404)
     }
     console.error('[api/category-groups/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '그룹 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/category-groups/route.ts
+++ b/src/app/api/category-groups/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,7 +16,7 @@ export async function GET() {
     return ok(groups)
   } catch (error) {
     console.error('[api/category-groups] GET 실패:', error)
-    return NextResponse.json({ error: '그룹 조회에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 조회에 실패했습니다.', 500)
   }
 }
 
@@ -29,15 +29,15 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     const name = typeof body.name === 'string' ? body.name.trim() : ''
     if (!name) {
-      return NextResponse.json({ error: '그룹 이름을 입력해주세요.' }, { status: 400 })
+      return fail('그룹 이름을 입력해주세요.', 400)
     }
     if (name.length > 50) {
-      return NextResponse.json({ error: '이름은 50자 이내로 입력해주세요.' }, { status: 400 })
+      return fail('이름은 50자 이내로 입력해주세요.', 400)
     }
 
     const icon = typeof body.icon === 'string' ? body.icon.trim() || null : null
@@ -48,12 +48,12 @@ export async function POST(request: NextRequest) {
       data: { name, icon, sortOrder },
     })
 
-    return NextResponse.json(group, { status: 201 })
+    return ok(group, { status: 201 })
   } catch (error) {
     if ((error as { code?: string }).code === 'P2002') {
-      return NextResponse.json({ error: '이미 존재하는 그룹 이름입니다.' }, { status: 409 })
+      return fail('이미 존재하는 그룹 이름입니다.', 409)
     }
     console.error('[api/category-groups] POST 실패:', error)
-    return NextResponse.json({ error: '그룹 생성에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/budgets/BudgetsClient.tsx
+++ b/src/app/budgets/BudgetsClient.tsx
@@ -57,7 +57,8 @@ export default function BudgetsClient() {
     try {
       const res = await fetch(`/api/budgets?year=${year}&month=${month}`, { signal: controller.signal })
       if (res.ok) {
-        setData(await res.json())
+        const json = await res.json()
+        if (json?.data) setData(json.data)
       }
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') return

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -104,8 +104,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       .catch(() => {})
     fetch('/api/assets')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        const list = data?.assets ?? data
+      .then((json) => {
+        const list = json?.data?.assets
         if (Array.isArray(list)) setAssets(list)
       })
       .catch(() => {})


### PR DESCRIPTION
## 요약

27-C 의 두 번째 sub-PR — Category + Budget + Asset 도메인 9 라우트 16+ 메소드를 envelope 으로 마이그.

### 라우트 (9 파일)
- categories (POST), [id] (PUT/DELETE), reorder
- category-groups (POST), [id] (PUT/DELETE)
- budgets (GET/POST: upsert + copy 액션), [id] (DELETE)
- assets (GET/POST), [id] (PUT/DELETE)

### 클라이언트 (2 fetcher)
- \`BudgetsClient\`: /api/budgets GET → \`json.data\`
- \`ExpensesClient\`: /api/assets GET → \`json.data.assets\`
- Form/Modal/Editor 13개는 \`res.ok\` 만 사용 — 변경 없음

### 변환 패턴 (27-C-1 동일)
- 성공: \`NextResponse.json(data)\` → \`ok(data)\`
- 201: \`{ status: 201 }\` 옵션 유지
- 204: \`new NextResponse(null, { status: 204 })\` → \`noContent()\`
- 에러: \`NextResponse.json({ error }, { status })\` → \`fail(error, status)\`
- upsert: \`ok(result.budget, { status: result.created ? 201 : 200 })\` 분기 보존

Closes #327

## 체크리스트
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run test:run\` — 162 tests passed
- [x] \`npm run build\` — Next + MCP + Bot 번들 성공
- [x] 코드 리뷰 통과 (P1/P2: 0건)

## 코드 리뷰 결과
- P2=0 / P1=0 / P0=1 → 즉시 반영 (ExpensesClient 다단 fallback 단순화) ✅
- 9 라우트 16+ 메소드 누락 없음
- 응답 구조 (객체/배열/숫자/copy 응답) 시맨틱 보존
- 다중 필드 검증 \`errors\` 배열 클라이언트 미사용 확인

## 다음
- 27-C-3 (Dividend + Deposit + Transaction)
- 27-C-4 (RSU + StockOption)
- 27-C-5 (Trade)