### PR TITLE
[Phase 27-C-4] RSU + StockOption envelope migration (#331)

### DIFF
--- a/docs/specs/331-envelope-c4.md
+++ b/docs/specs/331-envelope-c4.md
@@ -1,0 +1,72 @@
+# [Phase 27-C-4] RSU + StockOption envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 네 번째 — RSU 스케줄 + 스톡옵션 도메인의 mutation/베스팅 처리 라우트들을 envelope 으로 마이그.
+
+GET (`/api/rsu`, `/api/stock-options`) 은 27-B 에서 이미 envelope 적용 완료 — 본 PR 은 mutation + 베스팅 vest/exercise 경로만 정리.
+
+## 배경
+
+- 27-C-1 (Watchlist/Recurring/Settings/IncomeProfile), 27-C-2 (Category/Budget/Asset), 27-C-3 (Dividend/Deposit/Transaction) 완료
+- 27-C-4 는 권리행사 흐름이 포함된 도메인 — vesting status 전이, exercise 처리 등 동시성 안전성도 함께 확인
+- pagination GET 가 없어 27-D 분리 불필요
+
+## 요구사항
+
+- [ ] 7 라우트 파일 마이그
+  - `rsu/route.ts` (POST)
+  - `rsu/[id]/route.ts` (PUT/DELETE)
+  - `rsu/[id]/vest/route.ts` (POST)
+  - `stock-options/route.ts` (POST)
+  - `stock-options/[id]/route.ts` (PUT/DELETE)
+  - `stock-options/[id]/vestings/route.ts` (POST)
+  - `stock-options/[id]/vestings/[vid]/route.ts` (PUT/PATCH/DELETE)
+- [ ] 두 도메인의 GET 라우트 에러 path 만 추가 정리 (`fail()` 통일)
+- [ ] 클라이언트 fetcher: `/rsu`, `/stock-options`, `/vesting` 페이지 응답 본문 사용처 unwrap
+
+## 기술 설계
+
+### 1. 라우트 변환
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `rsu/route.ts` | POST | `ok(schedule, { status: 201 })` |
+| `rsu/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `rsu/[id]/vest/route.ts` | POST | `ok(result)` |
+| `stock-options/route.ts` | POST | `ok(option, { status: 201 })` |
+| `stock-options/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `stock-options/[id]/vestings/route.ts` | POST | `ok(vesting, { status: 201 })` |
+| `stock-options/[id]/vestings/[vid]/route.ts` | PUT, PATCH, DELETE | `ok(updated)`, `noContent()` |
+
+### 2. 클라이언트 fetcher
+
+확인 필요:
+- `/rsu` 페이지 — RSU 목록 + CRUD 폼
+- `/stock-options` 페이지 — 스톡옵션 목록 + 베스팅 행사
+- `/vesting` 캘린더 — RSU + 스톡옵션 통합 뷰
+
+PATCH (vesting status 전이) 응답 body 사용 여부 특히 확인.
+
+### 3. 변환 패턴 (이전 sub-phase 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - RSU 스케줄 등록/수정/삭제 + 베스팅 처리
+  - 스톡옵션 등록/수정/삭제
+  - 베스팅 스케줄 추가/수정/상태 변경/삭제
+  - 베스팅 캘린더 뷰
+
+## 제외 사항
+
+- 메인 GET (`/api/rsu`, `/api/stock-options`) — 27-B 에서 이미 envelope
+- 다른 도메인 (trade) — 27-C-5

--- a/src/app/api/rsu/[id]/route.ts
+++ b/src/app/api/rsu/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -16,14 +17,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     if (typeof body.shares === 'number' && (!Number.isInteger(body.shares) || body.shares <= 0)) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
     if (typeof body.basisValue === 'number' && body.basisValue < 0) {
-      return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('기준금액은 0 이상이어야 합니다.', 400)
     }
 
     const data: Record<string, unknown> = {}
@@ -48,17 +49,17 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       })
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Error) {
-      if (error.message === 'NOT_FOUND') return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
-      if (error.message === 'NOT_PENDING') return NextResponse.json({ error: '베스팅 완료된 스케줄은 수정할 수 없습니다.' }, { status: 400 })
+      if (error.message === 'NOT_FOUND') return fail('존재하지 않는 RSU 스케줄입니다.', 404)
+      if (error.message === 'NOT_PENDING') return fail('베스팅 완료된 스케줄은 수정할 수 없습니다.', 400)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 RSU 스케줄입니다.', 404)
     }
     console.error('PUT /api/rsu/[id] error:', error)
