### PR TITLE
[Phase 28-C] performance/* envelope 마이그 (#345)

### DIFF
--- a/docs/specs/345-envelope-28c.md
+++ b/docs/specs/345-envelope-28c.md
@@ -1,0 +1,45 @@
+# [Phase 28-C] performance/* envelope 마이그
+
+## 목적
+
+10차 마일스톤 세 번째 sub-PR — 성과 지표 도메인 4 라우트 envelope 통일.
+
+## 요구사항
+
+- [ ] `performance/snapshots/route.ts` GET/POST → `ok`/`fail` (POST `{ results }` wrapper 제거)
+- [ ] `performance/twr/route.ts` GET → `ok`/`fail`
+- [ ] `performance/contribution/route.ts` GET → `ok`/`fail`
+- [ ] `performance/benchmark/backfill/route.ts` POST → `ok({ results }, { status: 201 })` / `fail`
+- [ ] 클라이언트 `PerformanceClient.tsx` 3개 GET fetcher unwrap
+
+## 기술 설계
+
+### 라우트
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `snapshots/route.ts` | GET | `ok({ snapshots, benchmark, benchmarkName })` |
+| `snapshots/route.ts` | POST | `ok(results, { status: 201 })` (wrapper 제거 — 클라이언트 미사용) |
+| `twr/route.ts` | GET | `ok(result)` |
+| `contribution/route.ts` | GET | `ok(result)` |
+| `benchmark/backfill/route.ts` | POST | `ok(results, { status: 201 })` (wrapper 제거 — 미사용) |
+
+### 클라이언트 (`PerformanceClient.tsx`)
+
+- `fetchSnapshots`: `const json = await res.json(); setSnapshotData(json?.data ?? null)`
+- `fetchTWR`: 각 항목 `const json = await res.json(); return json?.data ?? { ...nullObj }`
+- `fetchContribution`: `setContributionData(json?.data ?? null)`
+- POST 2개 (`handleTriggerSnapshot`, `handleBackfill`): body 미사용 — 변경 없음
+
+## 위험도
+
+성과 지표 차트 데이터 영향 — fetcher unwrap 후 차트 컴포넌트가 받는 props 동일 구조 유지 확인 필수.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: `/performance` 페이지 — 계좌 선택 / period 변경 / 스냅샷 트리거 / backfill
+
+## 제외 사항
+
+- 다른 도메인 (28-D/E)

--- a/src/app/api/performance/benchmark/backfill/route.ts
+++ b/src/app/api/performance/benchmark/backfill/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { backfillAllBenchmarks } from '@/lib/performance/benchmark'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,9 +10,9 @@ export const dynamic = 'force-dynamic'
 export async function POST() {
   try {
     const results = await backfillAllBenchmarks()
-    return NextResponse.json({ results }, { status: 201 })
+    return ok(results, { status: 201 })
   } catch (error) {
     console.error('POST /api/performance/benchmark/backfill error:', error)
-    return NextResponse.json({ error: '벤치마크 backfill에 실패했습니다.' }, { status: 500 })
+    return fail('벤치마크 backfill에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/performance/contribution/route.ts
+++ b/src/app/api/performance/contribution/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { calculateContribution } from '@/lib/performance/contribution'
 import { VALID_PERIODS } from '@/lib/performance/constants'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,20 +16,17 @@ export async function GET(request: NextRequest) {
     const period = searchParams.get('period') ?? '6M'
 
     if (!accountId) {
-      return NextResponse.json({ error: 'accountId는 필수입니다.' }, { status: 400 })
+      return fail('accountId는 필수입니다.', 400)
     }
 
     if (!VALID_PERIODS.includes(period)) {
-      return NextResponse.json(
-        { error: `유효한 기간: ${VALID_PERIODS.join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`유효한 기간: ${VALID_PERIODS.join(', ')}`, 400)
     }
 
     const result = await calculateContribution(accountId, period)
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     console.error('GET /api/performance/contribution error:', error)
-    return NextResponse.json({ error: '기여도 분석에 실패했습니다.' }, { status: 500 })
+    return fail('기여도 분석에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/performance/snapshots/route.ts
+++ b/src/app/api/performance/snapshots/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { takeAllSnapshots } from '@/lib/performance/snapshot'
 import { BENCHMARK_DISPLAY_NAMES } from '@/lib/performance/constants'
 import { dateRangeSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const accountId = searchParams.get('accountId')
 
     if (!accountId) {
-      return NextResponse.json({ error: 'accountId는 필수입니다.' }, { status: 400 })
+      return fail('accountId는 필수입니다.', 400)
     }
 
     const dateResult = dateRangeSchema.safeParse({
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest) {
     })
     if (!dateResult.success) {
       const errs = zodErrorsToValidation(dateResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { from, to } = dateResult.data
 
@@ -91,14 +92,14 @@ export async function GET(request: NextRequest) {
       normalizedValue: baseValue > 0 ? (s.totalValueKRW / baseValue) * 100 : 100,
     }))
 
-    return NextResponse.json({
+    return ok({
       snapshots: normalizedSnapshots,
       benchmark,
       benchmarkName,
     })
   } catch (error) {
     console.error('GET /api/performance/snapshots error:', error)
-    return NextResponse.json({ error: '스냅샷 데이터를 불러올 수 없습니다.' }, { status: 500 })
+    return fail('스냅샷 데이터를 불러올 수 없습니다.', 500)
   }
 }
 
@@ -109,9 +110,9 @@ export async function GET(request: NextRequest) {
 export async function POST() {
   try {
     const results = await takeAllSnapshots()
-    return NextResponse.json({ results }, { status: 201 })
+    return ok(results, { status: 201 })
   } catch (error) {
     console.error('POST /api/performance/snapshots error:', error)
-    return NextResponse.json({ error: '스냅샷 생성에 실패했습니다.' }, { status: 500 })
+    return fail('스냅샷 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/performance/twr/route.ts
+++ b/src/app/api/performance/twr/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { calculateTWR } from '@/lib/performance/twr'
 import { VALID_PERIODS } from '@/lib/performance/constants'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,20 +16,17 @@ export async function GET(request: NextRequest) {
     const period = searchParams.get('period') ?? '3M'
 
     if (!accountId) {
-      return NextResponse.json({ error: 'accountId는 필수입니다.' }, { status: 400 })
+      return fail('accountId는 필수입니다.', 400)
     }
 
     if (!VALID_PERIODS.includes(period)) {
-      return NextResponse.json(
-        { error: `유효한 기간: ${VALID_PERIODS.join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`유효한 기간: ${VALID_PERIODS.join(', ')}`, 400)
     }
 
     const result = await calculateTWR(accountId, period)
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     console.error('GET /api/performance/twr error:', error)
-    return NextResponse.json({ error: 'TWR 계산에 실패했습니다.' }, { status: 500 })
+    return fail('TWR 계산에 실패했습니다.', 500)
   }
 }

--- a/src/app/performance/PerformanceClient.tsx
+++ b/src/app/performance/PerformanceClient.tsx
@@ -52,8 +52,8 @@ export default function PerformanceClient({ accounts, hasSnapshots }: Performanc
     setLoadingChart(true)
     try {
       const res = await fetch(`/api/performance/snapshots?accountId=${selectedAccount}`)
-      const data = await res.json()
-      setSnapshotData(data)
+      const json = await res.json()
+      setSnapshotData(json?.data ?? null)
     } catch (error) {
       console.error('Failed to fetch snapshots:', error)
     } finally {
@@ -66,19 +66,19 @@ export default function PerformanceClient({ accounts, hasSnapshots }: Performanc
     try {
       const results = await Promise.all(
         accounts.map(async (a) => {
-          const res = await fetch(`/api/performance/twr?accountId=${a.id}&period=${period}`)
-          if (!res.ok) {
-            return {
-              accountId: a.id,
-              accountName: a.name,
-              twr: null,
-              benchmarkReturn: null,
-              alpha: null,
-              benchmarkTicker: null,
-              snapshotCount: 0,
-            }
+          const fallback = {
+            accountId: a.id,
+            accountName: a.name,
+            twr: null,
+            benchmarkReturn: null,
+            alpha: null,
+            benchmarkTicker: null,
+            snapshotCount: 0,
           }
-          return res.json()
+          const res = await fetch(`/api/performance/twr?accountId=${a.id}&period=${period}`)
+          if (!res.ok) return fallback
+          const json = await res.json()
+          return json?.data ?? fallback
         })
       )
       setTwrData(results)
@@ -94,8 +94,8 @@ export default function PerformanceClient({ accounts, hasSnapshots }: Performanc
     setLoadingContrib(true)
     try {
       const res = await fetch(`/api/performance/contribution?accountId=${selectedAccount}&period=${period}`)
-      const data = await res.json()
-      setContributionData(data)
+      const json = await res.json()
+      setContributionData(json?.data ?? null)
     } catch (error) {
       console.error('Failed to fetch contribution:', error)
     } finally {


### PR DESCRIPTION
## 요약

10차 마일스톤 세 번째 sub-PR — 성과 지표 도메인 4 라우트 envelope 통일.

POST 의 `{ results }` wrapper 도 제거 — 클라이언트 미사용 + cron/MCP 는 HTTP 미경유 (lib 직접 호출) 라 영향 없음.

## 변경 내역

### 라우트 (4 파일)
- `performance/snapshots/route.ts` — GET (200/400/500), POST (201/500) — `{ results }` wrapper 제거
- `performance/twr/route.ts` — GET (200/400×2/500)
- `performance/contribution/route.ts` — GET (200/400×2/500)
- `performance/benchmark/backfill/route.ts` — POST (201/500) — wrapper 제거

### 클라이언트 (`PerformanceClient.tsx`)
- `fetchSnapshots` / `fetchContribution`: `json?.data ?? null` unwrap
- `fetchTWR`: fallback 객체 추출 + `json?.data ?? fallback` (계좌별 null-safe)
- POST 2개 (handleTriggerSnapshot, handleBackfill): body 미사용 — 영향 없음

### External consumer 영향 분석
- `src/lib/cron.ts` — `takeAllSnapshots()` 함수 직접 호출 (HTTP 미경유)
- `src/mcp/tools/performance.ts` — lib 직접 import
→ POST 응답 shape 변경 영향 0

## 체크리스트

- [x] 린트 — 0
- [x] 타입체크 — 0
- [x] 테스트 — 162/162
- [x] 빌드 — Next + MCP + Bot
- [x] 코드 리뷰 — P0/P1/P2: 0/0/0 (차트 컴포넌트 props 호환 + cron/MCP 영향 없음 확인)

Closes #345