### PR TITLE
[Phase 28-D] prices/* envelope 마이그 (#347)

### DIFF
--- a/docs/specs/347-envelope-28d.md
+++ b/docs/specs/347-envelope-28d.md
@@ -1,0 +1,40 @@
+# [Phase 28-D] prices/* envelope 마이그
+
+## 목적
+
+10차 마일스톤 네 번째 sub-PR — 시세 도메인 4 라우트 envelope 통일.
+
+## 외부 consumer 영향 분석
+
+- bot/cron 은 `refreshPrices()`, `syncKrxStocks()`, `searchYahooByName()` 등 **lib 직접 호출** — HTTP 미경유. 응답 shape 변경 영향 없음.
+- 웹 consumer:
+  - `/api/prices` GET — TradeForm, DividendForm: 이미 `json?.data?.prices` 사용 (27-B 호환)
+  - `/api/prices/refresh` POST — RefreshButton: success body 미사용, error path `data?.error` 호환
+  - `/api/prices/search` GET — 미사용
+  - `/api/prices/krx-sync` POST — 미사용
+
+→ 라우트 변경 안전. 클라이언트 fetcher 추가 변경 불필요.
+
+## 요구사항
+
+- [ ] `prices/route.ts` GET 에러 path → `fail()` (성공 이미 `ok`)
+- [ ] `prices/refresh/route.ts` POST → `ok(result)` / `fail(msg, 429/500)`
+- [ ] `prices/search/route.ts` GET → `ok({ source, results })` / `fail(...)`
+- [ ] `prices/krx-sync/route.ts` POST → `ok(result)` / `fail(msg, 429/500)`
+
+## 변환 패턴 (9차 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: 대시보드 갱신 버튼, 거래/배당 폼 (환율 prefill), Whoes 검색은 미사용이지만 수동 호출 가능
+
+## 제외 사항
+
+- 28-E (backtest + ai/ask)
+- lib 직접 호출 (cron/bot/MCP) 영향 없음

--- a/src/app/api/prices/krx-sync/route.ts
+++ b/src/app/api/prices/krx-sync/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { syncKrxStocks } from '@/lib/krx-stocks'
+import { ok, fail } from '@/lib/api-response'
 
 /** 최소 동기화 간격 (ms) — 10분 */
 const MIN_SYNC_INTERVAL_MS = 600_000