-    return NextResponse.json({ error: 'RSU 스케줄 수정에 실패했습니다.' }, { status: 500 })
+    return fail('RSU 스케줄 수정에 실패했습니다.', 500)
   }
 }
 
@@ -77,16 +78,16 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       await tx.rSUSchedule.delete({ where: { id } })
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Error) {
-      if (error.message === 'NOT_FOUND') return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
-      if (error.message === 'NOT_PENDING') return NextResponse.json({ error: '베스팅 완료된 스케줄은 삭제할 수 없습니다.' }, { status: 400 })
+      if (error.message === 'NOT_FOUND') return fail('존재하지 않는 RSU 스케줄입니다.', 404)
+      if (error.message === 'NOT_PENDING') return fail('베스팅 완료된 스케줄은 삭제할 수 없습니다.', 400)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 RSU 스케줄입니다.', 404)
     }
     console.error('DELETE /api/rsu/[id] error:', error)
-    return NextResponse.json({ error: 'RSU 스케줄 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('RSU 스케줄 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/rsu/[id]/vest/route.ts
+++ b/src/app/api/rsu/[id]/vest/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW } from '@/lib/trade-utils'
+import { ok, fail } from '@/lib/api-response'
 
 const RSU_TICKER = '035720.KS'
 const RSU_DISPLAY_NAME = '카카오'
@@ -16,10 +17,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: '유효한 JSON 요청을 보내주세요.' },
-        { status: 400 }
-      )
+      return fail('유효한 JSON 요청을 보내주세요.', 400)
     }
 
     const { vestPrice, autoSell } = body as {
@@ -29,16 +27,10 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
 
     // 입력 검증
     if (typeof vestPrice !== 'number' || !Number.isFinite(vestPrice) || vestPrice <= 0) {
-      return NextResponse.json(
-        { error: '베스팅일 종가는 0보다 큰 숫자여야 합니다.' },
-        { status: 400 }
-      )
+      return fail('베스팅일 종가는 0보다 큰 숫자여야 합니다.', 400)
     }
     if (typeof autoSell !== 'boolean') {
-      return NextResponse.json(
-        { error: 'autoSell은 boolean이어야 합니다.' },
-        { status: 400 }
-      )
+      return fail('autoSell은 boolean이어야 합니다.', 400)
     }
 
     const result = await prisma.$transaction(async (tx) => {
@@ -147,26 +139,17 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       return { schedule: updated, holding }
     }, { isolationLevel: 'Serializable' })
 
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     if (error instanceof Error) {
       if (error.message === 'NOT_FOUND') {
-        return NextResponse.json(
-          { error: 'RSU 스케줄을 찾을 수 없습니다.' },
-          { status: 404 }
-        )
+        return fail('RSU 스케줄을 찾을 수 없습니다.', 404)
       }
       if (error.message === 'ALREADY_VESTED') {
-        return NextResponse.json(
-          { error: '이미 베스팅 처리된 스케줄입니다.' },
-          { status: 400 }
-        )
+        return fail('이미 베스팅 처리된 스케줄입니다.', 400)
       }
       if (error.message === 'INVALID_SELL_SHARES') {
-        return NextResponse.json(
-          { error: '매도 수량이 베스팅 수량을 초과합니다.' },
-          { status: 400 }
-        )
+        return fail('매도 수량이 베스팅 수량을 초과합니다.', 400)
       }
     }
     // Prisma Serializable 충돌 (P2034)
@@ -176,15 +159,9 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       'code' in error &&
       (error as { code: string }).code === 'P2034'
     ) {
-      return NextResponse.json(
-        { error: '동시 요청이 충돌했습니다. 잠시 후 다시 시도해주세요.' },
-        { status: 409 }
-      )
+      return fail('동시 요청이 충돌했습니다. 잠시 후 다시 시도해주세요.', 409)
     }
     console.error('POST /api/rsu/[id]/vest error:', error)
