### PR TITLE
[Phase 27-C-3] Dividend/Deposit/Transaction envelope migration (#329)

### DIFF
--- a/docs/specs/329-envelope-c3.md
+++ b/docs/specs/329-envelope-c3.md
@@ -1,0 +1,71 @@
+# [Phase 27-C-3] Dividend + Deposit + Transaction envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 세 번째 — 자금 mutation 핵심 3 도메인 (dividends/deposits/transactions) 의 POST/PUT/DELETE + 분석/검색 GET 들을 envelope 으로 마이그. GET pagination (메인 list 라우트) 은 27-D 로 분리.
+
+## 배경
+
+- 27-C-1 (Watchlist/Recurring/Settings/IncomeProfile), 27-C-2 (Category/Budget/Asset) 완료
+- 27-C-3 은 자금 mutation 도메인 — Form/EditPanel 가 많아 클라이언트 영향 검증 중요
+- pagination GET (dividends/deposits/transactions list) 은 27-D 에서 별도
+
+## 요구사항
+
+- [ ] 9 라우트 파일 마이그
+  - `dividends/route.ts` (POST), `dividends/[id]/route.ts` (PUT/DELETE), `dividends/summary/route.ts` (GET)
+  - `deposits/route.ts` (POST), `deposits/[id]/route.ts` (PUT/DELETE)
+  - `transactions/route.ts` (POST), `transactions/[id]/route.ts` (PUT/DELETE)
+  - `transactions/analysis/route.ts` (GET), `transactions/suggest/route.ts` (GET)
+- [ ] 메인 list GET (dividends/deposits/transactions) 은 27-D 별도
+- [ ] 클라이언트 fetcher unwrap (응답 본문 사용처만)
+
+## 기술 설계
+
+### 1. 라우트 변환 (~15 메소드)
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `dividends/route.ts` | POST | `ok(dividend, { status: 201 })` (GET 은 27-D) |
+| `dividends/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `dividends/summary/route.ts` | GET | `ok({ year, totalNetKRW, ... byAccount, byTicker, byMonth })` |
+| `deposits/route.ts` | POST | `ok(deposit, { status: 201 })` (GET 은 27-D) |
+| `deposits/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `transactions/route.ts` | POST | `ok(transaction, { status: 201 })` (GET 은 27-D) |
+| `transactions/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `transactions/analysis/route.ts` | GET | `ok({ monthCompare, prevMonthSummary, trend })` |
+| `transactions/suggest/route.ts` | GET | `ok(suggestions)` (배열) 또는 객체 |
+
+### 2. 클라이언트 fetcher
+
+대부분 Form/EditPanel/DeleteModal — `res.ok` 만 확인:
+- DividendForm/EditPanel/DeleteModal — 응답 본문 미사용
+- DepositForm/EditPanel/DeleteModal — 동일
+- TransactionForm/DeleteModal — 동일
+
+응답 본문 사용:
+- DividendSummary 컴포넌트 (summary GET) — **확인 필요**
+- 가계부 분석 페이지 (analysis GET) — **확인 필요**
+- TransactionForm 카테고리 추천 (suggest GET) — **확인 필요**
+
+### 3. 변환 패턴 (이전 sub-phase 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 배당 등록/수정/삭제 + 배당 요약 페이지
+  - 입금 등록/수정/삭제
+  - 거래 등록/수정/삭제 + 분석/추천
+
+## 제외 사항
+
+- 메인 list GET (`/api/dividends`, `/api/deposits`, `/api/transactions`) — pagination 27-D 에서
+- 다른 도메인 (rsu/stock-option/trade) — 27-C-4, C-5

--- a/src/app/api/deposits/[id]/route.ts
+++ b/src/app/api/deposits/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -10,37 +11,37 @@ export async function PUT(request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.deposit.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '입금 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('입금 기록을 찾을 수 없습니다.', 404)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     const { amount, source, note, depositedAt } = body as Record<string, unknown>
 
     if (amount !== undefined && (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0)) {
-      return NextResponse.json({ error: '금액은 0보다 커야 합니다.' }, { status: 400 })
+      return fail('금액은 0보다 커야 합니다.', 400)
     }
     if (source !== undefined && (typeof source !== 'string' || !source.trim())) {
-      return NextResponse.json({ error: '출처를 입력해주세요.' }, { status: 400 })
+      return fail('출처를 입력해주세요.', 400)
     }
     if (depositedAt !== undefined && (typeof depositedAt !== 'string' || isNaN(Date.parse(depositedAt)))) {
-      return NextResponse.json({ error: '유효한 입금일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 입금일을 입력해주세요.', 400)
     }
     if (note !== undefined && note !== null && typeof note !== 'string') {
-      return NextResponse.json({ error: '메모는 문자열이어야 합니다.' }, { status: 400 })
+      return fail('메모는 문자열이어야 합니다.', 400)
     }
 
     if (typeof amount === 'number') {
       const roundedAmount = Math.round(amount)
       if (roundedAmount <= 0) {
-        return NextResponse.json({ error: '금액은 1원 이상이어야 합니다.' }, { status: 400 })
+        return fail('금액은 1원 이상이어야 합니다.', 400)
       }
     }
 
@@ -69,10 +70,10 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       return result
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/deposits/[id] error:', error)
-    return NextResponse.json({ error: '입금 수정에 실패했습니다.' }, { status: 500 })
+    return fail('입금 수정에 실패했습니다.', 500)
   }
 }
 
@@ -81,7 +82,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.deposit.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '입금 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('입금 기록을 찾을 수 없습니다.', 404)
     }
 
     await prisma.$transaction(async (tx) => {
@@ -95,9 +96,9 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
         })
       }
     })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     console.error('DELETE /api/deposits/[id] error:', error)
-    return NextResponse.json({ error: '입금 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('입금 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/deposits/route.ts
+++ b/src/app/api/deposits/route.ts
@@ -5,6 +5,7 @@ import { isGiftSource } from '@/lib/tax/gift-tax'
 import { checkGiftTaxLimit } from '@/bot/notifications/budget-alert'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -72,34 +73,34 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     const errors = validateDepositInput(body as Record<string, unknown>)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { accountId, assetId, amount, source, note, depositedAt } = body as Record<string, unknown>
 
     if (note !== undefined && note !== null && typeof note !== 'string') {
-      return NextResponse.json({ error: '메모는 문자열이어야 합니다.' }, { status: 400 })
+      return fail('메모는 문자열이어야 합니다.', 400)
     }
 
     if (accountId) {
       const account = await prisma.account.findUnique({ where: { id: accountId as string } })
-      if (!account) return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      if (!account) return fail('계좌를 찾을 수 없습니다.', 404)
     }
     if (assetId) {
       const asset = await prisma.asset.findUnique({ where: { id: assetId as string } })
-      if (!asset) return NextResponse.json({ error: '자산을 찾을 수 없습니다.' }, { status: 404 })
+      if (!asset) return fail('자산을 찾을 수 없습니다.', 404)
     }
 
     const roundedAmount = Math.round(amount as number)
     if (roundedAmount <= 0) {
-      return NextResponse.json({ error: '금액은 1원 이상이어야 합니다.' }, { status: 400 })
+      return fail('금액은 1원 이상이어야 합니다.', 400)
     }
 
     const deposit = await prisma.$transaction(async (tx) => {
@@ -130,12 +131,9 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    return NextResponse.json(deposit, { status: 201 })
+    return ok(deposit, { status: 201 })
   } catch (error) {
     console.error('POST /api/deposits error:', error)
-    return NextResponse.json(
-      { error: '입금 기록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('입금 기록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/dividends/[id]/route.ts
+++ b/src/app/api/dividends/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calcAmountKRW } from '@/lib/dividend-utils'
 import { validateFxRateForUSD } from '@/lib/trade-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -12,33 +13,33 @@ export async function PUT(request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.dividend.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '배당 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('배당 기록을 찾을 수 없습니다.', 404)
     }
 
     const body = await request.json()
     const { exDate, payDate, amountGross, amountNet, taxAmount, fxRate, reinvested } = body
 
     if (amountGross !== undefined && (typeof amountGross !== 'number' || !Number.isFinite(amountGross) || amountGross <= 0)) {
-      return NextResponse.json({ error: '세전 금액은 0보다 커야 합니다.' }, { status: 400 })
+      return fail('세전 금액은 0보다 커야 합니다.', 400)
     }
     if (amountNet !== undefined && (typeof amountNet !== 'number' || !Number.isFinite(amountNet) || amountNet < 0)) {
-      return NextResponse.json({ error: '세후 금액은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('세후 금액은 0 이상이어야 합니다.', 400)
     }
     if (payDate !== undefined && (typeof payDate !== 'string' || isNaN(Date.parse(payDate)))) {
-      return NextResponse.json({ error: '유효한 지급일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 지급일을 입력해주세요.', 400)
     }
     if (exDate !== undefined && exDate !== null && (typeof exDate !== 'string' || isNaN(Date.parse(exDate)))) {
-      return NextResponse.json({ error: '유효한 기준일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 기준일을 입력해주세요.', 400)
     }
     if (taxAmount !== undefined && taxAmount !== null && (typeof taxAmount !== 'number' || !Number.isFinite(taxAmount) || taxAmount < 0)) {
-      return NextResponse.json({ error: '세금은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('세금은 0 이상이어야 합니다.', 400)
     }
     if (fxRate !== undefined && fxRate !== null && existing.currency === 'USD') {
       const fxError = validateFxRateForUSD(fxRate, 'USD 배당')
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
     if (reinvested !== undefined && typeof reinvested !== 'boolean') {
-      return NextResponse.json({ error: '재투자 여부는 true/false여야 합니다.' }, { status: 400 })
+      return fail('재투자 여부는 true/false여야 합니다.', 400)
     }
 
     // 최종 적용값 결정
@@ -51,16 +52,16 @@ export async function PUT(request: NextRequest, props: RouteParams) {
 
     // 교차 검증: amountNet <= amountGross, taxAmount <= amountGross
     if (nextNet > nextGross) {
-      return NextResponse.json({ error: '세후 금액이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세후 금액이 세전 금액을 초과할 수 없습니다.', 400)
     }
     if (nextTax != null && nextTax > nextGross) {
-      return NextResponse.json({ error: '세금이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세금이 세전 금액을 초과할 수 없습니다.', 400)
     }
 
     // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
     if (existing.currency === 'USD') {
       const fxError = validateFxRateForUSD(nextFxRate, 'USD 배당')
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
 
     // 서버 측 amountKRW 재계산
@@ -80,10 +81,10 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       },
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/dividends/[id] error:', error)
-    return NextResponse.json({ error: '배당 수정에 실패했습니다.' }, { status: 500 })
+    return fail('배당 수정에 실패했습니다.', 500)
   }
 }
 
@@ -92,13 +93,13 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.dividend.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '배당 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('배당 기록을 찾을 수 없습니다.', 404)
     }
 
     await prisma.dividend.delete({ where: { id: params.id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     console.error('DELETE /api/dividends/[id] error:', error)
-    return NextResponse.json({ error: '배당 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('배당 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/dividends/route.ts
+++ b/src/app/api/dividends/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 import { validateDividendInput, calcAmountKRW } from '@/lib/dividend-utils'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -66,7 +67,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const errors = validateDividendInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { accountId, displayName, exDate, payDate, amountGross, amountNet, taxAmount, currency, fxRate, reinvested } = body
@@ -74,21 +75,21 @@ export async function POST(request: NextRequest) {
 
     // 옵션 필드 타입 검증
     if (exDate !== undefined && exDate !== null && (typeof exDate !== 'string' || isNaN(Date.parse(exDate)))) {
-      return NextResponse.json({ error: '유효한 기준일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 기준일을 입력해주세요.', 400)
     }
     if (taxAmount !== undefined && taxAmount !== null && (typeof taxAmount !== 'number' || !Number.isFinite(taxAmount) || taxAmount < 0)) {
-      return NextResponse.json({ error: '세금은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('세금은 0 이상이어야 합니다.', 400)
     }
     if (reinvested !== undefined && reinvested !== null && typeof reinvested !== 'boolean') {
-      return NextResponse.json({ error: '재투자 여부는 true/false여야 합니다.' }, { status: 400 })
+      return fail('재투자 여부는 true/false여야 합니다.', 400)
     }
 
     // 교차 검증
     if (amountNet > amountGross) {
-      return NextResponse.json({ error: '세후 금액이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세후 금액이 세전 금액을 초과할 수 없습니다.', 400)
     }
     if (taxAmount != null && taxAmount > amountGross) {
-      return NextResponse.json({ error: '세금이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세금이 세전 금액을 초과할 수 없습니다.', 400)
     }
 
     // 서버 측 amountKRW 재계산 (클라이언트 값 대신 서버 계산값 사용)
@@ -96,7 +97,7 @@ export async function POST(request: NextRequest) {
 
     const account = await prisma.account.findUnique({ where: { id: accountId } })
     if (!account) {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
     const dividend = await prisma.dividend.create({
@@ -116,12 +117,9 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(dividend, { status: 201 })
+    return ok(dividend, { status: 201 })
   } catch (error) {
     console.error('POST /api/dividends error:', error)
-    return NextResponse.json(
-      { error: '배당 기록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('배당 기록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/dividends/summary/route.ts
+++ b/src/app/api/dividends/summary/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,7 +12,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data ?? new Date().getFullYear()
     const accountId = searchParams.get('accountId')
@@ -75,7 +76,7 @@ export async function GET(request: NextRequest) {
       byMonth[month].count += 1
     }
 
-    return NextResponse.json({
+    return ok({
       year,
       totalNetKRW: Math.round(totalNetKRW),
       totalTaxKRW: Math.round(totalTaxKRW),
@@ -87,9 +88,6 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('GET /api/dividends/summary error:', error)
-    return NextResponse.json(
-      { error: '배당 요약을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('배당 요약을 불러올 수 없습니다.', 500)
   }
 }

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateTransactionInput } from '@/lib/transaction-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -17,14 +18,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
     const errors = validateTransactionInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const amount = body.amount as number
@@ -38,18 +39,18 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       select: { id: true, type: true },
     })
     if (!category) {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     if (txType && category.type !== 'transfer') {
-      return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('출금/입금은 이체 카테고리에서만 사용할 수 있습니다.', 400)
     }
     if (!txType && category.type === 'transfer') {
-      return NextResponse.json({ error: '이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.', 400)
     }
 
     const existing = await prisma.transaction.findUnique({ where: { id } })
     if (!existing) {
-      return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
+      return fail('존재하지 않는 내역입니다.', 404)
     }
 
     const transactedAt = body.transactedAt
@@ -95,7 +96,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       return result
     })
 
-    return NextResponse.json({
+    return ok({
       id: updated.id,
       amount: updated.amount,
       description: updated.description,
@@ -111,11 +112,11 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2025') return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
-      if (error.code === 'P2003') return NextResponse.json({ error: '존재하지 않는 카테고리 또는 자산입니다.' }, { status: 400 })
+      if (error.code === 'P2025') return fail('존재하지 않는 내역입니다.', 404)
+      if (error.code === 'P2003') return fail('존재하지 않는 카테고리 또는 자산입니다.', 400)
     }
     console.error('[api/transactions/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '내역 수정에 실패했습니다.' }, { status: 500 })
+    return fail('내역 수정에 실패했습니다.', 500)
   }
 }
 
@@ -143,15 +144,15 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       await tx.transaction.delete({ where: { id } })
     })
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Error && error.message === 'NOT_FOUND') {
-      return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
+      return fail('존재하지 않는 내역입니다.', 404)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
+      return fail('존재하지 않는 내역입니다.', 404)
     }
     console.error('[api/transactions/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '내역 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('내역 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/transactions/analysis/route.ts
+++ b/src/app/api/transactions/analysis/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { yearMonthSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,11 +30,11 @@ export async function GET(request: NextRequest) {
     })
     if (!ymResult.success) {
       const errs = zodErrorsToValidation(ymResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { year, month } = ymResult.data
     if (year === undefined || month === undefined) {
-      return NextResponse.json({ error: 'year, month 파라미터가 필요합니다.' }, { status: 400 })
+      return fail('year, month 파라미터가 필요합니다.', 400)
     }
 
     // 카테고리 → 그룹 매핑
@@ -173,7 +174,7 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    return NextResponse.json({
+    return ok({
       monthCompare,
       prevMonthSummary: {
         totalExpense: prevExpenseTotal,
@@ -187,7 +188,7 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[api/transactions/analysis] GET 실패:', error)
-    return NextResponse.json({ error: '분석 데이터 조회에 실패했습니다.' }, { status: 500 })
+    return fail('분석 데이터 조회에 실패했습니다.', 500)
   }
 }
 

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateTransactionInput } from '@/lib/transaction-utils'
 import { sendToWhooing } from '@/lib/whooing-webhook'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -216,14 +217,14 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
     const errors = validateTransactionInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const amount = body.amount as number
@@ -240,22 +241,22 @@ export async function POST(request: NextRequest) {
       select: { id: true, name: true, icon: true, type: true },
     })
     if (!category) {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
 
     // transfer 유형 ↔ transfer 카테고리 일치 검증
     if (txType && category.type !== 'transfer') {
-      return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('출금/입금은 이체 카테고리에서만 사용할 수 있습니다.', 400)
     }
     if (!txType && category.type === 'transfer') {
-      return NextResponse.json({ error: '이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.', 400)
     }
 
     // 자산 존재 확인 (transfer 유형)
     if (linkedAssetId) {
       const asset = await prisma.asset.findUnique({ where: { id: linkedAssetId }, select: { id: true } })
       if (!asset) {
-        return NextResponse.json({ error: '존재하지 않는 자산입니다.' }, { status: 400 })
+        return fail('존재하지 않는 자산입니다.', 400)
       }
     }
 
@@ -300,7 +301,7 @@ export async function POST(request: NextRequest) {
       console.error('[whooing] 전송 실패:', err)
     }
 
-    return NextResponse.json({
+    return ok({
       id: transaction.id,
       amount: transaction.amount,
       description: transaction.description,
@@ -316,9 +317,9 @@ export async function POST(request: NextRequest) {
     }, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/transactions] POST 실패:', error)
-    return NextResponse.json({ error: '내역 생성에 실패했습니다.' }, { status: 500 })
+    return fail('내역 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { matchCategory, suggestByHistory } from '@/lib/category-matcher'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,12 +30,12 @@ export async function GET(request: NextRequest) {
     const sp = request.nextUrl.searchParams
     const q = sp.get('q')?.trim()?.slice(0, MAX_QUERY_LENGTH)
     if (!q || q.length < 2) {
-      return NextResponse.json({ suggestions: [] })
+      return ok({ suggestions: [] })
     }
 
     const rawType = sp.get('type')
     if (rawType && !VALID_TYPES.has(rawType)) {
-      return NextResponse.json({ error: 'type은 expense 또는 income이어야 합니다.' }, { status: 400 })
+      return fail('type은 expense 또는 income이어야 합니다.', 400)
     }
     const types: Array<'expense' | 'income'> =
       rawType ? [rawType as 'expense' | 'income'] : ['expense', 'income']
@@ -69,9 +70,9 @@ export async function GET(request: NextRequest) {
 
     const suggestions = [...keywordSuggestions, ...historySuggestions].slice(0, MAX_SUGGESTIONS)
 
-    return NextResponse.json({ suggestions })
+    return ok({ suggestions })
   } catch (error) {
     console.error('[suggest] error:', error)
-    return NextResponse.json({ error: '추천 조회에 실패했습니다.' }, { status: 500 })
+    return fail('추천 조회에 실패했습니다.', 500)
   }
 }

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -148,7 +148,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
         try {
           const analysisRes = await fetch(`/api/transactions/analysis?year=${y}&month=${m}`, { signal: controller.signal })
           if (analysisRes.ok) {
-            setAnalysisData(await analysisRes.json())
+            const aJson = await analysisRes.json()
+            setAnalysisData(aJson?.data ?? null)
           } else {
             setAnalysisData(null)
           }

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -106,8 +106,8 @@ export default function TransactionForm({
           { signal: controller.signal }
         )
         if (res.ok) {
-          const data = await res.json()
-          setSuggestions(data.suggestions ?? [])
+          const json = await res.json()
+          setSuggestions(json?.data?.suggestions ?? [])
         } else {
           setSuggestions([])
         }


### PR DESCRIPTION
## 요약

Phase 27 envelope 마이그 5번째 sub-PR — Dividend/Deposit/Transaction 도메인의 mutation 라우트 + 보조 GET 라우트들을 `ApiResponse<T>` envelope 으로 일괄 마이그.

메인 list GET (`/api/dividends`, `/api/deposits`, `/api/transactions`) 은 27-D pagination 정리와 함께 별도 PR로 분리.

## 변경 내역

### 라우트 (9 파일)
- `dividends/route.ts` — POST → `ok(_, { status: 201 })` / `fail()`
- `dividends/[id]/route.ts` — PUT → `ok()`, DELETE → `noContent()`
- `dividends/summary/route.ts` — GET → `ok()`
- `deposits/route.ts` — POST → `ok(_, { status: 201 })` / `fail()`
- `deposits/[id]/route.ts` — PUT → `ok()`, DELETE → `noContent()`
- `transactions/route.ts` — POST → `ok(_, { status: 201 })` / `fail()`
- `transactions/[id]/route.ts` — PUT → `ok()`, DELETE → `noContent()`
- `transactions/analysis/route.ts` — GET → `ok()`
- `transactions/suggest/route.ts` — GET → `ok()`

### 클라이언트 fetcher unwrap (2 파일)
- `src/app/expenses/ExpensesClient.tsx` — analysis 응답 → `json?.data`
- `src/components/expense/TransactionForm.tsx` — suggest 응답 → `json?.data?.suggestions ?? []`

### 영향 없음 (error path 만 사용)
- Dividend/Deposit/Transaction Form/EditPanel/DeleteModal — 실패 시 `data?.error` 만 읽음 → envelope 의 `error` 필드와 호환

## 변환 패턴 (27-C-1/27-C-2 와 동일)

| 케이스 | before | after |
|---|---|---|
| 성공 | `NextResponse.json(data)` | `ok(data)` |
| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |

## 제외 사항

- 메인 list GET (`/api/dividends`, `/api/deposits`, `/api/transactions`) — 27-D 별도 (pagination + envelope 통합)
- 다른 도메인 (rsu/stock-option/trade) — 27-C-4, C-5

Closes #329

## 체크리스트

- [x] 린트 (`npm run lint`) — 0 warnings/errors
- [x] 타입체크 (`npx tsc --noEmit`) — 0 errors
- [x] 단위 테스트 (`npm run test:run`) — 162/162 passed
- [x] 빌드 (`npm run build`) — Next.js + MCP + Bot 정상
- [x] 코드 리뷰 — pr-review-toolkit:code-reviewer 1회, **P0/P1/P2: 0/0/0**
- [x] 27-D 영역(list GET) 미침범 확인
- [x] 클라이언트 unwrap null 안전성 검증

## 관련 PR

- #326 (27-C-1: Watchlist + Recurring + Settings + IncomeProfile)
- #328 (27-C-2: Category + Budget + Asset)