@@ -15,29 +15,23 @@ export async function POST() {
   try {
     const now = Date.now()
     if (now - lastSyncAt < MIN_SYNC_INTERVAL_MS) {
-      return NextResponse.json(
-        { error: 'KRX 동기화 간격이 너무 짧습니다. 10분 후 다시 시도해주세요.' },
-        { status: 429 }
-      )
+      return fail('KRX 동기화 간격이 너무 짧습니다. 10분 후 다시 시도해주세요.', 429)
     }
 
     if (isSyncing) {
-      return NextResponse.json(
-        { error: 'KRX 동기화가 이미 진행 중입니다.' },
-        { status: 429 }
-      )
+      return fail('KRX 동기화가 이미 진행 중입니다.', 429)
     }
 
     isSyncing = true
     try {
       const result = await syncKrxStocks()
       lastSyncAt = Date.now()
-      return NextResponse.json(result)
+      return ok(result)
     } finally {
       isSyncing = false
     }
   } catch (error) {
     console.error('[api] KRX 종목 동기화 실패:', error)
-    return NextResponse.json({ error: 'KRX 종목 동기화에 실패했습니다.' }, { status: 500 })
+    return fail('KRX 종목 동기화에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { refreshPrices } from '@/lib/price-fetcher'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,20 +12,14 @@ export async function POST() {
   try {
     const now = Date.now()
     if (now - lastRefreshAt < MIN_REFRESH_INTERVAL_MS) {
-      return NextResponse.json(
-        { error: '갱신 간격이 너무 짧습니다. 30초 후 다시 시도해주세요.' },
-        { status: 429 }
-      )
+      return fail('갱신 간격이 너무 짧습니다. 30초 후 다시 시도해주세요.', 429)
     }
 
     lastRefreshAt = now
     const result = await refreshPrices()
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     console.error('POST /api/prices/refresh error:', error)
-    return NextResponse.json(
-      { error: '주가 갱신에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('주가 갱신에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/prices/route.ts
+++ b/src/app/api/prices/route.ts
@@ -1,7 +1,6 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { getLastUpdatedAt } from '@/lib/format'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,9 +15,6 @@ export async function GET() {
     return ok({ prices, lastUpdatedAt })
   } catch (error) {
     console.error('GET /api/prices error:', error)
-    return NextResponse.json(
-      { error: '주가 정보를 불러오지 못했습니다.' },
-      { status: 500 }
-    )
+    return fail('주가 정보를 불러오지 못했습니다.', 500)
   }
 }

--- a/src/app/api/prices/search/route.ts
+++ b/src/app/api/prices/search/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { searchKrxByName } from '@/lib/krx-stocks'
 import { searchYahooByName } from '@/lib/price-fetcher'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,17 +14,14 @@ export async function GET(request: NextRequest) {
     const q = request.nextUrl.searchParams.get('q')?.trim()
 
     if (!q || q.length < 2) {
-      return NextResponse.json(
-        { error: '검색어는 2자 이상 입력해주세요.' },
-        { status: 400 }
-      )
+      return fail('검색어는 2자 이상 입력해주세요.', 400)
     }
 
     const hasKorean = /[가-힣]/.test(q)
 
     if (hasKorean) {
       const results = await searchKrxByName(q)
-      return NextResponse.json({
+      return ok({
         source: 'krx',
         results: results.map((r) => ({
           ticker: r.ticker,
@@ -34,7 +32,7 @@ export async function GET(request: NextRequest) {
     }
 
     const results = await searchYahooByName(q)
-    return NextResponse.json({
+    return ok({
       source: 'yahoo',
       results: results.map((r) => ({
         ticker: r.symbol,
@@ -45,6 +43,6 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[api] 종목 검색 실패:', error)
-    return NextResponse.json({ error: '종목 검색에 실패했습니다.' }, { status: 500 })
+    return fail('종목 검색에 실패했습니다.', 500)
   }
 }


### PR DESCRIPTION
## 요약

10차 마일스톤 네 번째 sub-PR — 시세 도메인 4 라우트 envelope 통일.

bot/cron 이 lib 직접 호출이라 외부 consumer 영향 없음. 클라이언트 (TradeForm/DividendForm/RefreshButton) 도 이미 envelope 호환.

## 변경 내역

### 라우트 (4 파일)
- `prices/route.ts` — GET 에러 path → `fail()` (성공은 이미 `ok`)
- `prices/refresh/route.ts` — POST (200/429/500) — 30초 throttle + rate limit
- `prices/search/route.ts` — GET (200/400/500) — KRX(한글)/Yahoo(영문) 분기
- `prices/krx-sync/route.ts` — POST (200/429×2/500) — 10분 throttle + 동시 lock

### 외부 consumer 영향 분석
- bot/cron: lib 직접 호출 (`refreshPrices`, `syncKrxStocks`, `searchYahooByName`) → HTTP 미경유 → 영향 0
- TradeForm/DividendForm: `json?.data?.prices` 이미 사용
- RefreshButton: 성공 path body 미사용, 에러 path `data?.error` envelope 호환

### 동시성 가드 유지
- refresh: `lastRefreshAt = now` 가드 위치 보존 (rate-limit 우회 방지)
- krx-sync: `isSyncing` 플래그 + `finally` 해제 패턴 유지

## 체크리스트

- [x] 린트 — 0
- [x] 타입체크 — 0
- [x] 테스트 — 162/162
- [x] 빌드 — Next + MCP + Bot
- [x] 코드 리뷰 — P0/P1/P2: 0/0/0 (429 status 보존, 동시성 가드 무결성, 외부 consumer 호환 확인)

Closes #347