-    return NextResponse.json(
-      { error: '베스팅 처리에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('베스팅 처리에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/rsu/route.ts
+++ b/src/app/api/rsu/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,10 +15,7 @@ export async function GET() {
     return ok(schedules)
   } catch (error) {
     console.error('GET /api/rsu error:', error)
-    return NextResponse.json(
-      { error: 'RSU 스케줄을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('RSU 스케줄을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -31,28 +28,28 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     if (!body.accountId || typeof body.accountId !== 'string') {
-      return NextResponse.json({ error: '계좌를 선택해주세요.' }, { status: 400 })
+      return fail('계좌를 선택해주세요.', 400)
     }
     if (!body.vestingDate || typeof body.vestingDate !== 'string') {
-      return NextResponse.json({ error: '베스팅일을 입력해주세요.' }, { status: 400 })
+      return fail('베스팅일을 입력해주세요.', 400)
     }
     if (typeof body.shares !== 'number' || !Number.isInteger(body.shares) || body.shares <= 0) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
     if (typeof body.basisValue !== 'number' || body.basisValue < 0) {
-      return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('기준금액은 0 이상이어야 합니다.', 400)
     }
 
     const shares = body.shares as number
     if (typeof body.sellShares === 'number' && (body.sellShares < 0 || body.sellShares > shares)) {
-      return NextResponse.json({ error: '매도 예정 수량은 0 이상, 총 수량 이하여야 합니다.' }, { status: 400 })
+      return fail('매도 예정 수량은 0 이상, 총 수량 이하여야 합니다.', 400)
     }
     if (typeof body.keepShares === 'number' && (body.keepShares < 0 || body.keepShares > shares)) {
-      return NextResponse.json({ error: '보유 예정 수량은 0 이상, 총 수량 이하여야 합니다.' }, { status: 400 })
+      return fail('보유 예정 수량은 0 이상, 총 수량 이하여야 합니다.', 400)
     }
 
     const schedule = await prisma.rSUSchedule.create({
@@ -70,12 +67,12 @@ export async function POST(request: NextRequest) {
       include: { account: { select: { id: true, name: true } } },
     })
 
-    return NextResponse.json(schedule, { status: 201 })
+    return ok(schedule, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 계좌입니다.' }, { status: 400 })
+      return fail('존재하지 않는 계좌입니다.', 400)
     }
     console.error('POST /api/rsu error:', error)
-    return NextResponse.json({ error: 'RSU 스케줄 생성에 실패했습니다.' }, { status: 500 })
+    return fail('RSU 스케줄 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/[id]/route.ts
+++ b/src/app/api/stock-options/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,7 +14,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const data: Record<string, unknown> = {}
     if (typeof body.ticker === 'string') data.ticker = body.ticker.trim()
@@ -29,7 +30,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     // remainingShares 재계산 (0 포함하므로 !== undefined 체크)
     if (data.totalShares !== undefined || data.cancelledShares !== undefined || data.adjustedShares !== undefined) {
       const existing = await prisma.stockOption.findUnique({ where: { id } })
-      if (!existing) return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 404 })
+      if (!existing) return fail('존재하지 않는 스톡옵션입니다.', 404)
       const total = (data.totalShares as number | undefined) ?? existing.totalShares
       const cancelled = (data.cancelledShares as number | undefined) ?? existing.cancelledShares
       const exercised = existing.exercisedShares
@@ -43,13 +44,13 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       include: { vestings: { orderBy: { vestingDate: 'asc' } }, account: { select: { name: true } } },
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 404 })
+      return fail('존재하지 않는 스톡옵션입니다.', 404)
     }
     console.error('PUT /api/stock-options/[id] error:', error)
-    return NextResponse.json({ error: '스톡옵션 수정에 실패했습니다.' }, { status: 500 })
+    return fail('스톡옵션 수정에 실패했습니다.', 500)
   }
 }
 
@@ -63,12 +64,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       await tx.stockOptionVesting.deleteMany({ where: { stockOptionId: id } })
       await tx.stockOption.delete({ where: { id } })
     })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 404 })
