### PR TITLE
[Phase 27-E] envelope 가이드 문서 갱신 (#337)

### DIFF
--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -2,10 +2,114 @@
 
 이 규칙은 src/app/api/**/*.ts 파일에 적용.
 
-- 모든 route handler는 try-catch로 감싸고, 에러 시 `{ error: string }` 형태로 응답
-- DB 접근은 반드시 `@/lib/prisma`의 singleton client 사용
-- Trade 생성 시 Holding 업데이트를 Prisma transaction으로 묶을 것
+## 기본 규칙
+
+- 모든 route handler 는 try-catch 로 감싸고, 에러 응답은 아래 envelope 헬퍼 (`fail`) 사용
+- DB 접근은 반드시 `@/lib/prisma` 의 singleton client 사용
+- Trade 생성 시 Holding 업데이트를 Prisma transaction 으로 묶을 것
 - 금액 관련 응답은 항상 currency 필드 포함
 - 날짜는 ISO 8601 형식으로 반환
-- DELETE 핸들러는 본문 없이 `new NextResponse(null, { status: 204 })` 로 응답. `{ success: true }` 등 wrapper 금지
 - catch 블록에서 `error.message` 를 그대로 노출하지 않는다. 사용자에게 보여도 안전한 비즈니스 예외는 `@/lib/api-errors` 의 `businessErrorResponse(err)` 로 통과시키고, 그 외는 한국어 정적 메시지(`'서버 오류가 발생했습니다.'` 등)로 응답
+
+## 응답 envelope (`ApiResponse<T>`)
+
+모든 API 응답은 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27).
+
+### 응답 구조
+
+```ts
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: { total: number; limit: number; offset: number }  // pagination 한정
+}
+```
+
+### 헬퍼 사용
+
+| 케이스 | 헬퍼 | 예시 |
+|---|---|---|
+| 성공 (200) | `ok(data)` | `return ok(user)` |
+| 생성 (201) | `ok(data, { status: 201 })` | `return ok(created, { status: 201 })` |
+| 본문 없음 (204/205/304) | `noContent()` | `return noContent()` |
+| 페이지네이션 | `paginated(arr, total, limit, offset)` | `return paginated(trades, total, limit, offset)` |
+| 복합 데이터 + meta | `ok({...}, { meta: { total, limit, offset } })` | transactions GET 같이 집계 필드 + pagination |
+| 에러 | `fail(error, status)` | `return fail('찾을 수 없습니다.', 404)` |
+
+### 패턴 예시
+
+```ts
+import { ok, fail, noContent, paginated } from '@/lib/api-response'
+
+// 단순 조회
+return ok(account)
+
+// 생성
+return ok(created, { status: 201 })
+
+// 페이지네이션
+return paginated(trades, total, limit, offset)
+// → { success: true, data: [...], meta: { total, limit, offset } }
+
+// 집계 + 페이지네이션
+return ok(
+  { transactions, summary, byMonth, byCategory },
+  { meta: { total, limit, offset } },
+)
+
+// 삭제 / 빈 ack
+return noContent()
+// → 204 No Content (body 없음)
+
+// 에러
+return fail('계좌를 찾을 수 없습니다.', 404)
+```
+
+### 비즈니스 예외
+
+화이트리스트 비즈니스 에러는 `businessErrorResponse()` 가 `fail()` 헬퍼로 위임한다:
+
+```ts
+import { businessErrorResponse } from '@/lib/api-errors'
+
+try {
+  // createTrade 등 비즈니스 로직 — "보유 수량 부족" 등 throw
+} catch (error) {
+  const businessResponse = businessErrorResponse(error)
+  if (businessResponse) return businessResponse
+  console.error('POST /api/trades error:', error)
+  return fail('거래 기록에 실패했습니다.', 500)
+}
+```
+
+화이트리스트는 `src/lib/api-errors.ts` 의 `SAFE_BUSINESS_PATTERNS` 에서 관리. 새 비즈니스 예외 메시지를 추가할 때는 우연 매칭을 피하기 위해 패턴을 명시적으로 잠근다.
+
+### 클라이언트 사용
+
+클라이언트 fetcher 는 envelope 의 `data` / `meta` / `error` 를 unwrap 한다:
+
+```ts
+const res = await fetch('/api/foo')
+const json = await res.json()
+if (!res.ok) {
+  setError(json?.error ?? '요청 실패')
+  return
+}
+const items = json?.data ?? []
+const total = json?.meta?.total ?? 0
+```
+
+### 예외 — 파일 응답
+
+CSV / ICS 등 다운로드 응답은 raw Response (`csvResponse()`, `new Response(ics, {...})`) 를 그대로 사용한다 — Content-Disposition 헤더 필요.
+**에러 path 만** envelope (`fail()`) 적용한다 (`src/app/api/exports/*` 참고).
+
+## 신규 라우트 작성 체크리스트
+
+- [ ] `@/lib/api-response` 에서 `ok` / `fail` / `noContent` / `paginated` 사용
+- [ ] try-catch 로 감싸고 catch 블록은 한국어 정적 메시지
+- [ ] 비즈니스 예외가 있다면 `businessErrorResponse()` 통과
+- [ ] DB 접근은 `@/lib/prisma` singleton + transaction 필요 시 묶기
+- [ ] 금액은 currency 필드, 날짜는 ISO 8601
+- [ ] DELETE / 빈 응답은 `noContent()` (204), `{ success: true }` wrapper 금지

