### PR TITLE
[Phase 28-E] ai/ask + backtest envelope (10차 마일스톤 종료) (#349)

### DIFF
--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -13,16 +13,11 @@
 
 ## 응답 envelope (`ApiResponse<T>`)
 
-**신규 라우트** 와 **마이그 완료 라우트** (아래 "적용 범위" 참고) 는 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27).
+모든 API 라우트는 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27/28 — 전체 마이그 완료).
 
 ### 적용 범위
 
-| 상태 | 도메인 |
-|---|---|
-| ✅ 마이그 완료 (27-A~D) | trades, dividends, deposits, transactions, rsu, stock-options, watchlist, recurring, settings, income-profiles, categories, budgets, assets, exports/* (에러 path), 그 외 27-B 단순 GET |
-| ⏳ 마이그 예정 (28차 마일스톤 후보) | accounts, networth, performance/*, prices/*, reports, tax/gift, backtest, ai/ask |
-
-**중요**: 미마이그 라우트의 응답을 envelope 으로 바꾸려면 **반드시 클라이언트 fetcher 도 함께 업데이트** 한다 (envelope 일방 변경은 화면 깨짐을 유발). 신규 라우트는 처음부터 envelope 사용.
+Phase 27 (27-A~E) + Phase 28 (28-A~E) 으로 **모든 도메인 envelope 적용 완료**. 신규 라우트는 처음부터 envelope 사용한다.
 
 ### 예외 (envelope 미적용)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ PM2 ──► myfinance-bot (standalone)        │
 
 - 한국어 UI, 코드/변수명은 영어.
 - 컴포넌트: 함수형 + hooks. default export.
-- API routes: `src/app/api/` 아래 route.ts. try-catch + 신규/마이그 완료 라우트는 `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 미마이그 라우트 변경 시 클라이언트 fetcher 동시 업데이트 필수. 상세 + 적용 범위는 `.claude/rules/api-routes.md`.
+- API routes: `src/app/api/` 아래 route.ts. try-catch + `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 상세는 `.claude/rules/api-routes.md`.
 - DB 접근: 반드시 `@/lib/prisma` singleton. raw query 금지.
 - Trade 생성 시 Holding 업데이트는 Prisma transaction으로 묶기.
 - 금액 응답에 항상 currency 필드 포함. 날짜는 ISO 8601.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -324,10 +324,16 @@
 - [x] **27-D**: pagination meta 통일 + 복잡한 GET (8 라우트 + ExpensesClient/ImportWizard unwrap)
 - [x] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)
 
-### 후속 (10차 마일스톤 후보)
+---
 
-27 시리즈에서 핵심 도메인 53+ 라우트는 마이그 완료. 남은 미마이그 라우트 (16개) 는 다음 마일스톤에서 envelope 화 예정:
+# 10차 마일스톤 — envelope 잔여 마이그
 
-- accounts, networth, performance/*, prices/*, reports/*, tax/gift, backtest, ai/ask
-- 각 라우트마다 클라이언트 fetcher 동시 업데이트 필요 (atomic PR)
-- 가이드 문서 (`.claude/rules/api-routes.md`) 의 "적용 범위" 표를 함께 갱신
+> 27 시리즈에서 빠진 16 라우트를 envelope 으로 정리. 외부 consumer (cron/MCP) 가 lib 직접 호출이라 영향 적음. 5 sub-PR 로 분할.
+
+## Phase 28: envelope 잔여 16 라우트
+
+- [x] **28-A**: accounts (2 라우트)
+- [x] **28-B**: networth + reports + tax/gift (4 라우트, PDF 다운로드 raw 유지)
+- [x] **28-C**: performance/* (4 라우트, cron/MCP lib 직접 호출 — 영향 없음)
+- [x] **28-D**: prices/* (4 라우트, bot/cron lib 직접 호출 — 영향 없음, 429 throttle 보존)
+- [x] **28-E**: ai/ask + backtest (2 라우트) + 가이드 문서 "전체 마이그 완료" 표기 갱신

--- a/docs/specs/349-envelope-28e.md
+++ b/docs/specs/349-envelope-28e.md
@@ -1,0 +1,56 @@
+# [Phase 28-E] ai/ask + backtest envelope 마이그 (10차 마일스톤 종료)
+
+## 목적
+
+10차 마일스톤 (Phase 28) **마지막 sub-PR** — AI/백테스트 도메인 2 라우트 envelope 통일.
+
+본 PR 종료 시 27/28 시리즈 전체 envelope 마이그 완료.
+
+## 라우트 분석
+
+- `/api/ai/ask` POST: 단일 JSON 응답 (스트리밍 아님) — envelope 적용 가능
+- `/api/backtest` POST: 단일 JSON 응답 — envelope 적용 가능. 단 catch 블록이 `error.message` 를 그대로 노출 — `.claude/rules/api-routes.md` 위반. 동시 수정.
+
+## 요구사항
+
+- [ ] `ai/ask/route.ts` POST → `ok({ response, model, durationMs, costUsd })` / `fail(...)`
+  - AdvisorTimeoutError → `fail(504)`
+  - AdvisorError + safe → `fail(error.message, 400)`
+  - 일반 → `fail('AI 응답 처리에 실패했습니다.', 500)`
+- [ ] `backtest/route.ts` POST → `ok({ ...result, currency })` / `fail(...)`
+  - catch 블록의 `error.message` 누출 제거 — 정적 한국어 메시지
+- [ ] 클라이언트 unwrap
+  - `AIClient.tsx`: `data.response` → `data?.data?.response`
+  - `BacktestClient.tsx`: `setResult(data)` → `setResult(data?.data)`
+
+## 기술 설계
+
+### 라우트 변환
+
+| 파일 | 변환 |
+|---|---|
+| `ai/ask/route.ts` POST | 성공 `ok({...})`, 검증/타임아웃/일반 → `fail(msg, status)` |
+| `backtest/route.ts` POST | 성공 `ok({...result, currency})`, 검증/일반 → `fail(msg, status)` (정적 메시지 통일) |
+
+### 클라이언트
+
+- `AIClient.tsx:83-89` — `data.response` → `data?.data?.response` + null guard
+- `BacktestClient.tsx:87-89` — `setResult(data?.data ?? null)` + null guard
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: `/ai` AI 질문, `/backtest` 백테스트 실행
+
+## 제외 사항
+
+- 10차 마일스톤 완료 — 추후 11차 기획 별도
+
+## 10차 마일스톤 종료
+
+5 sub-PR (28-A~E) 완료 시 27+28 시리즈 envelope 마이그 **100%**.
+- 28-A: accounts (#342)
+- 28-B: networth/reports/tax-gift (#344)
+- 28-C: performance/* (#346)
+- 28-D: prices/* (#348)
+- 본 PR (28-E): ai/ask + backtest

--- a/src/app/ai/AIClient.tsx
+++ b/src/app/ai/AIClient.tsx
@@ -83,10 +83,13 @@ export default function AIClient() {
       const data = await res.json()
 
       if (!res.ok) {
-        throw new Error(data.error || 'AI 응답 실패')
+        throw new Error(data?.error || 'AI 응답 실패')
       }
 
-      const aiContent = data.response
+      const aiContent = data?.data?.response
+      if (!aiContent) {
+        throw new Error('AI 응답을 받지 못했습니다.')
+      }
       const aiMsg: Message = {
         id: generateId(),
         role: 'assistant',

--- a/src/app/api/ai/ask/route.ts
+++ b/src/app/api/ai/ask/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   askAdvisor,
   AdvisorTimeoutError,
   AdvisorError,
 } from '@/lib/ai/claude-advisor'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -21,31 +22,22 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { prompt } = body as { prompt?: unknown }
 
     if (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {
-      return NextResponse.json(
-        { error: '질문을 입력해주세요.' },
-        { status: 400 }
-      )
+      return fail('질문을 입력해주세요.', 400)
     }
 
     const result = await askAdvisor(prompt.trim())
 
-    return NextResponse.json({
+    return ok({
       response: result.response,
       model: result.model,
       durationMs: result.durationMs,
@@ -53,23 +45,14 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     if (error instanceof AdvisorTimeoutError) {
-      return NextResponse.json(
-        { error: 'AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.' },
-        { status: 504 }
-      )
+      return fail('AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.', 504)
     }
 
     if (error instanceof AdvisorError && isSafeError(error.message)) {
-      return NextResponse.json(
-        { error: error.message },
-        { status: 400 }
-      )
+      return fail(error.message, 400)
     }
 
     console.error('POST /api/ai/ask error:', error)
-    return NextResponse.json(
-      { error: 'AI 응답 처리에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('AI 응답 처리에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/backtest/route.ts
+++ b/src/app/api/backtest/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { runBacktest } from '@/lib/backtest/engine'
 import { PRESET_STRATEGIES } from '@/lib/backtest/presets'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 120
@@ -12,26 +13,23 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { ticker, strategyKey, days } = body as Record<string, unknown>
 
     if (!ticker || typeof ticker !== 'string') {
-      return NextResponse.json({ error: '종목 티커를 입력해주세요.' }, { status: 400 })
+      return fail('종목 티커를 입력해주세요.', 400)
     }
 
     const key = typeof strategyKey === 'string' ? strategyKey : 'rsi'
     const strategy = PRESET_STRATEGIES[key]
     if (!strategy) {
-      return NextResponse.json(
-        { error: `사용 가능한 전략: ${Object.keys(PRESET_STRATEGIES).join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`사용 가능한 전략: ${Object.keys(PRESET_STRATEGIES).join(', ')}`, 400)
     }
 
     const periodDays = typeof days === 'number' && Number.isInteger(days) && days >= 30 && days <= 3650
@@ -58,10 +56,9 @@ export async function POST(request: NextRequest) {
       commission: 0.0025,
     })
 
-    return NextResponse.json({ ...result, currency })
+    return ok({ ...result, currency })
   } catch (error) {
-    const msg = error instanceof Error ? error.message : '백테스트 실행 실패'
     console.error('POST /api/backtest error:', error)
-    return NextResponse.json({ error: msg }, { status: 500 })
+    return fail('백테스트 실행에 실패했습니다.', 500)
   }
 }

--- a/src/app/backtest/BacktestClient.tsx
+++ b/src/app/backtest/BacktestClient.tsx
@@ -85,8 +85,10 @@ export default function BacktestClient() {
         body: JSON.stringify({ ticker: ticker.trim().toUpperCase(), strategyKey, days }),
       })
       const data = await res.json()
-      if (!res.ok) throw new Error(data.error || '백테스트 실패')
-      setResult(data)
+      if (!res.ok) throw new Error(data?.error || '백테스트 실패')
+      const payload = data?.data
+      if (!payload) throw new Error('백테스트 결과를 받지 못했습니다.')
+      setResult(payload)
     } catch (err) {
       setError(err instanceof Error ? err.message : '알 수 없는 오류')
     } finally {


### PR DESCRIPTION
## 요약

10차 마일스톤 (Phase 28) **마지막 sub-PR** — AI/백테스트 도메인 2 라우트 envelope 통일.

본 PR 종료 시 **27/28 시리즈 envelope 마이그 100% 완료** 🎉 (PDF 다운로드 raw Response 만 27-D 파일 예외 패턴 유지).

## 변경 내역

### 라우트 (2 파일)
- `ai/ask/route.ts` POST — `ok({ response, model, durationMs, costUsd })` / `fail(...)`
  - AdvisorTimeoutError → 504, AdvisorError safe → 400, 그 외 → 500
- `backtest/route.ts` POST — `ok({ ...result, currency })` / `fail(...)`
  - **보안 fix**: catch 블록의 `error.message` 누출 제거 → 정적 한국어 메시지 (`.claude/rules/api-routes.md` 보안 규칙 준수)

### 클라이언트 (2 파일)
- `AIClient.tsx` — `data?.data?.response` unwrap + null guard (응답 결손 시 throw)
- `BacktestClient.tsx` — `setResult(data?.data)` + null guard

### 가이드 문서
- `.claude/rules/api-routes.md` — '적용 범위' 표 제거, '모든 도메인 envelope 적용 완료' 표기
- `CLAUDE.md` — '미마이그 라우트 동시 업데이트' 경고 제거
- `docs/roadmap.md` — 10차 마일스톤 (Phase 28) 항목 신설 + A~E 모두 [x]

## 27 + 28 시리즈 종합

| 마일스톤 | 범위 | 라우트 |
|---|---|---|
| 9차 (Phase 27) | 핵심 도메인 envelope 전면 도입 | 53+ |
| 10차 (Phase 28) | 잔여 16 라우트 정리 (A~E 5 sub-PR) | 16 |
| **합계** | **전체 API envelope** | **70+ 라우트** |

남은 raw Response는 `reports/[id]/download/route.ts` PDF success path 1건 (27-D 파일 응답 예외 패턴, 의도된 유지).

## 체크리스트

- [x] 린트 — 0
- [x] 타입체크 — 0
- [x] 테스트 — 162/162
- [x] 빌드 — Next + MCP + Bot
- [x] 코드 리뷰 — P0/P1/P2: 0/0/0 (status code 보존, error.message 누출 차단, 문서/실제 일관성 확인)

Closes #349