### PR TITLE
[Phase 27-D] Pagination + 복잡한 GET envelope 마이그 (#335)

### DIFF
--- a/docs/specs/335-envelope-d.md
+++ b/docs/specs/335-envelope-d.md
@@ -1,0 +1,96 @@
+# [Phase 27-D] Pagination + 복잡한 GET envelope 마이그
+
+## 목적
+
+27 envelope 시리즈의 GET 라우트 마무리 — pagination 메타데이터를 envelope `meta` 로 통일하고, 복잡한 집계 GET (transactions) 및 파일 export GET 의 에러 path 까지 envelope 으로 통일.
+
+## 배경
+
+- 27-A (헬퍼), 27-B (단순 GET), 27-C-1~5 (mutation) 완료
+- 27-D 는 남은 list GET + exports/* 에러 path 정리. 본 PR 종료 시 27 시리즈의 GET 영역 마무리.
+- 27-E (가이드 문서) 만 남음
+
+## 요구사항
+
+- [ ] 4 list GET → `paginated()` / `ok({data,...}, {meta})`
+  - `trades/route.ts` GET — `{ trades, total, limit, offset }` → `paginated(trades, total, limit, offset)`
+  - `dividends/route.ts` GET — 동일 패턴
+  - `deposits/route.ts` GET — 동일 패턴
+  - `transactions/route.ts` GET — **복잡**: `{ transactions, summary, byMonth, byCategory, year, total, offset, limit }` → `ok({ transactions, summary, byMonth, byCategory, year }, { meta: { total, limit, offset } })`
+- [ ] 4 exports GET 에러 path → `fail()`
+  - `exports/trades/route.ts`
+  - `exports/deposits/route.ts`
+  - `exports/dividends/route.ts`
+  - `exports/vesting.ics/route.ts`
+- [ ] 클라이언트 unwrap
+  - `ExpensesClient.tsx` — transactions GET 응답 reshape
+
+## 기술 설계
+
+### 1. paginated() 적용 (단순 3개)
+
+```ts
+// before
+return NextResponse.json({ trades, total, limit, offset })
+
+// after
+return paginated(trades, total, limit, offset)
+// → { success: true, data: trades, meta: { total, limit, offset } }
+```
+
+→ 서버 컴포넌트만 prisma 직접 사용 (`src/app/trades/page.tsx` 등) — 클라이언트 fetcher 영향 없음.
+
+### 2. transactions GET (복잡)
+
+기존 응답 (listOnly 모드 vs 전체 모드 분기):
+```ts
+// listOnly 모드
+{ transactions, total, offset, limit, year }
+// 전체 모드
+{ transactions, total, offset, limit, summary, byMonth, byCategory, year }
+```
+
+envelope 변환:
+```ts
+return ok(
+  { transactions: serialized, year, ...(listOnly ? {} : { summary, byMonth, byCategory }) },
+  { meta: { total, limit, offset } },
+)
+```
+
+→ ExpensesClient.tsx 의 3 fetcher 모두 `json.transactions` → `json.data.transactions`, `json.total` → `json.meta.total`, `json.limit` → `json.meta.limit` 등으로 reshape.
+
+### 3. exports/* 에러 path
+
+성공 path 는 CSV/ICS 파일 응답 (`csvResponse` 등) — envelope 미적용.
+에러 path 만 `fail()` 로 통일:
+
+```ts
+// before
+return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+
+// after
+return fail(errs[0].message, 400)
+```
+
+### 4. 변환 패턴
+
+| 케이스 | before | after |
+|---|---|---|
+| paginated GET | `NextResponse.json({ [key], total, limit, offset })` | `paginated(arr, total, limit, offset)` |
+| 복잡 paginated | `NextResponse.json({ ..., total, limit, offset })` | `ok({...rest}, { meta: { total, limit, offset } })` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 거래/배당/입금 페이지 (서버 컴포넌트 — 영향 없음 예상)
+  - 가계부 페이지 (`/expenses`) 필터/페이지 이동/요약 카드 정상 동작
+  - CSV 내보내기 정상 다운로드, 잘못된 year 입력 시 에러 메시지
+
+## 제외 사항
+
+- 27-E (가이드 문서 갱신) — 별도 PR
+- mutation 라우트 (27-C-1~5 완료)
+- 파일 응답 자체 (CSV/ICS body) — Content-Disposition 기반, envelope 미적용

--- a/src/app/api/deposits/route.ts
+++ b/src/app/api/deposits/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateDepositInput } from '@/lib/deposit-utils'
 import { isGiftSource } from '@/lib/tax/gift-tax'
 import { checkGiftTaxLimit } from '@/bot/notifications/budget-alert'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
-import { ok, fail } from '@/lib/api-response'
+import { ok, fail, paginated } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,14 +19,14 @@ export async function GET(request: NextRequest) {
     })
     if (!paginationResult.success) {
       const errs = zodErrorsToValidation(paginationResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { limit, offset } = paginationResult.data
 
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -57,13 +57,10 @@ export async function GET(request: NextRequest) {
       prisma.deposit.count({ where }),
     ])
 
-    return NextResponse.json({ deposits, total, limit, offset })
+    return paginated(deposits, total, limit, offset)
   } catch (error) {
     console.error('GET /api/deposits error:', error)
-    return NextResponse.json(
-      { error: '입금 내역을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('입금 내역을 불러올 수 없습니다.', 500)
   }
 }
 

--- a/src/app/api/dividends/route.ts
+++ b/src/app/api/dividends/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateDividendInput, calcAmountKRW } from '@/lib/dividend-utils'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
-import { ok, fail } from '@/lib/api-response'
+import { ok, fail, paginated } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,14 +17,14 @@ export async function GET(request: NextRequest) {
     })
     if (!paginationResult.success) {
       const errs = zodErrorsToValidation(paginationResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { limit, offset } = paginationResult.data
 
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -52,13 +52,10 @@ export async function GET(request: NextRequest) {
       prisma.dividend.count({ where }),
     ])
 
-    return NextResponse.json({ dividends, total, limit, offset })
+    return paginated(dividends, total, limit, offset)
   } catch (error) {
     console.error('GET /api/dividends error:', error)
-    return NextResponse.json(
-      { error: '배당 내역을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('배당 내역을 불러올 수 없습니다.', 500)
   }
 }
 

--- a/src/app/api/exports/deposits/route.ts
+++ b/src/app/api/exports/deposits/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toCSV, csvResponse } from '@/lib/csv'
 import { formatDate } from '@/lib/format'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -57,9 +58,6 @@ export async function GET(request: NextRequest) {
     return csvResponse(csv, `deposits${suffix}_${yearSuffix}.csv`)
   } catch (error) {
     console.error('GET /api/exports/deposits error:', error)
-    return new Response(JSON.stringify({ error: 'CSV 생성에 실패했습니다.' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return fail('CSV 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/exports/dividends/route.ts
+++ b/src/app/api/exports/dividends/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toCSV, csvResponse } from '@/lib/csv'
 import { formatDate } from '@/lib/format'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -60,9 +61,6 @@ export async function GET(request: NextRequest) {
     return csvResponse(csv, `dividends${suffix}_${yearSuffix}.csv`)
   } catch (error) {
     console.error('GET /api/exports/dividends error:', error)
-    return new Response(JSON.stringify({ error: 'CSV 생성에 실패했습니다.' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return fail('CSV 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/exports/trades/route.ts
+++ b/src/app/api/exports/trades/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toCSV, csvResponse } from '@/lib/csv'
 import { formatDate } from '@/lib/format'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -63,9 +64,6 @@ export async function GET(request: NextRequest) {
     return csvResponse(csv, `trades${suffix}_${yearSuffix}.csv`)
   } catch (error) {
     console.error('GET /api/exports/trades error:', error)
-    return new Response(JSON.stringify({ error: 'CSV 생성에 실패했습니다.' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return fail('CSV 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/exports/vesting.ics/route.ts
+++ b/src/app/api/exports/vesting.ics/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toVestingEvents, toKSTDateString } from '@/lib/vesting-events'
 import { buildICS, type ICSEvent } from '@/lib/ics'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,6 +69,6 @@ export async function GET() {
     })
   } catch (error) {
     console.error('GET /api/exports/vesting.ics error:', error)
-    return NextResponse.json({ error: '캘린더 내보내기에 실패했습니다.' }, { status: 500 })
+    return fail('캘린더 내보내기에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateTradeInput } from '@/lib/trade-utils'
 import { createTrade } from '@/lib/trade-service'
 import { businessErrorResponse } from '@/lib/api-errors'
 import { paginationSchema, dateRangeSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
-import { ok, fail } from '@/lib/api-response'
+import { ok, fail, paginated } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     })
     if (!paginationResult.success) {
       const errs = zodErrorsToValidation(paginationResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { limit, offset } = paginationResult.data
 
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     })
     if (!dateResult.success) {
       const errs = zodErrorsToValidation(dateResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { from, to } = dateResult.data
 
@@ -64,13 +64,10 @@ export async function GET(request: NextRequest) {
       prisma.trade.count({ where }),
     ])
 
-    return NextResponse.json({ trades, total, limit, offset })
+    return paginated(trades, total, limit, offset)
   } catch (error) {
     console.error('GET /api/trades error:', error)
-    return NextResponse.json(
-      { error: '거래 내역을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('거래 내역을 불러올 수 없습니다.', 500)
   }
 }
 

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateTransactionInput } from '@/lib/transaction-utils'
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     const sp = request.nextUrl.searchParams
     const rawType = sp.get('type')
     if (rawType && rawType !== 'expense' && rawType !== 'income') {
-      return NextResponse.json({ error: 'type은 expense 또는 income만 허용됩니다.' }, { status: 400 })
+      return fail('type은 expense 또는 income만 허용됩니다.', 400)
     }
     const type = rawType ?? undefined
     const yearStr = sp.get('year')
@@ -107,13 +107,10 @@ export async function GET(request: NextRequest) {
 
     // listOnly 모드: 페이지 이동 시 집계 스킵
     if (listOnly) {
-      return NextResponse.json({
-        transactions: serialized,
-        total,
-        offset,
-        limit,
-        year,
-      })
+      return ok(
+        { transactions: serialized, year },
+        { meta: { total, limit, offset } },
+      )
     }
 
     // 집계 조회 (필터 변경 시에만)
@@ -184,25 +181,25 @@ export async function GET(request: NextRequest) {
       .filter((r): r is NonNullable<typeof r> => r !== null)
       .sort((a, b) => b.total - a.total)
 
-    return NextResponse.json({
-      transactions: serialized,
-      total,
-      offset,
-      limit,
-      summary: {
-        totalExpense,
-        totalIncome,
-        net: totalIncome - totalExpense,
-        count: filteredCount,
-        currency: 'KRW',
+    return ok(
+      {
+        transactions: serialized,
+        summary: {
+          totalExpense,
+          totalIncome,
+          net: totalIncome - totalExpense,
+          count: filteredCount,
+          currency: 'KRW',
+        },
+        byMonth,
+        byCategory,
+        year,
       },
-      byMonth,
-      byCategory,
-      year,
-    })
+      { meta: { total, limit, offset } },
+    )
   } catch (error) {
     console.error('[api/transactions] GET 실패:', error)
-    return NextResponse.json({ error: '거래 내역 조회에 실패했습니다.' }, { status: 500 })
+    return fail('거래 내역 조회에 실패했습니다.', 500)
   }
 }
 

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -65,20 +65,22 @@ interface TransactionsEnvelope {
 
 /**
  * 27-D envelope 응답을 컴포넌트가 사용하는 flat shape 로 변환.
- * listOnly 모드 응답은 summary/byMonth/byCategory 가 없으니 prev 값을 유지하기 위해
- * 호출처에서 mergePrev 로 보완한다.
+ *
+ * 전체 모드 (listOnly 미지정) 응답 전용 — summary/byMonth/byCategory 가 반드시 포함된다.
+ * listOnly 응답은 setData prev merge 패턴으로 별도 처리 (handlePageChange).
  */
-function envelopeToFlat(env: TransactionsEnvelope): ApiResponse | null {
+function fullEnvelopeToFlat(env: TransactionsEnvelope): ApiResponse | null {
   if (!env?.data || !env?.meta) return null
   const d = env.data
+  if (!d.summary || !d.byMonth || !d.byCategory) return null
   return {
     transactions: d.transactions,
     total: env.meta.total,
     limit: env.meta.limit,
     offset: env.meta.offset,
-    summary: d.summary ?? { totalExpense: 0, totalIncome: 0, net: 0, count: 0 },
-    byMonth: d.byMonth ?? [],
-    byCategory: d.byCategory ?? [],
+    summary: d.summary,
+    byMonth: d.byMonth,
+    byCategory: d.byCategory,
     year: d.year,
   }
 }
@@ -158,7 +160,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       const res = await fetch(`/api/transactions?${params}`, { signal: controller.signal })
       if (res.ok) {
         const env: TransactionsEnvelope = await res.json()
-        const flat = envelopeToFlat(env)
+        const flat = fullEnvelopeToFlat(env)
         if (flat) {
           // 삭제 후 offset >= total이면 마지막 유효 페이지로 보정
           if (requestOffset > 0 && flat.transactions.length === 0 && flat.total > 0) {
@@ -170,7 +172,7 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
             if (t !== 'all') retryParams.set('type', t)
             const retryRes = await fetch(`/api/transactions?${retryParams}`, { signal: controller.signal })
             if (retryRes.ok) {
-              const retryFlat = envelopeToFlat(await retryRes.json())
+              const retryFlat = fullEnvelopeToFlat(await retryRes.json())
               if (retryFlat) setData(retryFlat)
             }
           } else {

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -51,6 +51,38 @@ interface ApiResponse {
   year: number
 }
 
+interface TransactionsEnvelope {
+  success: boolean
+  data?: {
+    transactions: TransactionRow[]
+    summary?: ApiResponse['summary']
+    byMonth?: MonthlyData[]
+    byCategory?: CategoryData[]
+    year: number
+  }
+  meta?: { total: number; limit: number; offset: number }
+}
+
+/**
+ * 27-D envelope 응답을 컴포넌트가 사용하는 flat shape 로 변환.
+ * listOnly 모드 응답은 summary/byMonth/byCategory 가 없으니 prev 값을 유지하기 위해
+ * 호출처에서 mergePrev 로 보완한다.
+ */
+function envelopeToFlat(env: TransactionsEnvelope): ApiResponse | null {
+  if (!env?.data || !env?.meta) return null
+  const d = env.data
+  return {
+    transactions: d.transactions,
+    total: env.meta.total,
+    limit: env.meta.limit,
+    offset: env.meta.offset,
+    summary: d.summary ?? { totalExpense: 0, totalIncome: 0, net: 0, count: 0 },
+    byMonth: d.byMonth ?? [],
+    byCategory: d.byCategory ?? [],
+    year: d.year,
+  }
+}
+
 interface ExpensesClientProps {
   initialData: ApiResponse
 }
@@ -125,22 +157,26 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
 
       const res = await fetch(`/api/transactions?${params}`, { signal: controller.signal })
       if (res.ok) {
-        const json: ApiResponse = await res.json()
-        // 삭제 후 offset >= total이면 마지막 유효 페이지로 보정
-        if (requestOffset > 0 && json.transactions.length === 0 && json.total > 0) {
-          const corrected = Math.max(0, Math.floor((json.total - 1) / json.limit) * json.limit)
-          setOffset(corrected)
-          // 보정된 offset으로 재조회
-          const retryParams = new URLSearchParams({ year: String(y), offset: String(corrected) })
-          if (m) retryParams.set('month', String(m))
-          if (t !== 'all') retryParams.set('type', t)
-          const retryRes = await fetch(`/api/transactions?${retryParams}`, { signal: controller.signal })
-          if (retryRes.ok) {
-            setData(await retryRes.json())
+        const env: TransactionsEnvelope = await res.json()
+        const flat = envelopeToFlat(env)
+        if (flat) {
+          // 삭제 후 offset >= total이면 마지막 유효 페이지로 보정
+          if (requestOffset > 0 && flat.transactions.length === 0 && flat.total > 0) {
+            const corrected = Math.max(0, Math.floor((flat.total - 1) / flat.limit) * flat.limit)
+            setOffset(corrected)
+            // 보정된 offset으로 재조회
+            const retryParams = new URLSearchParams({ year: String(y), offset: String(corrected) })
+            if (m) retryParams.set('month', String(m))
+            if (t !== 'all') retryParams.set('type', t)
+            const retryRes = await fetch(`/api/transactions?${retryParams}`, { signal: controller.signal })
+            if (retryRes.ok) {
+              const retryFlat = envelopeToFlat(await retryRes.json())
+              if (retryFlat) setData(retryFlat)
+            }
+          } else {
+            setData(flat)
+            setOffset(requestOffset)
           }
-        } else {
-          setData(json)
-          setOffset(requestOffset)
         }
       }
       // 월 선택 시 분석 데이터도 조회 (소비 탭 또는 전체 탭에서만)
@@ -199,12 +235,16 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
 
       const res = await fetch(`/api/transactions?${params}`, { signal: controller.signal })
       if (res.ok) {
-        const json = await res.json()
-        setData((prev) => ({
-          ...prev,
-          transactions: json.transactions,
-          total: json.total,
-        }))
+        const env: TransactionsEnvelope = await res.json()
+        if (env?.data && env?.meta) {
+          setData((prev) => ({
+            ...prev,
+            transactions: env.data!.transactions,
+            total: env.meta!.total,
+          }))
+        } else {
+          setOffset(prevOffset)
+        }
       } else {
         setOffset(prevOffset)
       }

--- a/src/components/trade/import/ImportWizard.tsx
+++ b/src/components/trade/import/ImportWizard.tsx
@@ -60,9 +60,10 @@ export default function ImportWizard({ accounts }: ImportWizardProps) {
             `/api/trades?accountId=${accountId}&limit=${limit}&offset=${offset}`,
             { signal: controller.signal }
           )
-          const data = await res.json()
-          if (data.trades && data.trades.length > 0) {
-            for (const t of data.trades as Array<{ ticker: string; type: string; tradedAt: string; shares: number; price: number }>) {
+          const json = await res.json()
+          const trades = Array.isArray(json?.data) ? json.data : []
+          if (trades.length > 0) {
+            for (const t of trades as Array<{ ticker: string; type: string; tradedAt: string; shares: number; price: number }>) {
               allTrades.push({
                 ticker: t.ticker,
                 type: t.type,
@@ -72,7 +73,7 @@ export default function ImportWizard({ accounts }: ImportWizardProps) {
               })
             }
             offset += limit
-            hasMore = data.trades.length === limit
+            hasMore = trades.length === limit
           } else {
             hasMore = false
           }


### PR DESCRIPTION
## 요약

Phase 27 envelope 시리즈의 GET 라우트 마무리 — pagination 메타데이터를 envelope `meta` 로 통일하고, 복잡한 집계 GET (transactions) 및 파일 export GET 의 에러 path 까지 envelope 으로 통일.

본 PR 종료 시 27 시리즈의 **GET/POST/PUT/DELETE 모든 영역의 envelope 마이그가 완료**됨. 27-E (가이드 문서) 만 남음.

## 변경 내역

### list GET 4개 (paginated / ok+meta)
- `trades/route.ts` GET → `paginated(trades, total, limit, offset)`
- `dividends/route.ts` GET → `paginated(...)`
- `deposits/route.ts` GET → `paginated(...)`
- `transactions/route.ts` GET → `ok({ transactions, summary, byMonth, byCategory, year }, { meta: { total, limit, offset } })` (listOnly 분기는 `data` 에 transactions/year 만 + `meta`)

### exports/* 에러 path 4개
- `exports/trades/route.ts`, `exports/deposits/route.ts`, `exports/dividends/route.ts`, `exports/vesting.ics/route.ts`
- 성공 path 는 CSV/ICS 파일 응답 그대로 (envelope 미적용)

### 클라이언트 unwrap
- `ExpensesClient.tsx` — `TransactionsEnvelope` 타입 + `fullEnvelopeToFlat()` 헬퍼 + 3 fetcher (전체/재조회/listOnly) unwrap
- `ImportWizard.tsx` — `/api/trades` paginated GET 소비 → `json?.data` 배열 unwrap (1차 리뷰 P2 반영)

### SSR initialData 영향 없음
- `src/app/expenses/page.tsx` 는 prisma 직접 사용 (API 우회) — envelope 영향 없음
- `src/app/trades/page.tsx`, `dividends/page.tsx`, `deposits/page.tsx` 모두 동일 — 서버 컴포넌트

## 변환 패턴

| 케이스 | before | after |
|---|---|---|
| paginated GET | `NextResponse.json({ [key], total, limit, offset })` | `paginated(arr, total, limit, offset)` |
| 복잡 paginated | `NextResponse.json({ ..., total, limit, offset })` | `ok({...rest}, { meta: { total, limit, offset } })` |
| 에러 (exports raw) | `new Response(JSON.stringify({ error }), ...)` | `fail(error, status)` |

Closes #335

## 체크리스트

- [x] 린트 (`npm run lint`) — 0 warnings/errors
- [x] 타입체크 (`npx tsc --noEmit`) — 0 errors
- [x] 단위 테스트 (`npm run test:run`) — 162/162 passed
- [x] 빌드 (`npm run build`) — Next.js + MCP + Bot 정상
- [x] 코드 리뷰 — pr-review-toolkit:code-reviewer 1차 (P2: ImportWizard envelope 미대응, P1: fullEnvelopeToFlat 일관성) → 수정 후 재리뷰 통과 **P0/P1/P2: 0/0/0**
- [x] paginated() 헬퍼가 모든 list GET 에서 일관 적용
- [x] exports raw Response (500 에러) → fail() 정리
- [x] ExpensesClient 3 fetcher (full/retry/listOnly) 모두 envelope 처리
- [x] ImportWizard paginated GET unwrap 검증 (거래 import 중복 검출 회귀 차단)

## 27 시리즈 진행 현황

- [x] 27-A: ApiResponse 헬퍼 + 단위 테스트
- [x] 27-B: 단순 GET 라우트 마이그
- [x] 27-C-1~5: POST/PUT/DELETE 마이그 (5 sub-PR)
- [x] 본 PR (27-D): pagination + 복잡한 GET + exports
- [ ] 27-E: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`) — 다음 PR