+      return fail('존재하지 않는 스톡옵션입니다.', 404)
     }
     console.error('DELETE /api/stock-options/[id] error:', error)
-    return NextResponse.json({ error: '스톡옵션 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('스톡옵션 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/[id]/vestings/[vid]/route.ts
+++ b/src/app/api/stock-options/[id]/vestings/[vid]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string; vid: string }>
@@ -13,12 +14,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { id, vid } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     // parent 검증
     const existing = await prisma.stockOptionVesting.findUnique({ where: { id: vid } })
     if (!existing || existing.stockOptionId !== id) {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
 
     const data: Record<string, unknown> = {}
@@ -27,13 +28,13 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (body.note !== undefined) data.note = typeof body.note === 'string' ? body.note.trim() || null : null
 
     const updated = await prisma.stockOptionVesting.update({ where: { id: vid }, data })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
     console.error('PUT /api/stock-options/[id]/vestings/[vid] error:', error)
-    return NextResponse.json({ error: '행사 스케줄 수정에 실패했습니다.' }, { status: 500 })
+    return fail('행사 스케줄 수정에 실패했습니다.', 500)
   }
 }
 
@@ -51,23 +52,21 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const { id, vid } = await params
 
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const newStatus = body.status
     if (typeof newStatus !== 'string') {
-      return NextResponse.json({ error: 'status를 지정해주세요.' }, { status: 400 })
+      return fail('status를 지정해주세요.', 400)
     }
 
     const vesting = await prisma.stockOptionVesting.findUnique({ where: { id: vid } })
     if (!vesting || vesting.stockOptionId !== id) {
-      return NextResponse.json({ error: '베스팅을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('베스팅을 찾을 수 없습니다.', 404)
     }
 
     const allowed = ALLOWED_TRANSITIONS[vesting.status]
     if (!allowed || !allowed.includes(newStatus)) {
-      return NextResponse.json({
-        error: `'${vesting.status}' → '${newStatus}' 전환은 허용되지 않습니다.`,
-      }, { status: 400 })
+      return fail(`'${vesting.status}' → '${newStatus}' 전환은 허용되지 않습니다.`, 400)
     }
 
     // pending → exercisable: 베스팅일 도래 검증 (KST 일 단위)
@@ -75,7 +74,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       const kst = new Date(Date.now() + 9 * 60 * 60 * 1000)
       const todayEnd = new Date(Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate() + 1))
       if (vesting.vestingDate >= todayEnd) {
-        return NextResponse.json({ error: '베스팅일이 아직 도래하지 않았습니다.' }, { status: 400 })
+        return fail('베스팅일이 아직 도래하지 않았습니다.', 400)
       }
     }
 
@@ -99,7 +98,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         })
         return tx.stockOptionVesting.findUniqueOrThrow({ where: { id: vid } })
       }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
-      return NextResponse.json(updated)
+      return ok(updated)
     }
 
     // 기타 상태 전환도 조건부 업데이트
@@ -108,19 +107,19 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       data: { status: newStatus },
     })
     if (result.count === 0) {
-      return NextResponse.json({ error: '이미 처리된 요청입니다.' }, { status: 409 })
+      return fail('이미 처리된 요청입니다.', 409)
     }
     const updated = await prisma.stockOptionVesting.findUniqueOrThrow({ where: { id: vid } })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Error && error.message === 'ALREADY_PROCESSED') {
-      return NextResponse.json({ error: '이미 처리된 요청입니다.' }, { status: 409 })
+      return fail('이미 처리된 요청입니다.', 409)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034') {
-      return NextResponse.json({ error: '동시 요청이 감지되었습니다. 다시 시도해주세요.' }, { status: 409 })
+      return fail('동시 요청이 감지되었습니다. 다시 시도해주세요.', 409)
     }
     console.error('PATCH /api/stock-options/[id]/vestings/[vid] error:', error)
-    return NextResponse.json({ error: '상태 변경에 실패했습니다.' }, { status: 500 })
+    return fail('상태 변경에 실패했습니다.', 500)
   }
 }
 