--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -13,7 +13,21 @@
 
 ## 응답 envelope (`ApiResponse<T>`)
 
-모든 API 응답은 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27).
+**신규 라우트** 와 **마이그 완료 라우트** (아래 "적용 범위" 참고) 는 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27).
+
+### 적용 범위
+
+| 상태 | 도메인 |
+|---|---|
+| ✅ 마이그 완료 (27-A~D) | trades, dividends, deposits, transactions, rsu, stock-options, watchlist, recurring, settings, income-profiles, categories, budgets, assets, exports/* (에러 path), 그 외 27-B 단순 GET |
+| ⏳ 마이그 예정 (28차 마일스톤 후보) | accounts, networth, performance/*, prices/*, reports, tax/gift, backtest, ai/ask |
+
+**중요**: 미마이그 라우트의 응답을 envelope 으로 바꾸려면 **반드시 클라이언트 fetcher 도 함께 업데이트** 한다 (envelope 일방 변경은 화면 깨짐을 유발). 신규 라우트는 처음부터 envelope 사용.
+
+### 예외 (envelope 미적용)
+
+- **파일 응답**: CSV (`csvResponse()`), ICS (`new Response(ics, ...)`), PDF 등 — Content-Disposition 헤더 필요. **에러 path 만** envelope 적용 (`exports/*` 참고).
+- **스트리밍 / SSE**: 비표준 응답 본문.
 
 ### 응답 구조
 
@@ -99,11 +113,6 @@ if (!res.ok) {
 const items = json?.data ?? []
 const total = json?.meta?.total ?? 0
 ```
-
-### 예외 — 파일 응답
-
-CSV / ICS 등 다운로드 응답은 raw Response (`csvResponse()`, `new Response(ics, {...})`) 를 그대로 사용한다 — Content-Disposition 헤더 필요.
-**에러 path 만** envelope (`fail()`) 적용한다 (`src/app/api/exports/*` 참고).
 
 ## 신규 라우트 작성 체크리스트
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ PM2 ──► myfinance-bot (standalone)        │
 
 - 한국어 UI, 코드/변수명은 영어.
 - 컴포넌트: 함수형 + hooks. default export.
-- API routes: `src/app/api/` 아래 route.ts. try-catch + `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 상세는 `.claude/rules/api-routes.md`.
+- API routes: `src/app/api/` 아래 route.ts. try-catch + 신규/마이그 완료 라우트는 `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 미마이그 라우트 변경 시 클라이언트 fetcher 동시 업데이트 필수. 상세 + 적용 범위는 `.claude/rules/api-routes.md`.
 - DB 접근: 반드시 `@/lib/prisma` singleton. raw query 금지.
 - Trade 생성 시 Holding 업데이트는 Prisma transaction으로 묶기.
 - 금액 응답에 항상 currency 필드 포함. 날짜는 ISO 8601.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ PM2 ──► myfinance-bot (standalone)        │
 
 - 한국어 UI, 코드/변수명은 영어.
 - 컴포넌트: 함수형 + hooks. default export.
-- API routes: `src/app/api/` 아래 route.ts. try-catch + `{ error: string }` 에러 응답.
+- API routes: `src/app/api/` 아래 route.ts. try-catch + `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 상세는 `.claude/rules/api-routes.md`.
 - DB 접근: 반드시 `@/lib/prisma` singleton. raw query 금지.
 - Trade 생성 시 Holding 업데이트는 Prisma transaction으로 묶기.
 - 금액 응답에 항상 currency 필드 포함. 날짜는 ISO 8601.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -322,4 +322,4 @@
   - [x] **27-C-4**: RSU + StockOption (7 라우트 + 1 fetcher)
   - [x] **27-C-5**: Trade (3 라우트 + 3 fetcher + api-errors 헬퍼 통일)
 - [x] **27-D**: pagination meta 통일 + 복잡한 GET (8 라우트 + ExpensesClient/ImportWizard unwrap)
-- [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)
+- [x] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -323,3 +323,11 @@
   - [x] **27-C-5**: Trade (3 라우트 + 3 fetcher + api-errors 헬퍼 통일)
 - [x] **27-D**: pagination meta 통일 + 복잡한 GET (8 라우트 + ExpensesClient/ImportWizard unwrap)
 - [x] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)
+
+### 후속 (10차 마일스톤 후보)
+
+27 시리즈에서 핵심 도메인 53+ 라우트는 마이그 완료. 남은 미마이그 라우트 (16개) 는 다음 마일스톤에서 envelope 화 예정:
+
+- accounts, networth, performance/*, prices/*, reports/*, tax/gift, backtest, ai/ask
+- 각 라우트마다 클라이언트 fetcher 동시 업데이트 필요 (atomic PR)
+- 가이드 문서 (`.claude/rules/api-routes.md`) 의 "적용 범위" 표를 함께 갱신

--- a/docs/specs/337-envelope-e.md
+++ b/docs/specs/337-envelope-e.md
@@ -1,0 +1,72 @@
+# [Phase 27-E] envelope 가이드 문서 갱신
+
+## 목적
+
+27-A~D 에서 적용한 `ApiResponse<T>` envelope 패턴을 향후 신규 API 라우트 작성 시 자연스럽게 따를 수 있도록 `.claude/rules/api-routes.md` 와 `CLAUDE.md` 에 명시.
+
+27 시리즈의 **마지막 단계**.
+
+## 배경
+
+- 27-A: ApiResponse 헬퍼 + 단위 테스트 완료
+- 27-B: 단순 GET 라우트 마이그
+- 27-C-1~5: POST/PUT/DELETE 마이그 (5 sub-PR)
+- 27-D: pagination + 복잡한 GET + exports 에러 path
+- → 모든 API 라우트가 envelope 화 완료. 가이드 문서만 남음.
+
+## 요구사항
+
+- [ ] `.claude/rules/api-routes.md` 갱신
+  - 응답 envelope `ApiResponse<T>` 구조 명시
+  - `ok` / `fail` / `noContent` / `paginated` 사용 패턴 + 예시
+  - 에러 응답 컨벤션 (한국어 정적 메시지 + envelope `error` 필드)
+  - `businessErrorResponse()` 헬퍼 사용처 (Trade 도메인 비즈니스 예외)
+  - 파일 응답 (CSV/ICS) 의 예외 — 성공은 raw Response, 에러는 envelope
+- [ ] `CLAUDE.md` 갱신
+  - "Coding Conventions" 섹션에 envelope 사용 한 줄 추가
+
+## 기술 설계
+
+### api-routes.md 추가 섹션
+
+```markdown
+## 응답 envelope (ApiResponse<T>)
+
+모든 API 응답은 `src/lib/api-response.ts` 의 헬퍼를 사용해 통일된 envelope 으로 반환.
+
+### 응답 구조
+
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: { total, limit, offset }  // pagination 한정
+}
+
+### 헬퍼 사용
+
+| 케이스 | 헬퍼 |
+|---|---|
+| 단순 성공 (200) | ok(data) |
+| 생성 (201) | ok(data, { status: 201 }) |
+| 본문 없음 (204/205/304) | noContent() |
+| 페이지네이션 | paginated(arr, total, limit, offset) |
+| 복합 데이터 + meta | ok({...}, { meta: { total, limit, offset } }) |
+| 에러 | fail(error, status) |
+
+### 예외 — 파일 응답
+CSV/ICS 등 다운로드는 raw Response (csvResponse 등) 그대로.
+**에러 path 만** fail() 적용.
+```
+
+### CLAUDE.md 한 줄
+
+> API 응답: `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 사용. 모든 라우트는 envelope `{ success, data?, error?, meta? }` 형식.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build` — 문서 변경이라 영향 없을 것이나 형식 확인
+
+## 제외 사항
+
+- 신규 라우트 추가 / 기존 라우트 변경 — 27-A~D 에서 완료


### PR DESCRIPTION
## 요약

Phase 27 envelope 시리즈의 **마지막 단계** — 27-A~D 에서 적용한 `ApiResponse<T>` envelope 패턴을 향후 신규 API 라우트 작성 시 자연스럽게 따를 수 있도록 가이드 문서 갱신.

코드 변경 없음 (문서만).

## 변경 내역

### `.claude/rules/api-routes.md`
- "응답 envelope (`ApiResponse<T>`)" 섹션 신설
  - 응답 구조 (success / data / error / meta)
  - 헬퍼 사용 매트릭스 (`ok` / `fail` / `noContent` / `paginated`)
  - 패턴별 코드 예시 (단순 조회, 생성, 페이지네이션, 집계+meta, 삭제, 에러)
  - 비즈니스 예외 (`businessErrorResponse()`) 사용처
  - 클라이언트 fetcher unwrap 가이드
  - 파일 응답 (CSV/ICS) 예외 명시 — 성공은 raw Response, 에러만 envelope
- "신규 라우트 작성 체크리스트" 추가

### `CLAUDE.md`
- "Coding Conventions" 의 API routes 한 줄 갱신
  - 기존: `try-catch + { error: string } 에러 응답`
  - 신규: `try-catch + @/lib/api-response 의 ok/fail/noContent/paginated 헬퍼 사용 (envelope { success, data?, error?, meta? }). 상세는 .claude/rules/api-routes.md.`

## 검증

- [x] 린트 — 0 warnings/errors (문서만 변경)
- [x] 타입체크 — 0 errors
- [x] 단위 테스트 / 빌드 — 코드 변경 없어 영향 없음

## 27 시리즈 완료 🎉

- [x] 27-A: ApiResponse 헬퍼 + 단위 테스트
- [x] 27-B: 단순 GET 라우트 마이그
- [x] 27-C-1~5: POST/PUT/DELETE 마이그 (5 sub-PR)
- [x] 27-D: pagination + 복잡한 GET + exports
- [x] 본 PR (27-E): 가이드 문서 갱신

응답 envelope `ApiResponse<T>` 전면 도입 완료. 53+ 라우트 + 40+ 클라이언트 fetcher 마이그 무사고 완료.

Closes #337