### PR TITLE
[Phase 28-B] networth + reports + tax/gift envelope 마이그 (#343)

### DIFF
--- a/docs/specs/343-envelope-28b.md
+++ b/docs/specs/343-envelope-28b.md
@@ -1,0 +1,40 @@
+# [Phase 28-B] networth + reports + tax/gift envelope 마이그
+
+## 목적
+
+10차 마일스톤 (Phase 28) 두 번째 sub-PR — 조회 + 리포트 도메인 4 라우트 envelope 통일.
+
+## 요구사항
+
+- [ ] `networth/route.ts` GET (200/500) → `ok` / `fail`
+- [ ] `tax/gift/route.ts` GET (200/500) → `ok({ summaries })` / `fail` — 기존 wrapper `{ summaries }` 유지 (클라이언트 미사용이므로 자유)
+- [ ] `reports/route.ts` GET/POST → `ok` / `fail` (POST 201 응답 wrapper 제거 가능)
+- [ ] `reports/[id]/download/route.ts` — PDF 파일 응답이므로 27-D exports 패턴 (성공은 raw `NextResponse(buffer)`, 에러만 `fail()`)
+- [ ] 클라이언트 fetcher unwrap
+  - NetWorthClient: `setData(d.data ?? null)` + breakdown 가드
+  - ReportsClient: POST 응답 본문 미사용 (`fetchReports()` 재호출만 — 안전), GET 은 이미 `d?.data` 호환
+
+## 기술 설계
+
+### 라우트 변환
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `networth/route.ts` | GET | 성공 → `ok({...})`, 500 → `fail(...)` |
+| `tax/gift/route.ts` | GET | 성공 → `ok({ summaries })`, 500 → `fail(...)` |
+| `reports/route.ts` | GET, POST | 성공 → `ok(data)` / `ok(payload, { status: 201 })`, 검증/500 → `fail(...)` |
+| `reports/[id]/download/route.ts` | GET | 성공은 raw `NextResponse(buffer, { headers })` 유지 (PDF 다운로드), 404/500 → `fail()` |
+
+### 클라이언트
+
+- `NetWorthClient.tsx` — `if (d.breakdown)` → `if (d?.data?.breakdown)`, `setData(d)` → `setData(d.data)`
+- `ReportsClient.tsx` — POST 후 `fetchReports()` 재호출만 — 영향 없음. POST 에러 `data.error` 는 envelope 호환
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: `/networth`, `/reports` 페이지 + 리포트 생성/다운로드
+
+## 제외 사항
+
+- 다른 도메인 (28-C/D/E)

--- a/src/app/api/networth/route.ts
+++ b/src/app/api/networth/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import {
   calcCurrentValueKRW,
   DEFAULT_FX_RATE_USD_KRW,
 } from '@/lib/format'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -76,7 +76,7 @@ export async function GET() {
       take: 12,
     })
 
