### PR TITLE
[Phase 28-A] accounts envelope 마이그 (#341)

### DIFF
--- a/docs/specs/341-envelope-28a.md
+++ b/docs/specs/341-envelope-28a.md
@@ -1,0 +1,47 @@
+# [Phase 28-A] accounts 라우트 envelope 마이그
+
+## 목적
+
+10차 마일스톤 (Phase 28: 잔여 16 라우트 envelope) 첫 sub-PR — accounts 도메인 2 라우트 envelope 통일.
+
+## 배경
+
+- 9차 (Phase 27) 에서 핵심 53+ 라우트 마이그 완료
+- 10차 (Phase 28) 는 남은 16 라우트 정리 — 5 sub-PR (A~E)
+- 28-A 는 가장 안전한 단순 CRUD (accounts) — 위험도 낮은 순 시작
+
+## 요구사항
+
+- [ ] `src/app/api/accounts/route.ts` GET 에러 path → `fail()` (성공은 이미 `ok()`)
+- [ ] `src/app/api/accounts/[id]/route.ts` GET/PATCH → `ok` / `fail` 통일
+- [ ] 클라이언트 검증 — SettingsClient (`json.data`) / AccountEditor (`data?.error`) 모두 이미 envelope 호환
+
+## 기술 설계
+
+### 변환 대상
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `accounts/route.ts` | GET (성공) | 이미 `ok()` — 미변경 |
+| `accounts/route.ts` | GET 에러 (500) | `fail('계좌 목록을 불러올 수 없습니다.', 500)` |
+| `accounts/[id]/route.ts` | GET (성공/404/500) | `ok(account)` / `fail('찾을 수 없습니다.', 404)` / `fail(..., 500)` |
+| `accounts/[id]/route.ts` | PATCH (전 분기) | `ok(updated)` / `fail(msg, status)` |
+
+### 클라이언트 영향 분석
+
+- `src/app/settings/SettingsClient.tsx:36-37` — `json.data` 이미 사용 ✅
+- `src/components/settings/AccountEditor.tsx:81-83` — `data?.error` 이미 envelope 호환 ✅
+- 외부 consumer 없음 (server component 미사용)
+
+→ 라우트만 바꿔도 클라이언트 영향 없음 (atomic).
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - `/settings` 계좌 탭 — 목록 로드 + 수정 정상
+
+## 제외 사항
+
+- 다른 도메인 (28-B~E) — 별도 sub-PR
+- 신규 기능 없음

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail } from '@/lib/api-response'
 
 export async function GET(request: Request, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -18,19 +19,13 @@ export async function GET(request: Request, props: { params: Promise<{ id: strin
     })
 
     if (!account) {
-      return NextResponse.json(
-        { error: '계좌를 찾을 수 없습니다.' },
-        { status: 404 }
-      )
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
-    return NextResponse.json(account)
+    return ok(account)
   } catch (error) {
     console.error('GET /api/accounts/[id] error:', error)
-    return NextResponse.json(
-      { error: '계좌 정보를 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('계좌 정보를 불러올 수 없습니다.', 500)
   }
 }
 
@@ -46,24 +41,24 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     const data: Record<string, unknown> = {}
 
     if (body.name !== undefined) {
       if (typeof body.name !== 'string' || !body.name.trim()) {
-        return NextResponse.json({ error: '계좌 이름을 입력해주세요.' }, { status: 400 })
+        return fail('계좌 이름을 입력해주세요.', 400)
       }
       data.name = body.name.trim()
     }
 
     if (body.strategy !== undefined) {
       if (body.strategy !== null && typeof body.strategy !== 'string') {
-        return NextResponse.json({ error: '전략은 문자열이어야 합니다.' }, { status: 400 })
+        return fail('전략은 문자열이어야 합니다.', 400)
       }
       data.strategy = typeof body.strategy === 'string' ? body.strategy.trim() || null : null
     }
@@ -74,13 +69,13 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       } else if (typeof body.horizon === 'number' && Number.isInteger(body.horizon) && body.horizon > 0) {
         data.horizon = body.horizon
       } else {
-        return NextResponse.json({ error: '투자 기간은 양의 정수여야 합니다.' }, { status: 400 })
+        return fail('투자 기간은 양의 정수여야 합니다.', 400)
       }
     }
 
     if (body.benchmarkTicker !== undefined) {
       if (body.benchmarkTicker !== null && typeof body.benchmarkTicker !== 'string') {
-        return NextResponse.json({ error: '벤치마크는 문자열이어야 합니다.' }, { status: 400 })
+        return fail('벤치마크는 문자열이어야 합니다.', 400)
       }
       data.benchmarkTicker = typeof body.benchmarkTicker === 'string' ? body.benchmarkTicker.trim() || null : null
     }
@@ -91,12 +86,12 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       } else if (typeof body.ownerAge === 'number' && Number.isInteger(body.ownerAge) && body.ownerAge >= 0) {
         data.ownerAge = body.ownerAge
       } else {
-        return NextResponse.json({ error: '나이는 0 이상의 정수여야 합니다.' }, { status: 400 })
+        return fail('나이는 0 이상의 정수여야 합니다.', 400)
       }
     }
 
     if (Object.keys(data).length === 0) {
-      return NextResponse.json({ error: '수정할 필드가 없습니다.' }, { status: 400 })
+      return fail('수정할 필드가 없습니다.', 400)
     }
 
     const updated = await prisma.account.update({
@@ -104,12 +99,12 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       data,
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
     console.error('PATCH /api/accounts/[id] error:', error)
-    return NextResponse.json({ error: '계좌 수정에 실패했습니다.' }, { status: 500 })
+    return fail('계좌 수정에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,6 +1,5 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export async function GET() {
   try {
@@ -17,9 +16,6 @@ export async function GET() {
     return ok(accounts)
   } catch (error) {
     console.error('GET /api/accounts error:', error)
-    return NextResponse.json(
-      { error: '계좌 목록을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('계좌 목록을 불러올 수 없습니다.', 500)
   }
 }


### PR DESCRIPTION
## 요약

10차 마일스톤 (Phase 28: envelope 잔여 16 라우트) 첫 sub-PR — accounts 도메인 2 라우트 envelope 통일.

가장 안전한 단순 CRUD 부터 시작. 클라이언트 영향 없음 (이미 envelope 호환).

## 변경 내역

### 라우트 (2 파일)
- `accounts/route.ts` — GET 에러 path → `fail()` (성공은 이미 `ok()`)
- `accounts/[id]/route.ts` — GET (200/404/500) + PATCH (400 8개 / 404 / 500) 전 분기 `ok`/`fail` 통일

### 영향 없음 (이미 호환)
- `SettingsClient.tsx` — `json.data` 이미 사용 (27-B 에서 GET 성공 path 마이그된 상태)
- `AccountEditor.tsx` — `!res.ok` 시 `data?.error` 만 사용 → envelope `error` 와 호환

## 변환 패턴 (9차 시리즈 동일)

| 케이스 | before | after |
|---|---|---|
| 성공 | `NextResponse.json(data)` | `ok(data)` |
| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |

## 체크리스트

- [x] 린트 — 0
- [x] 타입체크 — 0
- [x] 테스트 — 162/162
- [x] 빌드 — Next + MCP + Bot 정상
- [x] 코드 리뷰 — P0/P1/P2: 0/0/0 (status code 1:1 보존 확인)

Closes #341