@@ -134,16 +133,16 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
     // parent 검증
     const existing = await prisma.stockOptionVesting.findUnique({ where: { id: vid } })
     if (!existing || existing.stockOptionId !== id) {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
 
     await prisma.stockOptionVesting.delete({ where: { id: vid } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
     console.error('DELETE /api/stock-options/[id]/vestings/[vid] error:', error)
-    return NextResponse.json({ error: '행사 스케줄 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('행사 스케줄 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/[id]/vestings/route.ts
+++ b/src/app/api/stock-options/[id]/vestings/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,13 +14,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: stockOptionId } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     if (!body.vestingDate || typeof body.vestingDate !== 'string') {
-      return NextResponse.json({ error: '행사가능일을 입력해주세요.' }, { status: 400 })
+      return fail('행사가능일을 입력해주세요.', 400)
     }
     if (typeof body.shares !== 'number' || !Number.isInteger(body.shares) || body.shares <= 0) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
 
     const vesting = await prisma.stockOptionVesting.create({
@@ -31,12 +32,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       },
     })
 
-    return NextResponse.json(vesting, { status: 201 })
+    return ok(vesting, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 400 })
+      return fail('존재하지 않는 스톡옵션입니다.', 400)
     }
     console.error('POST /api/stock-options/[id]/vestings error:', error)
-    return NextResponse.json({ error: '행사 스케줄 추가에 실패했습니다.' }, { status: 500 })
+    return fail('행사 스케줄 추가에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/route.ts
+++ b/src/app/api/stock-options/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
     return ok(stockOptions)
   } catch (err) {
     console.error('GET /api/stock-options error:', err)
-    return NextResponse.json({ error: '스톡옵션 조회 실패' }, { status: 500 })
+    return fail('스톡옵션 조회 실패', 500)
   }
 }
 