-    return NextResponse.json({
+    return ok({
       netWorthKRW,
       stockValueKRW,
       assetValueKRW,
@@ -104,6 +104,6 @@ export async function GET() {
     })
   } catch (error) {
     console.error('GET /api/networth error:', error)
-    return NextResponse.json({ error: '순자산을 계산할 수 없습니다.' }, { status: 500 })
+    return fail('순자산을 계산할 수 없습니다.', 500)
   }
 }

--- a/src/app/api/reports/[id]/download/route.ts
+++ b/src/app/api/reports/[id]/download/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { fail } from '@/lib/api-response'
 
 const REPORTS_DIR = path.join(process.cwd(), 'reports')
 
 /**
  * GET /api/reports/[id]/download — PDF 다운로드
+ *
+ * 성공 path 는 raw NextResponse(buffer) — Content-Disposition 헤더 필요.
+ * 에러 path 만 envelope (`fail()`).
  */
 export async function GET(_request: NextRequest, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -16,11 +20,11 @@ export async function GET(_request: NextRequest, props: { params: Promise<{ id: 
     })
 
     if (!report) {
-      return NextResponse.json({ error: '리포트를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('리포트를 찾을 수 없습니다.', 404)
     }
 
     if (!report.pdfPath) {
-      return NextResponse.json({ error: 'PDF가 아직 생성되지 않았습니다.' }, { status: 404 })
+      return fail('PDF가 아직 생성되지 않았습니다.', 404)
     }
 
     // path traversal 방지: basename만 사용
@@ -36,10 +40,10 @@ export async function GET(_request: NextRequest, props: { params: Promise<{ id: 
         },
       })
     } catch {
-      return NextResponse.json({ error: 'PDF 파일을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('PDF 파일을 찾을 수 없습니다.', 404)
     }
   } catch (error) {
     console.error('GET /api/reports/[id]/download error:', error)
-    return NextResponse.json({ error: '다운로드에 실패했습니다.' }, { status: 500 })
+    return fail('다운로드에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { generateReportPDF } from '@/lib/report/pdf-generator'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -17,7 +17,7 @@ export async function GET() {
     return ok(reports)
   } catch (error) {
     console.error('GET /api/reports error:', error)
-    return NextResponse.json({ error: '리포트 목록을 불러올 수 없습니다.' }, { status: 500 })
+    return fail('리포트 목록을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -31,26 +31,26 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { year, quarter } = body as { year?: unknown; quarter?: unknown }
 
     if (typeof year !== 'number' || !Number.isInteger(year) || year < 2020 || year > 2100) {
-      return NextResponse.json({ error: '유효한 연도를 입력해주세요.' }, { status: 400 })
+      return fail('유효한 연도를 입력해주세요.', 400)
     }
     if (typeof quarter !== 'number' || ![1, 2, 3, 4].includes(quarter)) {
-      return NextResponse.json({ error: '유효한 분기를 입력해주세요. (1~4)' }, { status: 400 })
+      return fail('유효한 분기를 입력해주세요. (1~4)', 400)
     }
 
     const { pdfPath, reportId } = await generateReportPDF(year, quarter)
-    return NextResponse.json({ reportId, pdfPath, message: '리포트 생성 완료' }, { status: 201 })
+    return ok({ reportId, pdfPath, message: '리포트 생성 완료' }, { status: 201 })
   } catch (error) {
     console.error('POST /api/reports error:', error)
-    return NextResponse.json({ error: '리포트 생성에 실패했습니다.' }, { status: 500 })
+    return fail('리포트 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/tax/gift/route.ts
+++ b/src/app/api/tax/gift/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -62,9 +62,9 @@ export async function GET() {
       }
     })
 
-    return NextResponse.json({ summaries })
+    return ok({ summaries })
   } catch (error) {
     console.error('GET /api/tax/gift error:', error)
-    return NextResponse.json({ error: '증여세 현황을 불러올 수 없습니다.' }, { status: 500 })
+    return fail('증여세 현황을 불러올 수 없습니다.', 500)
   }
 }

--- a/src/app/networth/NetWorthClient.tsx
+++ b/src/app/networth/NetWorthClient.tsx
@@ -77,8 +77,9 @@ export default function NetWorthClient() {
         if (!r.ok) throw new Error('API error')
         return r.json()
       })
-      .then((d) => {
-        if (d.breakdown) setData(d)
+      .then((json) => {
+        const d = json?.data
+        if (d?.breakdown) setData(d)
       })
       .catch(console.error)
       .finally(() => setLoading(false))

--- a/src/app/reports/ReportsClient.tsx
+++ b/src/app/reports/ReportsClient.tsx
@@ -45,8 +45,8 @@ export default function ReportsClient() {
         body: JSON.stringify({ year: genYear, quarter: genQuarter }),
       })
       if (!res.ok) {
-        const data = await res.json()
-        alert(data.error || '리포트 생성 실패')
+        const data = await res.json().catch(() => null)
+        alert(data?.error ?? '리포트 생성 실패')
         return
       }
       fetchReports()


### PR DESCRIPTION
## 요약

10차 마일스톤 (Phase 28) 두 번째 sub-PR — 조회/리포트 도메인 4 라우트 envelope 통일.

PDF 다운로드 (`reports/[id]/download`) 는 27-D exports 패턴 그대로: **성공은 raw `NextResponse(buffer)`, 에러만 `fail()`**.

## 변경 내역

### 라우트 (4 파일)
- `networth/route.ts` — GET 성공/500 envelope
- `tax/gift/route.ts` — GET 성공/500 envelope (`{ summaries }` wrapper 유지 — 클라이언트 미사용)
- `reports/route.ts` — GET / POST 전 분기 envelope (POST 201 `{ reportId, pdfPath, message }` payload 그대로)
- `reports/[id]/download/route.ts` — 성공은 raw PDF Response 유지, 404/500 에러만 envelope

### 클라이언트 (2 파일)
- `NetWorthClient.tsx` — `json?.data?.breakdown` 가드 + `setData(d)` (null 응답에도 안전)
- `ReportsClient.tsx` — POST 에러 path `catch(()=>null)` + `data?.error` fallback

## 변환 패턴 (27-D 동일)

| 케이스 | before | after |
|---|---|---|
| 성공 JSON | `NextResponse.json(data)` | `ok(data)` |
| 201 | `NextResponse.json(payload, { status: 201 })` | `ok(payload, { status: 201 })` |
| 파일 응답 (PDF/CSV/ICS) | `new NextResponse(buffer, { headers })` | **유지** (raw Response) |
| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |

## 체크리스트

- [x] 린트 — 0
- [x] 타입체크 — 0
- [x] 테스트 — 162/162
- [x] 빌드 — Next + MCP + Bot
- [x] 코드 리뷰 — P0/P1/P2: 0/0/0 (PDF 성공 path raw 유지 확인, 클라이언트 unwrap 안전성 검증)

Closes #343