### PR TITLE
[Phase 27-C-5] Trade envelope migration (#333)

### DIFF
--- a/docs/specs/333-envelope-c5.md
+++ b/docs/specs/333-envelope-c5.md
@@ -1,0 +1,67 @@
+# [Phase 27-C-5] Trade envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 마지막 — Trade 도메인의 mutation 라우트 (POST/PUT/DELETE) + 일괄 임포트 (POST) 를 envelope 으로 마이그.
+
+거래 mutation 은 Holding 재계산 트랜잭션, USD/KRW 환율 검증, 이동평균법 평균단가 계산 등이 얽혀있어 27-C 의 영향도가 가장 높은 도메인. main list GET (`/api/trades?...`) 은 27-D pagination 정리와 함께 별도.
+
+## 배경
+
+- 27-C-1~4 완료 (Watchlist/Recurring/Settings/IncomeProfile · Category/Budget/Asset · Dividend/Deposit/Transaction · RSU/StockOption)
+- 27-C-5 는 Trade — 거래 생성/수정/삭제 + 임포트 핵심 흐름
+- pagination GET (`/api/trades`) 은 27-D 별도
+
+## 요구사항
+
+- [ ] 3 라우트 파일 마이그
+  - `trades/route.ts` (POST) — GET 은 27-D 분리
+  - `trades/[id]/route.ts` (PUT/DELETE)
+  - `trades/import/route.ts` (POST — 일괄 임포트, `{ result }` 응답)
+- [ ] 클라이언트 fetcher 응답 본문 사용처 unwrap
+  - 거래 생성/수정 폼 — POST/PUT 결과 사용 여부 확인
+  - 임포트 페이지 — `result` 객체 사용 (success/failed 카운트, 에러 목록 등)
+
+## 기술 설계
+
+### 1. 라우트 변환
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `trades/route.ts` | POST | `ok(result, { status: 201 })` |
+| `trades/[id]/route.ts` | PUT, DELETE | `ok(result)`, `noContent()` |
+| `trades/import/route.ts` | POST | `ok(result, { status: 201 })` (기존 `{ result }` → `result` 직접) |
+
+### 2. 클라이언트 fetcher
+
+확인 필요:
+- `src/app/trades/new/` — 거래 생성 폼 (POST)
+- `src/app/trades/` 의 EditModal/DeleteModal — PUT/DELETE
+- `src/app/trades/import/` — bulk 임포트 결과 표시 (`result.success`, `result.failed`, `result.errors` 등)
+
+### 3. 변환 패턴 (이전 sub-phase 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 201 with wrap | `NextResponse.json({ result }, { status: 201 })` | `ok(result, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+### 4. import 응답 wrapper 제거
+
+기존 `{ result }` wrapper 는 envelope `data` 가 그 역할을 대신 — 클라이언트 fetcher 에서 `json.result` 대신 `json.data` 사용.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 거래 생성/수정/삭제 (USD/KRW 양쪽, BUY/SELL)
+  - Holding 재계산 정합성
+  - 일괄 임포트 (성공/실패 케이스)
+
+## 제외 사항
+
+- 메인 list GET (`/api/trades`) — 27-D
+- 다른 도메인 (rsu/stock-option/transaction 등) — 27-C-1~4 완료

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, validateTradedAt, validateFxRateForUSD } from '@/lib/trade-utils'
 import { businessErrorResponse, isSafeBusinessError } from '@/lib/api-errors'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -73,29 +74,29 @@ export async function PUT(request: NextRequest, props: RouteParams) {
   try {
     const trade = await prisma.trade.findUnique({ where: { id: params.id } })
     if (!trade) {
-      return NextResponse.json({ error: '거래를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('거래를 찾을 수 없습니다.', 404)
     }
 
     const body = await request.json()
     const { shares, price, fxRate, note, tradedAt } = body
 
     if (shares !== undefined && (typeof shares !== 'number' || !Number.isFinite(shares) || shares <= 0 || !Number.isInteger(shares))) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
     if (price !== undefined && (typeof price !== 'number' || !Number.isFinite(price) || price <= 0)) {
-      return NextResponse.json({ error: '단가는 0보다 큰 숫자여야 합니다.' }, { status: 400 })
+      return fail('단가는 0보다 큰 숫자여야 합니다.', 400)
     }
     if (fxRate !== undefined && trade.currency === 'USD') {
       const fxError = validateFxRateForUSD(fxRate)
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
     if (tradedAt !== undefined) {
       if (typeof tradedAt !== 'string') {
-        return NextResponse.json({ error: '유효한 거래일을 입력해주세요.' }, { status: 400 })
+        return fail('유효한 거래일을 입력해주세요.', 400)
       }
       const tradedAtError = validateTradedAt(tradedAt)
       if (tradedAtError) {
-        return NextResponse.json({ error: tradedAtError }, { status: 400 })
+        return fail(tradedAtError, 400)
       }
     }
 
@@ -106,7 +107,7 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
     if (trade.currency === 'USD') {
       const fxError = validateFxRateForUSD(updatedFxRate)
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
 
     const updatedTotalKRW = trade.currency === 'USD'
@@ -146,12 +147,12 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       return { trade: updated, holding, holdingBefore }
     }, { isolationLevel: 'Serializable' })
 
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     const businessResponse = businessErrorResponse(error)
     if (businessResponse) return businessResponse
     console.error('PUT /api/trades/[id] error:', error)
-    return NextResponse.json({ error: '거래 수정에 실패했습니다.' }, { status: 500 })
+    return fail('거래 수정에 실패했습니다.', 500)
   }
 }
 
@@ -160,7 +161,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
   try {
     const trade = await prisma.trade.findUnique({ where: { id: params.id } })
     if (!trade) {
-      return NextResponse.json({ error: '거래를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('거래를 찾을 수 없습니다.', 404)
     }
 
     await prisma.$transaction(async (tx) => {
@@ -172,12 +173,12 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
       )
     }, { isolationLevel: 'Serializable' })
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (isSafeBusinessError(error) && error.message.startsWith('보유 수량 부족')) {
-      return NextResponse.json({ error: '이 거래를 삭제하면 보유 수량이 음수가 됩니다.' }, { status: 400 })
+      return fail('이 거래를 삭제하면 보유 수량이 음수가 됩니다.', 400)
     }
     console.error('DELETE /api/trades/[id] error:', error)
-    return NextResponse.json({ error: '거래 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('거래 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/trades/import/route.ts
+++ b/src/app/api/trades/import/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW, validateTradeInput } from '@/lib/trade-utils'
 import { normalizeMarket } from '@/lib/market-hours'
 import { businessErrorResponse } from '@/lib/api-errors'
+import { ok, fail } from '@/lib/api-response'
 import type { ImportResult } from '@/types/csv-import'
 
 export const dynamic = 'force-dynamic'
@@ -15,39 +16,33 @@ export async function POST(request: NextRequest) {
     const { accountId, market, currency, skipDuplicates, trades } = body
 
     if (!accountId || !market || !currency || !Array.isArray(trades)) {
-      return NextResponse.json(
-        { error: '필수 필드가 누락되었습니다.' },
-        { status: 400 }
-      )
+      return fail('필수 필드가 누락되었습니다.', 400)
     }
 
     if (!['US', 'KR'].includes(market)) {
-      return NextResponse.json({ error: '잘못된 시장입니다.' }, { status: 400 })
+      return fail('잘못된 시장입니다.', 400)
     }
     if (!['USD', 'KRW'].includes(currency)) {
-      return NextResponse.json({ error: '잘못된 통화입니다.' }, { status: 400 })
+      return fail('잘못된 통화입니다.', 400)
     }
     if (market === 'US' && currency !== 'USD') {
-      return NextResponse.json({ error: 'US 시장은 USD만 가능합니다.' }, { status: 400 })
+      return fail('US 시장은 USD만 가능합니다.', 400)
     }
     if (market === 'KR' && currency !== 'KRW') {
-      return NextResponse.json({ error: 'KR 시장은 KRW만 가능합니다.' }, { status: 400 })
+      return fail('KR 시장은 KRW만 가능합니다.', 400)
     }
 
     if (trades.length === 0) {
-      return NextResponse.json({ error: '임포트할 거래가 없습니다.' }, { status: 400 })
+      return fail('임포트할 거래가 없습니다.', 400)
     }
     if (trades.length > MAX_ROWS) {
-      return NextResponse.json(
-        { error: `최대 ${MAX_ROWS}건까지 임포트 가능합니다.` },
-        { status: 400 }
-      )
+      return fail(`최대 ${MAX_ROWS}건까지 임포트 가능합니다.`, 400)
     }
 
     // 계좌 존재 확인
     const account = await prisma.account.findUnique({ where: { id: accountId } })
     if (!account) {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
     // 각 행 검증
@@ -123,10 +118,7 @@ export async function POST(request: NextRequest) {
     for (const meta of existingMeta) {
       const normalizedExisting = normalizeMarket(meta.market, meta.ticker)
       if (normalizedExisting !== market || meta.currency !== currency) {
-        return NextResponse.json(
-          { error: `${meta.ticker}은(는) 이미 ${normalizedExisting}/${meta.currency}로 등록되어 있습니다.` },
-          { status: 400 }
-        )
+        return fail(`${meta.ticker}은(는) 이미 ${normalizedExisting}/${meta.currency}로 등록되어 있습니다.`, 400)
       }
     }
     // Holding 테이블도 검증 (Trade 없이 Holding만 있는 시드 데이터 대응)
@@ -137,10 +129,7 @@ export async function POST(request: NextRequest) {
     for (const h of existingHoldings) {
       const normalizedExisting = normalizeMarket(h.market, h.ticker)
       if (normalizedExisting !== market || h.currency !== currency) {
-        return NextResponse.json(
-          { error: `${h.ticker}은(는) 이미 ${normalizedExisting}/${h.currency}로 등록되어 있습니다.` },
-          { status: 400 }
-        )
+        return fail(`${h.ticker}은(는) 이미 ${normalizedExisting}/${h.currency}로 등록되어 있습니다.`, 400)
       }
     }
 
@@ -183,7 +172,7 @@ export async function POST(request: NextRequest) {
         failed: resultErrors.length > 0 ? trades.length - skipped : 0,
         errors: resultErrors,
       }
-      return NextResponse.json({ result }, { status: 201 })
+      return ok(result, { status: 201 })
     }
 
     // Serializable 트랜잭션: 일괄 생성 + Holding 재계산
@@ -302,14 +291,11 @@ export async function POST(request: NextRequest) {
       errors: resultErrors,
     }
 
-    return NextResponse.json({ result }, { status: 201 })
+    return ok(result, { status: 201 })
   } catch (error) {
     const businessResponse = businessErrorResponse(error)
     if (businessResponse) return businessResponse
     console.error('POST /api/trades/import error:', error)
-    return NextResponse.json(
-      { error: '거래 일괄 등록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('거래 일괄 등록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -5,6 +5,7 @@ import { createTrade } from '@/lib/trade-service'
 import { businessErrorResponse } from '@/lib/api-errors'
 import { paginationSchema, dateRangeSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -89,7 +90,7 @@ export async function POST(request: NextRequest) {
       displayName: normalizedDisplayName,
     })
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { accountId, market, type, shares, price, currency, fxRate, note, tradedAt } = body
@@ -99,7 +100,7 @@ export async function POST(request: NextRequest) {
     // 계좌 존재 확인
     const account = await prisma.account.findUnique({ where: { id: accountId } })
     if (!account) {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
     const result = await createTrade({
@@ -116,14 +117,11 @@ export async function POST(request: NextRequest) {
       tradedAt: new Date(tradedAt),
     })
 
-    return NextResponse.json(result, { status: 201 })
+    return ok(result, { status: 201 })
   } catch (error) {
     const businessResponse = businessErrorResponse(error)
     if (businessResponse) return businessResponse
     console.error('POST /api/trades error:', error)
-    return NextResponse.json(
-      { error: '거래 기록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('거래 기록에 실패했습니다.', 500)
   }
 }

--- a/src/components/trade/EditPanel.tsx
+++ b/src/components/trade/EditPanel.tsx
@@ -89,7 +89,8 @@ export default function EditPanel({ trade, onClose }: EditPanelProps) {
         return
       }
 
-      const result = await res.json().catch(() => null)
+      const json = await res.json().catch(() => null)
+      const result = json?.data
       if (result?.holding !== undefined && result?.holdingBefore !== undefined) {
         const diff = formatHoldingEditDiff({
           ticker: trade.ticker,

--- a/src/components/trade/TradeForm.tsx
+++ b/src/components/trade/TradeForm.tsx
@@ -163,7 +163,8 @@ export default function TradeForm({ accounts }: TradeFormProps) {
         return
       }
 
-      const result = await res.json().catch(() => null)
+      const json = await res.json().catch(() => null)
+      const result = json?.data
       if (result?.holding !== undefined && result?.holdingBefore !== undefined) {
         const diff = formatHoldingDiff({
           ticker,

--- a/src/components/trade/import/StepValidation.tsx
+++ b/src/components/trade/import/StepValidation.tsx
@@ -84,11 +84,11 @@ export default function StepValidation({
 
       const data = await res.json()
       if (!res.ok) {
-        setSubmitError(data.error ?? '임포트에 실패했습니다.')
+        setSubmitError(data?.error ?? '임포트에 실패했습니다.')
         return
       }
 
-      onNext(data.result as ImportResult)
+      onNext(data?.data as ImportResult)
     } catch {
       setSubmitError('네트워크 오류가 발생했습니다.')
     } finally {

--- a/src/components/trade/import/StepValidation.tsx
+++ b/src/components/trade/import/StepValidation.tsx
@@ -88,7 +88,12 @@ export default function StepValidation({
         return
       }
 
-      onNext(data?.data as ImportResult)
+      const result = data?.data as ImportResult | undefined
+      if (!result) {
+        setSubmitError('임포트 결과를 받지 못했습니다.')
+        return
+      }
+      onNext(result)
     } catch {
       setSubmitError('네트워크 오류가 발생했습니다.')
     } finally {

--- a/src/lib/__tests__/api-errors.test.ts
+++ b/src/lib/__tests__/api-errors.test.ts
@@ -43,12 +43,12 @@ describe('isSafeBusinessError', () => {
 })
 
 describe('businessErrorResponse', () => {
-  it('화이트리스트 매칭 시 400 + 메시지 응답', async () => {
+  it('화이트리스트 매칭 시 400 + envelope 응답', async () => {
     const res = businessErrorResponse(new Error('보유 수량 부족: 5주'))
     expect(res).not.toBeNull()
     expect(res?.status).toBe(400)
     const body = await res?.json()
-    expect(body).toEqual({ error: '보유 수량 부족: 5주' })
+    expect(body).toEqual({ success: false, error: '보유 수량 부족: 5주' })
   })
 
   it('화이트리스트 외부는 null 반환', () => {

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { fail } from './api-response'
 
 // 사용자에게 노출해도 안전한 비즈니스 예외 메시지를 식별하는 화이트리스트.
 // 새 메시지를 추가할 때는 우연 매칭을 피하기 위해 메시지 형식을 명시적으로 잠근다.
@@ -14,5 +15,5 @@ export function isSafeBusinessError(err: unknown): err is Error {
 
 export function businessErrorResponse(err: unknown): NextResponse | null {
   if (!isSafeBusinessError(err)) return null
-  return NextResponse.json({ error: err.message }, { status: 400 })
+  return fail(err.message, 400)
 }


### PR DESCRIPTION
## 요약

Phase 27 envelope 마이그의 **마지막 sub-PR** — Trade 도메인 mutation 라우트 + bulk 임포트를 envelope 으로 마이그. 27-C 시리즈 완료.

거래 mutation 은 Holding 재계산 트랜잭션, USD/KRW 환율 검증, 이동평균법 평균단가 계산이 얽혀있어 27-C 도메인 중 영향도 최대. main list GET (`/api/trades`) 은 27-D pagination 정리와 함께 별도.

## 변경 내역

### 라우트 (3 파일)
- `trades/route.ts` — POST → `ok(result, { status: 201 })`
- `trades/[id]/route.ts` — PUT → `ok(result)`, DELETE → `noContent()` (Serializable tx + Holding 재계산 + `isSafeBusinessError` 분기 유지)
- `trades/import/route.ts` — POST → `ok(result, { status: 201 })` (기존 `{ result }` wrapper 제거, envelope `data` 가 그 역할 대체)

### 공통 헬퍼 (envelope 통일)
- `src/lib/api-errors.ts` — `businessErrorResponse()` 가 `fail()` 헬퍼로 위임 → 화이트리스트 비즈니스 에러도 envelope 응답
- `src/lib/__tests__/api-errors.test.ts` — envelope shape 으로 expected body 갱신

### 클라이언트 fetcher unwrap (3 파일)
- `src/components/trade/TradeForm.tsx` — POST 응답의 `holding`/`holdingBefore` → `json?.data` 로 접근
- `src/components/trade/EditPanel.tsx` — PUT 응답 동일 패턴
- `src/components/trade/import/StepValidation.tsx` — `data.result` → `data?.data as ImportResult` + null guard

### 영향 없음 (error path 만 사용)
- `DeleteModal` — `data?.error` (envelope 와 호환)

## 변환 패턴 (27-C-1~4 와 동일)

| 케이스 | before | after |
|---|---|---|
| 성공 | `NextResponse.json(data)` | `ok(data)` |
| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
| 201 with wrap | `NextResponse.json({ result }, { status: 201 })` | `ok(result, { status: 201 })` |
| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
| 헬퍼 비즈니스 에러 | `NextResponse.json({ error: msg }, { status: 400 })` | `fail(msg, 400)` |

## 제외 사항

- 메인 list GET (`/api/trades`) — 27-D
- 다른 도메인 — 27-C-1~4 모두 완료

Closes #333

## 체크리스트

- [x] 린트 (`npm run lint`) — 0 warnings/errors
- [x] 타입체크 (`npx tsc --noEmit`) — 0 errors
- [x] 단위 테스트 (`npm run test:run`) — 162/162 passed (api-errors envelope shape 갱신 포함)
- [x] 빌드 (`npm run build`) — Next.js + MCP + Bot 정상
- [x] 코드 리뷰 — pr-review-toolkit:code-reviewer 1회, **P0/P1/P2: 0/0/0** + minor null-safety FYI 반영
- [x] businessErrorResponse 헬퍼 위임이 3 callers 모두 동작 확인
- [x] Serializable tx 내부 비즈니스 throw → businessErrorResponse → fail 매핑 검증

## 27-C 시리즈 마무리

5 sub-PR 모두 완료:
- #326 (27-C-1: Watchlist + Recurring + Settings + IncomeProfile)
- #328 (27-C-2: Category + Budget + Asset)
- #330 (27-C-3: Dividend + Deposit + Transaction)
- #332 (27-C-4: RSU + StockOption)
- 본 PR (27-C-5: Trade)

다음: **27-D** — pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/* 8 라우트).