@@ -42,15 +42,15 @@ export async function GET(request: Request) {
 export async function POST(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
-    if (!body.accountId || typeof body.accountId !== 'string') return NextResponse.json({ error: '계좌를 선택해주세요.' }, { status: 400 })
-    if (!body.ticker || typeof body.ticker !== 'string') return NextResponse.json({ error: '종목 티커를 입력해주세요.' }, { status: 400 })
-    if (!body.displayName || typeof body.displayName !== 'string') return NextResponse.json({ error: '종목명을 입력해주세요.' }, { status: 400 })
-    if (!body.grantDate || typeof body.grantDate !== 'string') return NextResponse.json({ error: '부여일을 입력해주세요.' }, { status: 400 })
-    if (!body.expiryDate || typeof body.expiryDate !== 'string') return NextResponse.json({ error: '만료일을 입력해주세요.' }, { status: 400 })
-    if (typeof body.strikePrice !== 'number' || body.strikePrice < 0) return NextResponse.json({ error: '행사가격은 0 이상이어야 합니다.' }, { status: 400 })
-    if (typeof body.totalShares !== 'number' || !Number.isInteger(body.totalShares) || body.totalShares <= 0) return NextResponse.json({ error: '총부여수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+    if (!body.accountId || typeof body.accountId !== 'string') return fail('계좌를 선택해주세요.', 400)
+    if (!body.ticker || typeof body.ticker !== 'string') return fail('종목 티커를 입력해주세요.', 400)
+    if (!body.displayName || typeof body.displayName !== 'string') return fail('종목명을 입력해주세요.', 400)
+    if (!body.grantDate || typeof body.grantDate !== 'string') return fail('부여일을 입력해주세요.', 400)
+    if (!body.expiryDate || typeof body.expiryDate !== 'string') return fail('만료일을 입력해주세요.', 400)
+    if (typeof body.strikePrice !== 'number' || body.strikePrice < 0) return fail('행사가격은 0 이상이어야 합니다.', 400)
+    if (typeof body.totalShares !== 'number' || !Number.isInteger(body.totalShares) || body.totalShares <= 0) return fail('총부여수량은 1 이상의 정수여야 합니다.', 400)
 
     const option = await prisma.stockOption.create({
       data: {
@@ -67,12 +67,12 @@ export async function POST(request: NextRequest) {
       include: { vestings: true, account: { select: { name: true } } },
     })
 
-    return NextResponse.json(option, { status: 201 })
+    return ok(option, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 계좌입니다.' }, { status: 400 })
+      return fail('존재하지 않는 계좌입니다.', 400)
     }
     console.error('POST /api/stock-options error:', error)
-    return NextResponse.json({ error: '스톡옵션 생성에 실패했습니다.' }, { status: 500 })
+    return fail('스톡옵션 생성에 실패했습니다.', 500)
   }
 }

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -74,7 +74,12 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
         return
       }
 
-      const { schedule: updated } = await res.json()
+      const json = await res.json()
+      const updated = json?.data?.schedule
+      if (!updated) {
+        setError('베스팅 처리 결과를 받지 못했습니다.')
+        return
+      }
 
       setSchedules((prev) =>
         prev.map((s) =>


### PR DESCRIPTION
## 요약

Phase 27 envelope 마이그 4번째 sub-PR — RSU 스케줄 + 스톡옵션 도메인의 mutation 라우트 + 베스팅 처리 (vest/exercise) 경로를 envelope 으로 마이그.

두 도메인의 list GET (`/api/rsu`, `/api/stock-options`) 은 27-B 에서 이미 envelope 적용 완료 — 본 PR 에서는 에러 path 만 추가로 `fail()` 통일.

## 변경 내역

### 라우트 (7 파일)
- `rsu/route.ts` — POST → `ok(_, { status: 201 })` + GET 에러 path 정리
- `rsu/[id]/route.ts` — PUT → `ok()`, DELETE → `noContent()`
- `rsu/[id]/vest/route.ts` — POST → `ok(result)` (Serializable tx 내부 throw → fail() 매핑 보존)
- `stock-options/route.ts` — POST → `ok(_, { status: 201 })` + GET 에러 path
- `stock-options/[id]/route.ts` — PUT → `ok()`, DELETE → `noContent()`
- `stock-options/[id]/vestings/route.ts` — POST → `ok(_, { status: 201 })`
- `stock-options/[id]/vestings/[vid]/route.ts` — PUT/PATCH → `ok()`, DELETE → `noContent()` (상태 전이 status 보존: 400/404/409/500)

### 클라이언트 fetcher unwrap (1 파일)
- `src/components/rsu/RSUDashboard.tsx` — `handleVest` 의 `{ schedule }` 응답 → `json?.data?.schedule` + null guard

### 영향 없음 (error path 만 사용)
- RSUForm/StockOptionForm/RSUDeleteModal/StockOptionDeleteModal/StockOptionDashboard — 모두 `res.ok` 또는 `data?.error` (envelope 와 호환)

## 변환 패턴 (27-C-1/2/3 와 동일)

| 케이스 | before | after |
|---|---|---|
| 성공 | `NextResponse.json(data)` | `ok(data)` |
| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |

## 제외 사항

- 두 도메인 list GET (`/api/rsu`, `/api/stock-options`) — 27-B 에서 이미 envelope
- 다른 도메인 (trade) — 27-C-5

Closes #331

## 체크리스트

- [x] 린트 (`npm run lint`) — 0 warnings/errors
- [x] 타입체크 (`npx tsc --noEmit`) — 0 errors
- [x] 단위 테스트 (`npm run test:run`) — 162/162 passed
- [x] 빌드 (`npm run build`) — Next.js + MCP + Bot 정상
- [x] 코드 리뷰 — pr-review-toolkit:code-reviewer 1회, **P0/P1/P2: 0/0/0**
- [x] Serializable tx 내부 throw → fail() 매핑 검증 (NOT_FOUND/ALREADY_VESTED/INVALID_SELL_SHARES/ALREADY_PROCESSED/P2025/P2034)
- [x] PATCH 상태 전이 HTTP status 보존 (200/400/404/409/500)

## 관련 PR

- #326 (27-C-1: Watchlist + Recurring + Settings + IncomeProfile)
- #328 (27-C-2: Category + Budget + Asset)
- #330 (27-C-3: Dividend + Deposit + Transaction)