### PR TITLE
Release v0.8.0 — Phase 27 + 28 (ApiResponse envelope 전면 도입)

### DIFF
--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -2,10 +2,123 @@
 
 이 규칙은 src/app/api/**/*.ts 파일에 적용.
 
-- 모든 route handler는 try-catch로 감싸고, 에러 시 `{ error: string }` 형태로 응답
-- DB 접근은 반드시 `@/lib/prisma`의 singleton client 사용
-- Trade 생성 시 Holding 업데이트를 Prisma transaction으로 묶을 것
+## 기본 규칙
+
+- 모든 route handler 는 try-catch 로 감싸고, 에러 응답은 아래 envelope 헬퍼 (`fail`) 사용
+- DB 접근은 반드시 `@/lib/prisma` 의 singleton client 사용
+- Trade 생성 시 Holding 업데이트를 Prisma transaction 으로 묶을 것
 - 금액 관련 응답은 항상 currency 필드 포함
 - 날짜는 ISO 8601 형식으로 반환
-- DELETE 핸들러는 본문 없이 `new NextResponse(null, { status: 204 })` 로 응답. `{ success: true }` 등 wrapper 금지
 - catch 블록에서 `error.message` 를 그대로 노출하지 않는다. 사용자에게 보여도 안전한 비즈니스 예외는 `@/lib/api-errors` 의 `businessErrorResponse(err)` 로 통과시키고, 그 외는 한국어 정적 메시지(`'서버 오류가 발생했습니다.'` 등)로 응답
+
+## 응답 envelope (`ApiResponse<T>`)
+
+**신규 라우트** 와 **마이그 완료 라우트** (아래 "적용 범위" 참고) 는 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27).
+
+### 적용 범위
+
+| 상태 | 도메인 |
+|---|---|
+| ✅ 마이그 완료 (27-A~D) | trades, dividends, deposits, transactions, rsu, stock-options, watchlist, recurring, settings, income-profiles, categories, budgets, assets, exports/* (에러 path), 그 외 27-B 단순 GET |
+| ⏳ 마이그 예정 (28차 마일스톤 후보) | accounts, networth, performance/*, prices/*, reports, tax/gift, backtest, ai/ask |
+
+**중요**: 미마이그 라우트의 응답을 envelope 으로 바꾸려면 **반드시 클라이언트 fetcher 도 함께 업데이트** 한다 (envelope 일방 변경은 화면 깨짐을 유발). 신규 라우트는 처음부터 envelope 사용.
+
+### 예외 (envelope 미적용)
+
+- **파일 응답**: CSV (`csvResponse()`), ICS (`new Response(ics, ...)`), PDF 등 — Content-Disposition 헤더 필요. **에러 path 만** envelope 적용 (`exports/*` 참고).
+- **스트리밍 / SSE**: 비표준 응답 본문.
+
+### 응답 구조
+
+```ts
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: { total: number; limit: number; offset: number }  // pagination 한정
+}
+```
+
+### 헬퍼 사용
+
+| 케이스 | 헬퍼 | 예시 |
+|---|---|---|
+| 성공 (200) | `ok(data)` | `return ok(user)` |
+| 생성 (201) | `ok(data, { status: 201 })` | `return ok(created, { status: 201 })` |
+| 본문 없음 (204/205/304) | `noContent()` | `return noContent()` |
+| 페이지네이션 | `paginated(arr, total, limit, offset)` | `return paginated(trades, total, limit, offset)` |
+| 복합 데이터 + meta | `ok({...}, { meta: { total, limit, offset } })` | transactions GET 같이 집계 필드 + pagination |
+| 에러 | `fail(error, status)` | `return fail('찾을 수 없습니다.', 404)` |
+
+### 패턴 예시
+
+```ts
+import { ok, fail, noContent, paginated } from '@/lib/api-response'
+
+// 단순 조회
+return ok(account)
+
+// 생성
+return ok(created, { status: 201 })
+
+// 페이지네이션
+return paginated(trades, total, limit, offset)
+// → { success: true, data: [...], meta: { total, limit, offset } }
+
+// 집계 + 페이지네이션
+return ok(
+  { transactions, summary, byMonth, byCategory },
+  { meta: { total, limit, offset } },
+)
+
+// 삭제 / 빈 ack
+return noContent()
+// → 204 No Content (body 없음)
+
+// 에러
+return fail('계좌를 찾을 수 없습니다.', 404)
+```
+
+### 비즈니스 예외
+
+화이트리스트 비즈니스 에러는 `businessErrorResponse()` 가 `fail()` 헬퍼로 위임한다:
+
+```ts
+import { businessErrorResponse } from '@/lib/api-errors'
+
+try {
+  // createTrade 등 비즈니스 로직 — "보유 수량 부족" 등 throw
+} catch (error) {
+  const businessResponse = businessErrorResponse(error)
+  if (businessResponse) return businessResponse
+  console.error('POST /api/trades error:', error)
+  return fail('거래 기록에 실패했습니다.', 500)
+}
+```
+
+화이트리스트는 `src/lib/api-errors.ts` 의 `SAFE_BUSINESS_PATTERNS` 에서 관리. 새 비즈니스 예외 메시지를 추가할 때는 우연 매칭을 피하기 위해 패턴을 명시적으로 잠근다.
+
+### 클라이언트 사용
+
+클라이언트 fetcher 는 envelope 의 `data` / `meta` / `error` 를 unwrap 한다:
+
+```ts
+const res = await fetch('/api/foo')
+const json = await res.json()
+if (!res.ok) {
+  setError(json?.error ?? '요청 실패')
+  return
+}
+const items = json?.data ?? []
+const total = json?.meta?.total ?? 0
+```
+
+## 신규 라우트 작성 체크리스트
+
+- [ ] `@/lib/api-response` 에서 `ok` / `fail` / `noContent` / `paginated` 사용
+- [ ] try-catch 로 감싸고 catch 블록은 한국어 정적 메시지
+- [ ] 비즈니스 예외가 있다면 `businessErrorResponse()` 통과
+- [ ] DB 접근은 `@/lib/prisma` singleton + transaction 필요 시 묶기
+- [ ] 금액은 currency 필드, 날짜는 ISO 8601
+- [ ] DELETE / 빈 응답은 `noContent()` (204), `{ success: true }` wrapper 금지

--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -13,16 +13,11 @@
 
 ## 응답 envelope (`ApiResponse<T>`)
 
-**신규 라우트** 와 **마이그 완료 라우트** (아래 "적용 범위" 참고) 는 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27).
+모든 API 라우트는 `@/lib/api-response` 의 헬퍼를 사용해 통일된 envelope 으로 반환한다 (Phase 27/28 — 전체 마이그 완료).
 
 ### 적용 범위
 
-| 상태 | 도메인 |
-|---|---|
-| ✅ 마이그 완료 (27-A~D) | trades, dividends, deposits, transactions, rsu, stock-options, watchlist, recurring, settings, income-profiles, categories, budgets, assets, exports/* (에러 path), 그 외 27-B 단순 GET |
-| ⏳ 마이그 예정 (28차 마일스톤 후보) | accounts, networth, performance/*, prices/*, reports, tax/gift, backtest, ai/ask |
-
-**중요**: 미마이그 라우트의 응답을 envelope 으로 바꾸려면 **반드시 클라이언트 fetcher 도 함께 업데이트** 한다 (envelope 일방 변경은 화면 깨짐을 유발). 신규 라우트는 처음부터 envelope 사용.
+Phase 27 (27-A~E) + Phase 28 (28-A~E) 으로 **모든 도메인 envelope 적용 완료**. 신규 라우트는 처음부터 envelope 사용한다.
 
 ### 예외 (envelope 미적용)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ PM2 ──► myfinance-bot (standalone)        │
 
 - 한국어 UI, 코드/변수명은 영어.
 - 컴포넌트: 함수형 + hooks. default export.
-- API routes: `src/app/api/` 아래 route.ts. try-catch + 신규/마이그 완료 라우트는 `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 미마이그 라우트 변경 시 클라이언트 fetcher 동시 업데이트 필수. 상세 + 적용 범위는 `.claude/rules/api-routes.md`.
+- API routes: `src/app/api/` 아래 route.ts. try-catch + `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 상세는 `.claude/rules/api-routes.md`.
 - DB 접근: 반드시 `@/lib/prisma` singleton. raw query 금지.
 - Trade 생성 시 Holding 업데이트는 Prisma transaction으로 묶기.
 - 금액 응답에 항상 currency 필드 포함. 날짜는 ISO 8601.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ PM2 ──► myfinance-bot (standalone)        │
 
 - 한국어 UI, 코드/변수명은 영어.
 - 컴포넌트: 함수형 + hooks. default export.
-- API routes: `src/app/api/` 아래 route.ts. try-catch + `{ error: string }` 에러 응답.
+- API routes: `src/app/api/` 아래 route.ts. try-catch + 신규/마이그 완료 라우트는 `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 헬퍼 사용 (envelope `{ success, data?, error?, meta? }`). 미마이그 라우트 변경 시 클라이언트 fetcher 동시 업데이트 필수. 상세 + 적용 범위는 `.claude/rules/api-routes.md`.
 - DB 접근: 반드시 `@/lib/prisma` singleton. raw query 금지.
 - Trade 생성 시 Holding 업데이트는 Prisma transaction으로 묶기.
 - 금액 응답에 항상 currency 필드 포함. 날짜는 ISO 8601.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -313,7 +313,7 @@
 
 ## Phase 27: ApiResponse envelope 전면 도입
 
-- [ ] **27-A**: `ApiResponse<T>` 타입 + 헬퍼 (`ok`, `fail`, `paginated`) + 단위 테스트
+- [x] **27-A**: `ApiResponse<T>` 타입 + 헬퍼 (`ok` / `fail` / `paginated` / `noContent`) + 16 단위 테스트
 - [ ] **27-B**: 신규/단순 GET 라우트 마이그 (~15) + 클라이언트 fetcher 업데이트
 - [ ] **27-C**: POST/PUT/DELETE 마이그 (단일 도메인씩, ~20 라우트 + Form/EditPanel)
 - [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -322,4 +322,12 @@
   - [x] **27-C-4**: RSU + StockOption (7 라우트 + 1 fetcher)
   - [x] **27-C-5**: Trade (3 라우트 + 3 fetcher + api-errors 헬퍼 통일)
 - [x] **27-D**: pagination meta 통일 + 복잡한 GET (8 라우트 + ExpensesClient/ImportWizard unwrap)
-- [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)
+- [x] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)
+
+### 후속 (10차 마일스톤 후보)
+
+27 시리즈에서 핵심 도메인 53+ 라우트는 마이그 완료. 남은 미마이그 라우트 (16개) 는 다음 마일스톤에서 envelope 화 예정:
+
+- accounts, networth, performance/*, prices/*, reports/*, tax/gift, backtest, ai/ask
+- 각 라우트마다 클라이언트 fetcher 동시 업데이트 필요 (atomic PR)
+- 가이드 문서 (`.claude/rules/api-routes.md`) 의 "적용 범위" 표를 함께 갱신

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -318,7 +318,7 @@
 - [ ] **27-C**: POST/PUT/DELETE + 일부 GET 마이그 (5 sub-PR 분할)
   - [x] **27-C-1**: Watchlist + Recurring + Settings + IncomeProfile (7 라우트 16 메소드)
   - [x] **27-C-2**: Category + Budget + Asset (9 라우트 + 2 fetcher)
-  - [ ] **27-C-3**: Dividend + Deposit + Transaction
+  - [x] **27-C-3**: Dividend + Deposit + Transaction (9 라우트 + 2 fetcher)
   - [ ] **27-C-4**: RSU + StockOption
   - [ ] **27-C-5**: Trade
 - [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -324,10 +324,16 @@
 - [x] **27-D**: pagination meta 통일 + 복잡한 GET (8 라우트 + ExpensesClient/ImportWizard unwrap)
 - [x] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)
 
-### 후속 (10차 마일스톤 후보)
+---
 
-27 시리즈에서 핵심 도메인 53+ 라우트는 마이그 완료. 남은 미마이그 라우트 (16개) 는 다음 마일스톤에서 envelope 화 예정:
+# 10차 마일스톤 — envelope 잔여 마이그
 
-- accounts, networth, performance/*, prices/*, reports/*, tax/gift, backtest, ai/ask
-- 각 라우트마다 클라이언트 fetcher 동시 업데이트 필요 (atomic PR)
-- 가이드 문서 (`.claude/rules/api-routes.md`) 의 "적용 범위" 표를 함께 갱신
+> 27 시리즈에서 빠진 16 라우트를 envelope 으로 정리. 외부 consumer (cron/MCP) 가 lib 직접 호출이라 영향 적음. 5 sub-PR 로 분할.
+
+## Phase 28: envelope 잔여 16 라우트
+
+- [x] **28-A**: accounts (2 라우트)
+- [x] **28-B**: networth + reports + tax/gift (4 라우트, PDF 다운로드 raw 유지)
+- [x] **28-C**: performance/* (4 라우트, cron/MCP lib 직접 호출 — 영향 없음)
+- [x] **28-D**: prices/* (4 라우트, bot/cron lib 직접 호출 — 영향 없음, 429 throttle 보존)
+- [x] **28-E**: ai/ask + backtest (2 라우트) + 가이드 문서 "전체 마이그 완료" 표기 갱신

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -315,6 +315,11 @@
 
 - [x] **27-A**: `ApiResponse<T>` 타입 + 헬퍼 (`ok` / `fail` / `paginated` / `noContent`) + 16 단위 테스트
 - [x] **27-B**: 단순 GET 라우트 마이그 (10 라우트 + 13 fetcher, atomic)
-- [ ] **27-C**: POST/PUT/DELETE 마이그 (단일 도메인씩, ~20 라우트 + Form/EditPanel)
+- [ ] **27-C**: POST/PUT/DELETE + 일부 GET 마이그 (5 sub-PR 분할)
+  - [x] **27-C-1**: Watchlist + Recurring + Settings + IncomeProfile (7 라우트 16 메소드)
+  - [ ] **27-C-2**: Category + Budget + Asset
+  - [ ] **27-C-3**: Dividend + Deposit + Transaction
+  - [ ] **27-C-4**: RSU + StockOption
+  - [ ] **27-C-5**: Trade
 - [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)
 - [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -315,11 +315,11 @@
 
 - [x] **27-A**: `ApiResponse<T>` 타입 + 헬퍼 (`ok` / `fail` / `paginated` / `noContent`) + 16 단위 테스트
 - [x] **27-B**: 단순 GET 라우트 마이그 (10 라우트 + 13 fetcher, atomic)
-- [ ] **27-C**: POST/PUT/DELETE + 일부 GET 마이그 (5 sub-PR 분할)
+- [x] **27-C**: POST/PUT/DELETE + 일부 GET 마이그 (5 sub-PR 완료)
   - [x] **27-C-1**: Watchlist + Recurring + Settings + IncomeProfile (7 라우트 16 메소드)
   - [x] **27-C-2**: Category + Budget + Asset (9 라우트 + 2 fetcher)
   - [x] **27-C-3**: Dividend + Deposit + Transaction (9 라우트 + 2 fetcher)
   - [x] **27-C-4**: RSU + StockOption (7 라우트 + 1 fetcher)
-  - [ ] **27-C-5**: Trade
+  - [x] **27-C-5**: Trade (3 라우트 + 3 fetcher + api-errors 헬퍼 통일)
 - [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)
 - [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -317,7 +317,7 @@
 - [x] **27-B**: 단순 GET 라우트 마이그 (10 라우트 + 13 fetcher, atomic)
 - [ ] **27-C**: POST/PUT/DELETE + 일부 GET 마이그 (5 sub-PR 분할)
   - [x] **27-C-1**: Watchlist + Recurring + Settings + IncomeProfile (7 라우트 16 메소드)
-  - [ ] **27-C-2**: Category + Budget + Asset
+  - [x] **27-C-2**: Category + Budget + Asset (9 라우트 + 2 fetcher)
   - [ ] **27-C-3**: Dividend + Deposit + Transaction
   - [ ] **27-C-4**: RSU + StockOption
   - [ ] **27-C-5**: Trade

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -304,3 +304,17 @@
 - [x] **26-C**: GET 쿼리 파라미터 Zod 검증 (zod-schemas lib + 8 라우트 + 26 단위 테스트)
 - [x] **26-D**: Generic 성공 토스트 확장 (22 컴포넌트: 9 DeleteModal + 13 Form/EditPanel)
 - [x] **26-F**: 베스팅 iCal 내보내기 (RFC 5545 + line folding + CR 정규화 + 145 단위 테스트)
+
+---
+
+# 9차 마일스톤 — 응답 envelope `ApiResponse<T>` 전면 도입
+
+> 25-E (API 응답 형식 일관화) 후속 — DELETE 204 / 비즈니스 에러 헬퍼는 끝났지만 **성공 응답 형식** 은 라우트마다 다름. 53 라우트 + 40+ 클라이언트 fetcher 영향 범위 → 단독 마일스톤. 점진 적용 (sub-phase 단위) 으로 안전하게.
+
+## Phase 27: ApiResponse envelope 전면 도입
+
+- [ ] **27-A**: `ApiResponse<T>` 타입 + 헬퍼 (`ok`, `fail`, `paginated`) + 단위 테스트
+- [ ] **27-B**: 신규/단순 GET 라우트 마이그 (~15) + 클라이언트 fetcher 업데이트
+- [ ] **27-C**: POST/PUT/DELETE 마이그 (단일 도메인씩, ~20 라우트 + Form/EditPanel)
+- [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)
+- [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -319,7 +319,7 @@
   - [x] **27-C-1**: Watchlist + Recurring + Settings + IncomeProfile (7 라우트 16 메소드)
   - [x] **27-C-2**: Category + Budget + Asset (9 라우트 + 2 fetcher)
   - [x] **27-C-3**: Dividend + Deposit + Transaction (9 라우트 + 2 fetcher)
-  - [ ] **27-C-4**: RSU + StockOption
+  - [x] **27-C-4**: RSU + StockOption (7 라우트 + 1 fetcher)
   - [ ] **27-C-5**: Trade
 - [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)
 - [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -321,5 +321,5 @@
   - [x] **27-C-3**: Dividend + Deposit + Transaction (9 라우트 + 2 fetcher)
   - [x] **27-C-4**: RSU + StockOption (7 라우트 + 1 fetcher)
   - [x] **27-C-5**: Trade (3 라우트 + 3 fetcher + api-errors 헬퍼 통일)
-- [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)
+- [x] **27-D**: pagination meta 통일 + 복잡한 GET (8 라우트 + ExpensesClient/ImportWizard unwrap)
 - [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -314,7 +314,7 @@
 ## Phase 27: ApiResponse envelope 전면 도입
 
 - [x] **27-A**: `ApiResponse<T>` 타입 + 헬퍼 (`ok` / `fail` / `paginated` / `noContent`) + 16 단위 테스트
-- [ ] **27-B**: 신규/단순 GET 라우트 마이그 (~15) + 클라이언트 fetcher 업데이트
+- [x] **27-B**: 단순 GET 라우트 마이그 (10 라우트 + 13 fetcher, atomic)
 - [ ] **27-C**: POST/PUT/DELETE 마이그 (단일 도메인씩, ~20 라우트 + Form/EditPanel)
 - [ ] **27-D**: pagination meta 통일 + 복잡한 GET (trades/deposits/dividends/exports/*, 8 라우트)
 - [ ] **27-E**: 가이드 문서 갱신 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

--- a/docs/specs/321-api-response-envelope.md
+++ b/docs/specs/321-api-response-envelope.md
@@ -1,0 +1,108 @@
+# [Phase 27-A] ApiResponse envelope 인프라 구축
+
+## 목적
+
+9차 마일스톤의 첫 단계 — `ApiResponse<T>` 타입 + 헬퍼 (`ok`, `fail`, `paginated`) 신규 lib 구축. 라우트/클라이언트 마이그는 후속 sub-phase (27-B~D) 에서 진행.
+
+이 PR 은 **호환성 100% 보장** — 인프라만 추가, 기존 라우트 변경 없음.
+
+## 배경
+
+- 25-E (API 응답 일관화) 후속: DELETE 204 / 비즈니스 에러 헬퍼는 완료, **성공 응답 형식** 은 라우트마다 불일치
+- `.claude/rules/common/patterns.md` 의 권장 envelope 형식 미사용
+- 점진 마이그 (53 라우트 + 40+ fetcher) 전 인프라 먼저
+
+## 요구사항
+
+- [ ] `src/lib/api-response.ts` 신규
+  - `ApiResponse<T>` 타입
+  - `ok<T>(data: T, { status?, meta? }?): NextResponse` (no-body status 자동 분기)
+  - `noContent(status = 204): NextResponse` (204/205/304 전용)
+  - `fail(error: string, status?): NextResponse`
+  - `paginated<T>(data: T[], total: number, limit: number, offset: number, status?): NextResponse`
+- [ ] 단위 테스트 (`__tests__/api-response.test.ts`)
+- [ ] 라우트/클라이언트 변경 **없음** (호환 100%)
+
+## 기술 설계
+
+### 1. 타입
+
+```ts
+// src/lib/api-response.ts
+import { NextResponse } from 'next/server'
+
+export interface ApiResponseMeta {
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: ApiResponseMeta
+}
+```
+
+### 2. 헬퍼
+
+```ts
+export function ok<T>(data: T, init?: { status?: number; meta?: ApiResponseMeta }): NextResponse {
+  const body: ApiResponse<T> = { success: true, data }
+  if (init?.meta) body.meta = init.meta
+  return NextResponse.json(body, { status: init?.status ?? 200 })
+}
+
+export function fail(error: string, status = 400): NextResponse {
+  const body: ApiResponse<never> = { success: false, error }
+  return NextResponse.json(body, { status })
+}
+
+export function paginated<T>(
+  data: T[],
+  total: number,
+  limit: number,
+  offset: number,
+  status = 200,
+): NextResponse {
+  return ok(data, { status, meta: { total, limit, offset } })
+}
+```
+
+### 3. 시그니처 결정 이유
+
+- `ok` 의 `status` 옵션 — 201 Created 같은 케이스 지원
+- `fail` 의 status 기본 400 — 가장 흔한 클라이언트 오류
+- `paginated` 은 `ok` 를 wrap — DRY
+- `data: T` 직접 임베드 — `null` 도 허용 가능 (`ok<null>(null)` — DELETE 단계로 가능 case 대비)
+
+### 4. 단위 테스트 케이스
+
+- `ok(data)` → `{ success: true, data }` + status 200
+- `ok(data, { status: 201 })` → status 201
+- `ok(data, { meta })` → meta 포함
+- `fail('error')` → `{ success: false, error }` + status 400
+- `fail('error', 500)` → status 500
+- `paginated([], 0, 10, 0)` → meta 포함 + status 200
+- Content-Type `application/json`
+
+## 호환성
+
+- 기존 라우트 / 클라이언트 변경 **0건**
+- 새 lib 만 추가
+- 라우트 마이그는 27-B 부터 점진적
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 7~8 케이스
+- 회귀 없음 (기존 145 테스트 + 신규 ~7)
+
+## 제외 사항
+
+- 라우트 마이그 (27-B/C/D)
+- 클라이언트 fetcher 업데이트 (27-B/C 와 함께)
+- 가이드 문서 (27-E)
+- error code/타입 enum (필요 시 후속 phase)
+- success: boolean 외 상세 status 필드 (KISS)

--- a/docs/specs/323-simple-get-envelope.md
+++ b/docs/specs/323-simple-get-envelope.md
@@ -1,0 +1,93 @@
+# [Phase 27-B] 단순 GET 라우트 ApiResponse envelope 마이그
+
+## 목적
+
+9차 마일스톤의 두 번째 단계 — 27-A 에서 도입한 `ok()`/`fail()` 헬퍼를 **단순 GET 라우트 10개** + 클라이언트 fetcher 13개에 적용. pagination 가진 라우트는 27-D, GET/PUT 짝은 27-C 로 별도 진행.
+
+## 배경
+
+- 27-A: `ApiResponse<T>` 헬퍼 인프라 구축 완료 (162 단위 테스트)
+- 현재 라우트별 응답 형식이 제각각 (`{ accounts }`, `{ items: [] }`, raw array 등)
+- 점진 마이그 — breaking change 라 같은 PR 에 라우트 + fetcher 동시 변경 필수
+
+## 요구사항
+
+- [ ] 10 GET 라우트 응답 형식을 `ok(data)` 로 통일
+- [ ] 13 클라이언트 fetcher 가 `json.data` 로 unwrap
+- [ ] 라우트와 fetcher 동시 변경 (atomic — breaking change 회피)
+- [ ] 다른 메소드 (POST/PUT/DELETE) 는 변경 없음 (도메인별로 27-C 에서 진행)
+
+## 기술 설계
+
+### 1. 마이그 대상 라우트 / 변환
+
+| # | 라우트 | before | after |
+|---|---|---|---|
+| 1 | `/api/accounts` | `NextResponse.json({ accounts })` | `ok(accounts)` |
+| 2 | `/api/prices` | `NextResponse.json({ prices, lastUpdatedAt })` | `ok({ prices, lastUpdatedAt })` |
+| 3 | `/api/categories` | `NextResponse.json({ categories })` | `ok(categories)` |
+| 4 | `/api/watchlist` | `NextResponse.json({ items })` | `ok(items)` |
+| 5 | `/api/recurring` | `NextResponse.json({ items })` | `ok(items)` |
+| 6 | `/api/reports` | `NextResponse.json({ reports })` | `ok(reports)` |
+| 7 | `/api/category-groups` | `NextResponse.json({ groups })` | `ok(groups)` |
+| 8 | `/api/income-profiles` | `NextResponse.json(profiles)` (raw) | `ok(profiles)` |
+| 9 | `/api/rsu` | `NextResponse.json({ schedules })` | `ok(schedules)` |
+| 10 | `/api/stock-options` | `NextResponse.json({ stockOptions })` | `ok(stockOptions)` |
+
+에러 응답은 그대로 (`fail()` 마이그는 27-C 와 함께 — POST/PUT 의 catch 와 일관 정리).
+
+### 2. 클라이언트 fetcher 패턴 변환
+
+```ts
+// before
+const res = await fetch('/api/accounts')
+const data = await res.json()
+setAccounts(data.accounts)
+
+// after
+const res = await fetch('/api/accounts')
+const json = await res.json()
+setAccounts(json.data)
+```
+
+### 3. 영향 받는 클라이언트 파일 (8개 추정)
+
+- `SettingsClient.tsx` — `/api/accounts`
+- `TradeForm.tsx`, `DividendForm.tsx` — `/api/prices`
+- `ExpensesClient.tsx`, `BudgetsClient.tsx`, `WhooingSettings.tsx` — `/api/categories`
+- `WatchlistClient.tsx` — `/api/watchlist`
+- `RecurringClient.tsx` — `/api/recurring`
+- `ReportsClient.tsx` — `/api/reports`
+- `CategoryEditPanel.tsx` — `/api/category-groups`
+- `IncomeProfileManager.tsx` — `/api/income-profiles`
+- `RSUDashboard.tsx` — `/api/rsu`
+
+### 4. 봇 MCP / 서버컴포넌트 영향
+
+- 봇 standalone 은 prisma 직접 호출 — 라우트 fetch 안 함 (영향 0)
+- MCP 서버는 자체 prisma 호출 (영향 0)
+- 서버 컴포넌트는 prisma 직접 호출 (영향 0)
+
+→ 영향은 클라이언트 컴포넌트만.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 추가 안 함 (27-A 의 ApiResponse 테스트가 헬퍼 자체 검증)
+- 수동 회귀:
+  - 10 라우트가 접근하는 화면 정상 표시
+  - 각 페이지 새로고침 후 fetcher 정상 동작
+  - 에러 케이스 (인증 미통과 등) — 기존 동작 유지
+
+## 제외 사항
+
+- 동일 라우트의 POST/PUT/DELETE 응답 (27-C 와 함께)
+- 에러 응답 (`fail()` 마이그) — 27-C 와 함께
+- pagination GET (trades/deposits/dividends/transactions) — 27-D
+- GET/PUT 짝 라우트 (alerts/config, settings/whooing 등) — 27-C
+- CSV/ICS/PDF 응답 — 영구 스킵 (envelope 불가)
+
+## 호환성
+
+- 라우트와 fetcher 같은 PR 에 묶어 atomic 마이그
+- 다른 라우트는 영향 0 (점진)

--- a/docs/specs/325-envelope-c1.md
+++ b/docs/specs/325-envelope-c1.md
@@ -1,0 +1,86 @@
+# [Phase 27-C-1] Watchlist + Recurring + Settings + IncomeProfile envelope 마이그
+
+## 목적
+
+9차 마일스톤의 세 번째 단계 — 27-A 의 `ok` / `fail` / `noContent` 헬퍼를 **위험도 낮은 4개 도메인** (watchlist, recurring, settings, income-profiles) 의 POST/PUT/PATCH/DELETE + 일부 GET 에 적용. 27-C 의 5 sub-PR 중 첫 번째.
+
+## 배경
+
+- 27-B 에서 단순 GET 10 라우트 + 13 fetcher 마이그 완료
+- 27-C 는 도메인별 5 sub-PR 로 분할 (계획 확정)
+- C-1 은 **가장 단순한 4 도메인** — 패턴 검증 + 다음 sub-phase 의 기반
+
+## 요구사항
+
+- [ ] 7 라우트 파일의 모든 메소드 응답을 envelope 으로 마이그
+  - `watchlist` POST + `watchlist/[id]` PUT/DELETE
+  - `recurring` POST + `recurring/[id]` PUT/PATCH/DELETE
+  - `alerts/config` GET/PUT
+  - `settings/whooing` GET/PUT
+  - `settings/whooing/mappings` GET/PUT
+  - `income-profiles` POST + `income-profiles/[id]` PUT/DELETE
+- [ ] 에러 응답도 `fail(message, status)` 로 통일
+- [ ] 클라이언트 fetcher 가 envelope 형식에 맞춰 unwrap
+- [ ] atomic (라우트 + fetcher 같은 PR)
+
+## 기술 설계
+
+### 1. 라우트 변환 패턴
+
+| 케이스 | before | after |
+|---|---|---|
+| POST 성공 (201) | `NextResponse.json(item, { status: 201 })` | `ok(item, { status: 201 })` |
+| PUT 성공 | `NextResponse.json(updated)` | `ok(updated)` |
+| PATCH 성공 | `NextResponse.json({ id, isActive })` | `ok({ id, isActive })` |
+| DELETE 성공 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| GET 성공 | `NextResponse.json({ configs })` | `ok(configs)` |
+| 에러 응답 | `NextResponse.json({ error }, { status: N })` | `fail(error, N)` |
+
+### 2. 영향 라우트 (16 메소드 / 7 파일)
+
+| 파일 | 메소드 | 응답 |
+|---|---|---|
+| `watchlist/route.ts` | POST | `ok(item, { status: 201 })` |
+| `watchlist/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `recurring/route.ts` | POST | `ok(item, { status: 201 })` |
+| `recurring/[id]/route.ts` | PUT, PATCH, DELETE | `ok(item)`, `ok({id, isActive})`, `noContent()` |
+| `alerts/config/route.ts` | GET, PUT | `ok(configs)`, `ok(updated)` |
+| `settings/whooing/route.ts` | GET, PUT | `ok({...})`, `ok({...})` |
+| `settings/whooing/mappings/route.ts` | GET, PUT | `ok(mappings)`, `ok(updated)` |
+| `income-profiles/route.ts` | POST | `ok(profile, { status: 201 })` |
+| `income-profiles/[id]/route.ts` | PUT, DELETE | `ok(profile)`, `noContent()` |
+
+### 3. 클라이언트 fetcher
+
+POST/PUT/PATCH 응답 본문을 사용하는 곳만:
+- `WatchlistForm`: POST/PUT 결과 — 사용 여부 확인 (대부분 `res.ok` 만 봄)
+- `RecurringForm`: POST/PUT 결과
+- `RecurringClient`: PATCH 결과 (`isActive` 토글)
+- `IncomeProfileForm`: POST/PUT 결과
+- `WhooingSettings`: GET 응답 사용 (이미 사용 중) + PUT 결과
+- alerts/config 호출자
+
+DELETE 호출자는 `res.ok` 만 보므로 변경 없음 (DELETE 인 만큼).
+에러 응답 클라이언트 처리도 변경 없음 (envelope 의 `error` 필드 동일).
+
+### 4. 추가 작업
+
+- 모든 catch 블록의 `NextResponse.json({ error: ... }, { status: 500 })` → `fail(message, 500)`
+- 비즈니스 에러 헬퍼 (`businessErrorResponse`) 사용처는 그대로 유지 (envelope 형식 호환 — 후속 검토)
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 추가 안 함 (27-A 헬퍼 검증으로 충분)
+- 수동 회귀:
+  - 관심종목 추가/수정/삭제
+  - 반복 거래 추가/수정/일시정지/삭제
+  - 후잉 설정 저장
+  - 근로소득 프로필 추가/수정/삭제
+  - 알림 설정 변경
+
+## 제외 사항
+
+- POST 응답 본문을 사용하지 않는 호출자는 unwrap 변경 불필요
+- 같은 도메인의 단순 GET 은 27-B 에서 완료
+- 다른 도메인 (category/budget/asset, dividend/deposit/transaction, rsu/stock-option, trade) — 27-C-2 ~ C-5

--- a/docs/specs/327-envelope-c2.md
+++ b/docs/specs/327-envelope-c2.md
@@ -1,0 +1,80 @@
+# [Phase 27-C-2] Category + Budget + Asset envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 두 번째 — 자금 분류 관련 3 도메인 (categories/category-groups, budgets, assets) 의 모든 메소드를 `ok`/`fail`/`noContent` 헬퍼로 마이그. budgets GET, assets GET 같은 GET/POST 짝 라우트도 함께 (응답 형식이 복잡해 atomic 변경 필수).
+
+## 배경
+
+- 27-C-1 (Watchlist/Recurring/Settings/IncomeProfile) 완료 (PR #326)
+- 27-C-2 은 두 번째 sub-PR — 27-C-1 보다 약간 큰 규모 (9 라우트 + 7 fetcher)
+- 카테고리 reorder (POST) 도 함께 envelope 화
+
+## 요구사항
+
+- [ ] 9 라우트 파일의 모든 메소드 응답을 envelope 으로
+  - `categories` (POST) + `categories/[id]` (PUT/DELETE) + `categories/reorder` (POST)
+  - `category-groups` (POST) + `category-groups/[id]` (PUT/DELETE)
+  - `budgets` (GET/POST) + `budgets/[id]` (DELETE)
+  - `assets` (GET/POST) + `assets/[id]` (PUT/DELETE)
+- [ ] 에러 응답도 `fail()` 로 통일
+- [ ] 클라이언트 fetcher 7개 unwrap
+- [ ] atomic (라우트 + fetcher 같은 PR)
+
+## 기술 설계
+
+### 1. 라우트 변환 (16 메소드 / 9 파일)
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `categories/route.ts` | POST | `ok(category, { status: 201 })` |
+| `categories/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `categories/reorder/route.ts` | POST | `noContent()` (이미 204 응답) |
+| `category-groups/route.ts` | POST | `ok(group, { status: 201 })` |
+| `category-groups/[id]/route.ts` | PUT, DELETE | `ok(group)`, `noContent()` |
+| `budgets/route.ts` | GET | `ok({ year, month, totalBudget, ... })` |
+| `budgets/route.ts` | POST (upsert) | `ok(budget, { status: created ? 201 : 200 })` |
+| `budgets/route.ts` (copy 액션) | POST | `ok({ copied, targetYear, targetMonth })` |
+| `budgets/[id]/route.ts` | DELETE | `noContent()` |
+| `assets/route.ts` | GET | `ok({ assets, totalAssets, totalLiabilities, netAssets })` |
+| `assets/route.ts` | POST | `ok(asset, { status: 201 })` |
+| `assets/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+
+### 2. 클라이언트 fetcher unwrap (7개)
+
+- `CategoryForm` (POST), `CategoryEditPanel` (PUT) — 응답 본문 미사용 → 변경 없음
+- `CategoryDeleteModal` (DELETE) → 변경 없음
+- `CategoryTable` (reorder POST) — `res.ok` 만 → 변경 없음
+- `BudgetManager` (GET 응답 본문 사용 — 복잡) — **변경 필요**
+- `BudgetManager` (POST upsert + copy 응답) — 본문 사용 여부 확인
+- `AssetForm` (POST/PUT 응답) — 본문 사용 여부 확인
+- `AssetDeleteModal` (DELETE) → 변경 없음
+- 서버 컴포넌트가 `/api/assets` GET 직접 호출하지 않는지 (prisma 사용 권장)
+
+### 3. 변환 패턴 (27-C-1 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+### 4. 다중 필드 에러
+
+`{ error: errors[0].message, errors }` 패턴 (categories POST, budgets POST 등) → `fail(errors[0].message, 400)`. 클라이언트가 `errors` 배열 미사용 (27-C-1 grep 확인됨).
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 카테고리 추가/수정/삭제/순서 변경
+  - 카테고리 그룹 추가/수정/삭제
+  - 예산 페이지 조회, 추가, 삭제, 월별 복사
+  - 자산 페이지 조회, 추가, 수정, 삭제
+
+## 제외 사항
+
+- 같은 도메인의 단순 GET 은 27-B 에서 완료 (`/api/categories` GET, `/api/category-groups` GET)
+- 다른 도메인 (dividend/deposit/transaction, rsu/stock-option, trade) — 27-C-3/4/5
+- pagination 라우트 (trades/deposits/dividends/transactions) — 27-D

--- a/docs/specs/329-envelope-c3.md
+++ b/docs/specs/329-envelope-c3.md
@@ -1,0 +1,71 @@
+# [Phase 27-C-3] Dividend + Deposit + Transaction envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 세 번째 — 자금 mutation 핵심 3 도메인 (dividends/deposits/transactions) 의 POST/PUT/DELETE + 분석/검색 GET 들을 envelope 으로 마이그. GET pagination (메인 list 라우트) 은 27-D 로 분리.
+
+## 배경
+
+- 27-C-1 (Watchlist/Recurring/Settings/IncomeProfile), 27-C-2 (Category/Budget/Asset) 완료
+- 27-C-3 은 자금 mutation 도메인 — Form/EditPanel 가 많아 클라이언트 영향 검증 중요
+- pagination GET (dividends/deposits/transactions list) 은 27-D 에서 별도
+
+## 요구사항
+
+- [ ] 9 라우트 파일 마이그
+  - `dividends/route.ts` (POST), `dividends/[id]/route.ts` (PUT/DELETE), `dividends/summary/route.ts` (GET)
+  - `deposits/route.ts` (POST), `deposits/[id]/route.ts` (PUT/DELETE)
+  - `transactions/route.ts` (POST), `transactions/[id]/route.ts` (PUT/DELETE)
+  - `transactions/analysis/route.ts` (GET), `transactions/suggest/route.ts` (GET)
+- [ ] 메인 list GET (dividends/deposits/transactions) 은 27-D 별도
+- [ ] 클라이언트 fetcher unwrap (응답 본문 사용처만)
+
+## 기술 설계
+
+### 1. 라우트 변환 (~15 메소드)
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `dividends/route.ts` | POST | `ok(dividend, { status: 201 })` (GET 은 27-D) |
+| `dividends/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `dividends/summary/route.ts` | GET | `ok({ year, totalNetKRW, ... byAccount, byTicker, byMonth })` |
+| `deposits/route.ts` | POST | `ok(deposit, { status: 201 })` (GET 은 27-D) |
+| `deposits/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `transactions/route.ts` | POST | `ok(transaction, { status: 201 })` (GET 은 27-D) |
+| `transactions/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `transactions/analysis/route.ts` | GET | `ok({ monthCompare, prevMonthSummary, trend })` |
+| `transactions/suggest/route.ts` | GET | `ok(suggestions)` (배열) 또는 객체 |
+
+### 2. 클라이언트 fetcher
+
+대부분 Form/EditPanel/DeleteModal — `res.ok` 만 확인:
+- DividendForm/EditPanel/DeleteModal — 응답 본문 미사용
+- DepositForm/EditPanel/DeleteModal — 동일
+- TransactionForm/DeleteModal — 동일
+
+응답 본문 사용:
+- DividendSummary 컴포넌트 (summary GET) — **확인 필요**
+- 가계부 분석 페이지 (analysis GET) — **확인 필요**
+- TransactionForm 카테고리 추천 (suggest GET) — **확인 필요**
+
+### 3. 변환 패턴 (이전 sub-phase 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 배당 등록/수정/삭제 + 배당 요약 페이지
+  - 입금 등록/수정/삭제
+  - 거래 등록/수정/삭제 + 분석/추천
+
+## 제외 사항
+
+- 메인 list GET (`/api/dividends`, `/api/deposits`, `/api/transactions`) — pagination 27-D 에서
+- 다른 도메인 (rsu/stock-option/trade) — 27-C-4, C-5

--- a/docs/specs/331-envelope-c4.md
+++ b/docs/specs/331-envelope-c4.md
@@ -1,0 +1,72 @@
+# [Phase 27-C-4] RSU + StockOption envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 네 번째 — RSU 스케줄 + 스톡옵션 도메인의 mutation/베스팅 처리 라우트들을 envelope 으로 마이그.
+
+GET (`/api/rsu`, `/api/stock-options`) 은 27-B 에서 이미 envelope 적용 완료 — 본 PR 은 mutation + 베스팅 vest/exercise 경로만 정리.
+
+## 배경
+
+- 27-C-1 (Watchlist/Recurring/Settings/IncomeProfile), 27-C-2 (Category/Budget/Asset), 27-C-3 (Dividend/Deposit/Transaction) 완료
+- 27-C-4 는 권리행사 흐름이 포함된 도메인 — vesting status 전이, exercise 처리 등 동시성 안전성도 함께 확인
+- pagination GET 가 없어 27-D 분리 불필요
+
+## 요구사항
+
+- [ ] 7 라우트 파일 마이그
+  - `rsu/route.ts` (POST)
+  - `rsu/[id]/route.ts` (PUT/DELETE)
+  - `rsu/[id]/vest/route.ts` (POST)
+  - `stock-options/route.ts` (POST)
+  - `stock-options/[id]/route.ts` (PUT/DELETE)
+  - `stock-options/[id]/vestings/route.ts` (POST)
+  - `stock-options/[id]/vestings/[vid]/route.ts` (PUT/PATCH/DELETE)
+- [ ] 두 도메인의 GET 라우트 에러 path 만 추가 정리 (`fail()` 통일)
+- [ ] 클라이언트 fetcher: `/rsu`, `/stock-options`, `/vesting` 페이지 응답 본문 사용처 unwrap
+
+## 기술 설계
+
+### 1. 라우트 변환
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `rsu/route.ts` | POST | `ok(schedule, { status: 201 })` |
+| `rsu/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `rsu/[id]/vest/route.ts` | POST | `ok(result)` |
+| `stock-options/route.ts` | POST | `ok(option, { status: 201 })` |
+| `stock-options/[id]/route.ts` | PUT, DELETE | `ok(updated)`, `noContent()` |
+| `stock-options/[id]/vestings/route.ts` | POST | `ok(vesting, { status: 201 })` |
+| `stock-options/[id]/vestings/[vid]/route.ts` | PUT, PATCH, DELETE | `ok(updated)`, `noContent()` |
+
+### 2. 클라이언트 fetcher
+
+확인 필요:
+- `/rsu` 페이지 — RSU 목록 + CRUD 폼
+- `/stock-options` 페이지 — 스톡옵션 목록 + 베스팅 행사
+- `/vesting` 캘린더 — RSU + 스톡옵션 통합 뷰
+
+PATCH (vesting status 전이) 응답 body 사용 여부 특히 확인.
+
+### 3. 변환 패턴 (이전 sub-phase 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - RSU 스케줄 등록/수정/삭제 + 베스팅 처리
+  - 스톡옵션 등록/수정/삭제
+  - 베스팅 스케줄 추가/수정/상태 변경/삭제
+  - 베스팅 캘린더 뷰
+
+## 제외 사항
+
+- 메인 GET (`/api/rsu`, `/api/stock-options`) — 27-B 에서 이미 envelope
+- 다른 도메인 (trade) — 27-C-5

--- a/docs/specs/333-envelope-c5.md
+++ b/docs/specs/333-envelope-c5.md
@@ -1,0 +1,67 @@
+# [Phase 27-C-5] Trade envelope 마이그
+
+## 목적
+
+27-C 5 sub-PR 중 마지막 — Trade 도메인의 mutation 라우트 (POST/PUT/DELETE) + 일괄 임포트 (POST) 를 envelope 으로 마이그.
+
+거래 mutation 은 Holding 재계산 트랜잭션, USD/KRW 환율 검증, 이동평균법 평균단가 계산 등이 얽혀있어 27-C 의 영향도가 가장 높은 도메인. main list GET (`/api/trades?...`) 은 27-D pagination 정리와 함께 별도.
+
+## 배경
+
+- 27-C-1~4 완료 (Watchlist/Recurring/Settings/IncomeProfile · Category/Budget/Asset · Dividend/Deposit/Transaction · RSU/StockOption)
+- 27-C-5 는 Trade — 거래 생성/수정/삭제 + 임포트 핵심 흐름
+- pagination GET (`/api/trades`) 은 27-D 별도
+
+## 요구사항
+
+- [ ] 3 라우트 파일 마이그
+  - `trades/route.ts` (POST) — GET 은 27-D 분리
+  - `trades/[id]/route.ts` (PUT/DELETE)
+  - `trades/import/route.ts` (POST — 일괄 임포트, `{ result }` 응답)
+- [ ] 클라이언트 fetcher 응답 본문 사용처 unwrap
+  - 거래 생성/수정 폼 — POST/PUT 결과 사용 여부 확인
+  - 임포트 페이지 — `result` 객체 사용 (success/failed 카운트, 에러 목록 등)
+
+## 기술 설계
+
+### 1. 라우트 변환
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `trades/route.ts` | POST | `ok(result, { status: 201 })` |
+| `trades/[id]/route.ts` | PUT, DELETE | `ok(result)`, `noContent()` |
+| `trades/import/route.ts` | POST | `ok(result, { status: 201 })` (기존 `{ result }` → `result` 직접) |
+
+### 2. 클라이언트 fetcher
+
+확인 필요:
+- `src/app/trades/new/` — 거래 생성 폼 (POST)
+- `src/app/trades/` 의 EditModal/DeleteModal — PUT/DELETE
+- `src/app/trades/import/` — bulk 임포트 결과 표시 (`result.success`, `result.failed`, `result.errors` 등)
+
+### 3. 변환 패턴 (이전 sub-phase 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 201 | `NextResponse.json(data, { status: 201 })` | `ok(data, { status: 201 })` |
+| 201 with wrap | `NextResponse.json({ result }, { status: 201 })` | `ok(result, { status: 201 })` |
+| 204 | `new NextResponse(null, { status: 204 })` | `noContent()` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+### 4. import 응답 wrapper 제거
+
+기존 `{ result }` wrapper 는 envelope `data` 가 그 역할을 대신 — 클라이언트 fetcher 에서 `json.result` 대신 `json.data` 사용.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 거래 생성/수정/삭제 (USD/KRW 양쪽, BUY/SELL)
+  - Holding 재계산 정합성
+  - 일괄 임포트 (성공/실패 케이스)
+
+## 제외 사항
+
+- 메인 list GET (`/api/trades`) — 27-D
+- 다른 도메인 (rsu/stock-option/transaction 등) — 27-C-1~4 완료

--- a/docs/specs/335-envelope-d.md
+++ b/docs/specs/335-envelope-d.md
@@ -1,0 +1,96 @@
+# [Phase 27-D] Pagination + 복잡한 GET envelope 마이그
+
+## 목적
+
+27 envelope 시리즈의 GET 라우트 마무리 — pagination 메타데이터를 envelope `meta` 로 통일하고, 복잡한 집계 GET (transactions) 및 파일 export GET 의 에러 path 까지 envelope 으로 통일.
+
+## 배경
+
+- 27-A (헬퍼), 27-B (단순 GET), 27-C-1~5 (mutation) 완료
+- 27-D 는 남은 list GET + exports/* 에러 path 정리. 본 PR 종료 시 27 시리즈의 GET 영역 마무리.
+- 27-E (가이드 문서) 만 남음
+
+## 요구사항
+
+- [ ] 4 list GET → `paginated()` / `ok({data,...}, {meta})`
+  - `trades/route.ts` GET — `{ trades, total, limit, offset }` → `paginated(trades, total, limit, offset)`
+  - `dividends/route.ts` GET — 동일 패턴
+  - `deposits/route.ts` GET — 동일 패턴
+  - `transactions/route.ts` GET — **복잡**: `{ transactions, summary, byMonth, byCategory, year, total, offset, limit }` → `ok({ transactions, summary, byMonth, byCategory, year }, { meta: { total, limit, offset } })`
+- [ ] 4 exports GET 에러 path → `fail()`
+  - `exports/trades/route.ts`
+  - `exports/deposits/route.ts`
+  - `exports/dividends/route.ts`
+  - `exports/vesting.ics/route.ts`
+- [ ] 클라이언트 unwrap
+  - `ExpensesClient.tsx` — transactions GET 응답 reshape
+
+## 기술 설계
+
+### 1. paginated() 적용 (단순 3개)
+
+```ts
+// before
+return NextResponse.json({ trades, total, limit, offset })
+
+// after
+return paginated(trades, total, limit, offset)
+// → { success: true, data: trades, meta: { total, limit, offset } }
+```
+
+→ 서버 컴포넌트만 prisma 직접 사용 (`src/app/trades/page.tsx` 등) — 클라이언트 fetcher 영향 없음.
+
+### 2. transactions GET (복잡)
+
+기존 응답 (listOnly 모드 vs 전체 모드 분기):
+```ts
+// listOnly 모드
+{ transactions, total, offset, limit, year }
+// 전체 모드
+{ transactions, total, offset, limit, summary, byMonth, byCategory, year }
+```
+
+envelope 변환:
+```ts
+return ok(
+  { transactions: serialized, year, ...(listOnly ? {} : { summary, byMonth, byCategory }) },
+  { meta: { total, limit, offset } },
+)
+```
+
+→ ExpensesClient.tsx 의 3 fetcher 모두 `json.transactions` → `json.data.transactions`, `json.total` → `json.meta.total`, `json.limit` → `json.meta.limit` 등으로 reshape.
+
+### 3. exports/* 에러 path
+
+성공 path 는 CSV/ICS 파일 응답 (`csvResponse` 등) — envelope 미적용.
+에러 path 만 `fail()` 로 통일:
+
+```ts
+// before
+return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+
+// after
+return fail(errs[0].message, 400)
+```
+
+### 4. 변환 패턴
+
+| 케이스 | before | after |
+|---|---|---|
+| paginated GET | `NextResponse.json({ [key], total, limit, offset })` | `paginated(arr, total, limit, offset)` |
+| 복잡 paginated | `NextResponse.json({ ..., total, limit, offset })` | `ok({...rest}, { meta: { total, limit, offset } })` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - 거래/배당/입금 페이지 (서버 컴포넌트 — 영향 없음 예상)
+  - 가계부 페이지 (`/expenses`) 필터/페이지 이동/요약 카드 정상 동작
+  - CSV 내보내기 정상 다운로드, 잘못된 year 입력 시 에러 메시지
+
+## 제외 사항
+
+- 27-E (가이드 문서 갱신) — 별도 PR
+- mutation 라우트 (27-C-1~5 완료)
+- 파일 응답 자체 (CSV/ICS body) — Content-Disposition 기반, envelope 미적용

--- a/docs/specs/337-envelope-e.md
+++ b/docs/specs/337-envelope-e.md
@@ -1,0 +1,72 @@
+# [Phase 27-E] envelope 가이드 문서 갱신
+
+## 목적
+
+27-A~D 에서 적용한 `ApiResponse<T>` envelope 패턴을 향후 신규 API 라우트 작성 시 자연스럽게 따를 수 있도록 `.claude/rules/api-routes.md` 와 `CLAUDE.md` 에 명시.
+
+27 시리즈의 **마지막 단계**.
+
+## 배경
+
+- 27-A: ApiResponse 헬퍼 + 단위 테스트 완료
+- 27-B: 단순 GET 라우트 마이그
+- 27-C-1~5: POST/PUT/DELETE 마이그 (5 sub-PR)
+- 27-D: pagination + 복잡한 GET + exports 에러 path
+- → 모든 API 라우트가 envelope 화 완료. 가이드 문서만 남음.
+
+## 요구사항
+
+- [ ] `.claude/rules/api-routes.md` 갱신
+  - 응답 envelope `ApiResponse<T>` 구조 명시
+  - `ok` / `fail` / `noContent` / `paginated` 사용 패턴 + 예시
+  - 에러 응답 컨벤션 (한국어 정적 메시지 + envelope `error` 필드)
+  - `businessErrorResponse()` 헬퍼 사용처 (Trade 도메인 비즈니스 예외)
+  - 파일 응답 (CSV/ICS) 의 예외 — 성공은 raw Response, 에러는 envelope
+- [ ] `CLAUDE.md` 갱신
+  - "Coding Conventions" 섹션에 envelope 사용 한 줄 추가
+
+## 기술 설계
+
+### api-routes.md 추가 섹션
+
+```markdown
+## 응답 envelope (ApiResponse<T>)
+
+모든 API 응답은 `src/lib/api-response.ts` 의 헬퍼를 사용해 통일된 envelope 으로 반환.
+
+### 응답 구조
+
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: { total, limit, offset }  // pagination 한정
+}
+
+### 헬퍼 사용
+
+| 케이스 | 헬퍼 |
+|---|---|
+| 단순 성공 (200) | ok(data) |
+| 생성 (201) | ok(data, { status: 201 }) |
+| 본문 없음 (204/205/304) | noContent() |
+| 페이지네이션 | paginated(arr, total, limit, offset) |
+| 복합 데이터 + meta | ok({...}, { meta: { total, limit, offset } }) |
+| 에러 | fail(error, status) |
+
+### 예외 — 파일 응답
+CSV/ICS 등 다운로드는 raw Response (csvResponse 등) 그대로.
+**에러 path 만** fail() 적용.
+```
+
+### CLAUDE.md 한 줄
+
+> API 응답: `@/lib/api-response` 의 `ok`/`fail`/`noContent`/`paginated` 사용. 모든 라우트는 envelope `{ success, data?, error?, meta? }` 형식.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build` — 문서 변경이라 영향 없을 것이나 형식 확인
+
+## 제외 사항
+
+- 신규 라우트 추가 / 기존 라우트 변경 — 27-A~D 에서 완료

--- a/docs/specs/339-security-deps.md
+++ b/docs/specs/339-security-deps.md
@@ -1,0 +1,57 @@
+# [Security] Dependabot 4건 패치 — dompurify/esbuild/js-yaml/postcss
+
+## 목적
+
+GitHub Dependabot 에 누적된 4건의 보안 취약점 해결.
+
+## 알림 목록
+
+| # | 패키지 | 현재 | 수정 | 심각도 | 요약 |
+|---|---|---|---|---|---|
+| 74 | dompurify | 3.4.9 | 3.4.11 | medium | `ALLOWED_ATTR` 영구 오염 (hook clone-guard 우회) |
+| 73 | js-yaml | 4.1.1 | 4.2.0 | medium | merge key alias 반복 → quadratic DoS |
+| 70 | esbuild | 0.27.4 | 0.28.1 | low | Windows dev server 임의 파일 읽기 (서버는 Ubuntu — 영향 없음) |
+| 62 | postcss | 8.4.31 (transitive) | 8.5.10+ | medium | CSS Stringify `</style>` 미이스케이프 XSS |
+
+## 패키지 의존 트리 (npm ls)
+
+- `dompurify@3.4.9` — 직접 의존 (`^3.3.3` → `^3.4.11` 로 bump)
+- `esbuild@0.27.4` — 직접 devDependency (`^0.27.4` → `^0.28.1` 로 bump)
+- `js-yaml@4.1.1` — `eslint@8.57.1` 의 transitive (eslint 8 EOL — overrides 로 강제 4.2.0)
+- `postcss@8.5.15` (top-level safe) + `postcss@8.4.31` (next 15.5.19 transitive — overrides 로 강제)
+
+## 변경
+
+### package.json
+```json
+{
+  "dependencies": {
+    "dompurify": "^3.4.11"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.1"
+  },
+  "overrides": {
+    "js-yaml": "^4.2.0",
+    "postcss": "^8.5.10"
+  }
+}
+```
+
+### 검증
+- `npm install`
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- `npm audit` 으로 잔여 취약점 확인
+- esbuild 0.27 → 0.28 minor bump — MCP/Bot 번들 정상 생성 확인
+
+## 위험도
+
+- dompurify: minor patch — API 호환
+- esbuild: 0.27 → 0.28 (minor, 일부 breaking 가능성) — 빌드 명령 정상 동작 확인 필수
+- js-yaml: minor (4.1 → 4.2) — eslint 가 사용. eslint 동작 확인
+- postcss: patch 영역 (8.4 → 8.5) — Tailwind/Next 빌드 정상 확인
+
+## 제외 사항
+
+- 코드 수정 없음 (의존성만)
+- 신규 기능 없음

--- a/docs/specs/341-envelope-28a.md
+++ b/docs/specs/341-envelope-28a.md
@@ -1,0 +1,47 @@
+# [Phase 28-A] accounts 라우트 envelope 마이그
+
+## 목적
+
+10차 마일스톤 (Phase 28: 잔여 16 라우트 envelope) 첫 sub-PR — accounts 도메인 2 라우트 envelope 통일.
+
+## 배경
+
+- 9차 (Phase 27) 에서 핵심 53+ 라우트 마이그 완료
+- 10차 (Phase 28) 는 남은 16 라우트 정리 — 5 sub-PR (A~E)
+- 28-A 는 가장 안전한 단순 CRUD (accounts) — 위험도 낮은 순 시작
+
+## 요구사항
+
+- [ ] `src/app/api/accounts/route.ts` GET 에러 path → `fail()` (성공은 이미 `ok()`)
+- [ ] `src/app/api/accounts/[id]/route.ts` GET/PATCH → `ok` / `fail` 통일
+- [ ] 클라이언트 검증 — SettingsClient (`json.data`) / AccountEditor (`data?.error`) 모두 이미 envelope 호환
+
+## 기술 설계
+
+### 변환 대상
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `accounts/route.ts` | GET (성공) | 이미 `ok()` — 미변경 |
+| `accounts/route.ts` | GET 에러 (500) | `fail('계좌 목록을 불러올 수 없습니다.', 500)` |
+| `accounts/[id]/route.ts` | GET (성공/404/500) | `ok(account)` / `fail('찾을 수 없습니다.', 404)` / `fail(..., 500)` |
+| `accounts/[id]/route.ts` | PATCH (전 분기) | `ok(updated)` / `fail(msg, status)` |
+
+### 클라이언트 영향 분석
+
+- `src/app/settings/SettingsClient.tsx:36-37` — `json.data` 이미 사용 ✅
+- `src/components/settings/AccountEditor.tsx:81-83` — `data?.error` 이미 envelope 호환 ✅
+- 외부 consumer 없음 (server component 미사용)
+
+→ 라우트만 바꿔도 클라이언트 영향 없음 (atomic).
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀:
+  - `/settings` 계좌 탭 — 목록 로드 + 수정 정상
+
+## 제외 사항
+
+- 다른 도메인 (28-B~E) — 별도 sub-PR
+- 신규 기능 없음

--- a/docs/specs/343-envelope-28b.md
+++ b/docs/specs/343-envelope-28b.md
@@ -1,0 +1,40 @@
+# [Phase 28-B] networth + reports + tax/gift envelope 마이그
+
+## 목적
+
+10차 마일스톤 (Phase 28) 두 번째 sub-PR — 조회 + 리포트 도메인 4 라우트 envelope 통일.
+
+## 요구사항
+
+- [ ] `networth/route.ts` GET (200/500) → `ok` / `fail`
+- [ ] `tax/gift/route.ts` GET (200/500) → `ok({ summaries })` / `fail` — 기존 wrapper `{ summaries }` 유지 (클라이언트 미사용이므로 자유)
+- [ ] `reports/route.ts` GET/POST → `ok` / `fail` (POST 201 응답 wrapper 제거 가능)
+- [ ] `reports/[id]/download/route.ts` — PDF 파일 응답이므로 27-D exports 패턴 (성공은 raw `NextResponse(buffer)`, 에러만 `fail()`)
+- [ ] 클라이언트 fetcher unwrap
+  - NetWorthClient: `setData(d.data ?? null)` + breakdown 가드
+  - ReportsClient: POST 응답 본문 미사용 (`fetchReports()` 재호출만 — 안전), GET 은 이미 `d?.data` 호환
+
+## 기술 설계
+
+### 라우트 변환
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `networth/route.ts` | GET | 성공 → `ok({...})`, 500 → `fail(...)` |
+| `tax/gift/route.ts` | GET | 성공 → `ok({ summaries })`, 500 → `fail(...)` |
+| `reports/route.ts` | GET, POST | 성공 → `ok(data)` / `ok(payload, { status: 201 })`, 검증/500 → `fail(...)` |
+| `reports/[id]/download/route.ts` | GET | 성공은 raw `NextResponse(buffer, { headers })` 유지 (PDF 다운로드), 404/500 → `fail()` |
+
+### 클라이언트
+
+- `NetWorthClient.tsx` — `if (d.breakdown)` → `if (d?.data?.breakdown)`, `setData(d)` → `setData(d.data)`
+- `ReportsClient.tsx` — POST 후 `fetchReports()` 재호출만 — 영향 없음. POST 에러 `data.error` 는 envelope 호환
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: `/networth`, `/reports` 페이지 + 리포트 생성/다운로드
+
+## 제외 사항
+
+- 다른 도메인 (28-C/D/E)

--- a/docs/specs/345-envelope-28c.md
+++ b/docs/specs/345-envelope-28c.md
@@ -1,0 +1,45 @@
+# [Phase 28-C] performance/* envelope 마이그
+
+## 목적
+
+10차 마일스톤 세 번째 sub-PR — 성과 지표 도메인 4 라우트 envelope 통일.
+
+## 요구사항
+
+- [ ] `performance/snapshots/route.ts` GET/POST → `ok`/`fail` (POST `{ results }` wrapper 제거)
+- [ ] `performance/twr/route.ts` GET → `ok`/`fail`
+- [ ] `performance/contribution/route.ts` GET → `ok`/`fail`
+- [ ] `performance/benchmark/backfill/route.ts` POST → `ok({ results }, { status: 201 })` / `fail`
+- [ ] 클라이언트 `PerformanceClient.tsx` 3개 GET fetcher unwrap
+
+## 기술 설계
+
+### 라우트
+
+| 파일 | 메소드 | 변환 |
+|---|---|---|
+| `snapshots/route.ts` | GET | `ok({ snapshots, benchmark, benchmarkName })` |
+| `snapshots/route.ts` | POST | `ok(results, { status: 201 })` (wrapper 제거 — 클라이언트 미사용) |
+| `twr/route.ts` | GET | `ok(result)` |
+| `contribution/route.ts` | GET | `ok(result)` |
+| `benchmark/backfill/route.ts` | POST | `ok(results, { status: 201 })` (wrapper 제거 — 미사용) |
+
+### 클라이언트 (`PerformanceClient.tsx`)
+
+- `fetchSnapshots`: `const json = await res.json(); setSnapshotData(json?.data ?? null)`
+- `fetchTWR`: 각 항목 `const json = await res.json(); return json?.data ?? { ...nullObj }`
+- `fetchContribution`: `setContributionData(json?.data ?? null)`
+- POST 2개 (`handleTriggerSnapshot`, `handleBackfill`): body 미사용 — 변경 없음
+
+## 위험도
+
+성과 지표 차트 데이터 영향 — fetcher unwrap 후 차트 컴포넌트가 받는 props 동일 구조 유지 확인 필수.
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: `/performance` 페이지 — 계좌 선택 / period 변경 / 스냅샷 트리거 / backfill
+
+## 제외 사항
+
+- 다른 도메인 (28-D/E)

--- a/docs/specs/347-envelope-28d.md
+++ b/docs/specs/347-envelope-28d.md
@@ -1,0 +1,40 @@
+# [Phase 28-D] prices/* envelope 마이그
+
+## 목적
+
+10차 마일스톤 네 번째 sub-PR — 시세 도메인 4 라우트 envelope 통일.
+
+## 외부 consumer 영향 분석
+
+- bot/cron 은 `refreshPrices()`, `syncKrxStocks()`, `searchYahooByName()` 등 **lib 직접 호출** — HTTP 미경유. 응답 shape 변경 영향 없음.
+- 웹 consumer:
+  - `/api/prices` GET — TradeForm, DividendForm: 이미 `json?.data?.prices` 사용 (27-B 호환)
+  - `/api/prices/refresh` POST — RefreshButton: success body 미사용, error path `data?.error` 호환
+  - `/api/prices/search` GET — 미사용
+  - `/api/prices/krx-sync` POST — 미사용
+
+→ 라우트 변경 안전. 클라이언트 fetcher 추가 변경 불필요.
+
+## 요구사항
+
+- [ ] `prices/route.ts` GET 에러 path → `fail()` (성공 이미 `ok`)
+- [ ] `prices/refresh/route.ts` POST → `ok(result)` / `fail(msg, 429/500)`
+- [ ] `prices/search/route.ts` GET → `ok({ source, results })` / `fail(...)`
+- [ ] `prices/krx-sync/route.ts` POST → `ok(result)` / `fail(msg, 429/500)`
+
+## 변환 패턴 (9차 동일)
+
+| 케이스 | before | after |
+|---|---|---|
+| 성공 | `NextResponse.json(data)` | `ok(data)` |
+| 에러 | `NextResponse.json({ error }, { status })` | `fail(error, status)` |
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: 대시보드 갱신 버튼, 거래/배당 폼 (환율 prefill), Whoes 검색은 미사용이지만 수동 호출 가능
+
+## 제외 사항
+
+- 28-E (backtest + ai/ask)
+- lib 직접 호출 (cron/bot/MCP) 영향 없음

--- a/docs/specs/349-envelope-28e.md
+++ b/docs/specs/349-envelope-28e.md
@@ -1,0 +1,56 @@
+# [Phase 28-E] ai/ask + backtest envelope 마이그 (10차 마일스톤 종료)
+
+## 목적
+
+10차 마일스톤 (Phase 28) **마지막 sub-PR** — AI/백테스트 도메인 2 라우트 envelope 통일.
+
+본 PR 종료 시 27/28 시리즈 전체 envelope 마이그 완료.
+
+## 라우트 분석
+
+- `/api/ai/ask` POST: 단일 JSON 응답 (스트리밍 아님) — envelope 적용 가능
+- `/api/backtest` POST: 단일 JSON 응답 — envelope 적용 가능. 단 catch 블록이 `error.message` 를 그대로 노출 — `.claude/rules/api-routes.md` 위반. 동시 수정.
+
+## 요구사항
+
+- [ ] `ai/ask/route.ts` POST → `ok({ response, model, durationMs, costUsd })` / `fail(...)`
+  - AdvisorTimeoutError → `fail(504)`
+  - AdvisorError + safe → `fail(error.message, 400)`
+  - 일반 → `fail('AI 응답 처리에 실패했습니다.', 500)`
+- [ ] `backtest/route.ts` POST → `ok({ ...result, currency })` / `fail(...)`
+  - catch 블록의 `error.message` 누출 제거 — 정적 한국어 메시지
+- [ ] 클라이언트 unwrap
+  - `AIClient.tsx`: `data.response` → `data?.data?.response`
+  - `BacktestClient.tsx`: `setResult(data)` → `setResult(data?.data)`
+
+## 기술 설계
+
+### 라우트 변환
+
+| 파일 | 변환 |
+|---|---|
+| `ai/ask/route.ts` POST | 성공 `ok({...})`, 검증/타임아웃/일반 → `fail(msg, status)` |
+| `backtest/route.ts` POST | 성공 `ok({...result, currency})`, 검증/일반 → `fail(msg, status)` (정적 메시지 통일) |
+
+### 클라이언트
+
+- `AIClient.tsx:83-89` — `data.response` → `data?.data?.response` + null guard
+- `BacktestClient.tsx:87-89` — `setResult(data?.data ?? null)` + null guard
+
+## 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동 회귀: `/ai` AI 질문, `/backtest` 백테스트 실행
+
+## 제외 사항
+
+- 10차 마일스톤 완료 — 추후 11차 기획 별도
+
+## 10차 마일스톤 종료
+
+5 sub-PR (28-A~E) 완료 시 27+28 시리즈 envelope 마이그 **100%**.
+- 28-A: accounts (#342)
+- 28-B: networth/reports/tax-gift (#344)
+- 28-C: performance/* (#346)
+- 28-D: prices/* (#348)
+- 본 PR (28-E): ai/ask + backtest

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@prisma/client": "^6.19.2",
         "@react-pdf/renderer": "^4.3.2",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.11",
         "dotenv": "^17.3.1",
         "grammy": "^1.41.1",
         "marked": "^17.0.4",
@@ -35,10 +35,10 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitest/coverage-v8": "^4.1.8",
-        "esbuild": "^0.27.4",
+        "esbuild": "^0.28.1",
         "eslint": "^8",
         "eslint-config-next": "^15.5.16",
-        "postcss": "^8",
+        "postcss": "^8.5.10",
         "prisma": "^6.19.2",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.21.0",
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -199,21 +199,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -334,9 +334,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -521,9 +521,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -589,9 +589,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -623,9 +623,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -726,6 +726,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -737,9 +761,9 @@
       }
     },
     "node_modules/@grammyjs/types": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.25.0.tgz",
-      "integrity": "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.28.0.tgz",
+      "integrity": "sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
@@ -1298,9 +1322,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1337,39 +1361,23 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
@@ -1379,43 +1387,13 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.16",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.16.tgz",
-      "integrity": "sha512-pXa+4smRrgzea94YeAR8txf2CYg4pc1HkcoLUigrE5a0j70dVdUYMKfsOGCe8ulDSLvqnm2keMoxKss5RxHokg==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.19.tgz",
+      "integrity": "sha512-Ctwb4qYuMbHN/1oXLlTdMchwG8h8Xzwq+wGZZMgF3o6+uwyBKAI2c96bdOsl+C62PaUD0Jkh+QpNkhUeDlam0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
-      }
-    },
-    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -1546,6 +1524,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1604,9 +1606,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
-      "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1636,6 +1638,102 @@
         "deepmerge-ts": "7.1.5",
         "effect": "3.21.0",
         "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@prisma/debug": {
@@ -1689,79 +1787,73 @@
       }
     },
     "node_modules/@react-pdf/fns": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
-      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
       "license": "MIT"
     },
     "node_modules/@react-pdf/font": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.4.tgz",
-      "integrity": "sha512-8YtgGtL511txIEc9AjiilpZ7yjid8uCd8OGUl6jaL3LIHnrToUupSN4IzsMQpVTCMYiDLFnDNQzpZsOYtRS/Pg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
       "license": "MIT",
       "dependencies": {
-        "@react-pdf/pdfkit": "^4.1.0",
-        "@react-pdf/types": "^2.9.2",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
         "fontkit": "^2.0.2",
         "is-url": "^1.2.4"
       }
     },
     "node_modules/@react-pdf/image": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.4.tgz",
-      "integrity": "sha512-z0ogVQE0bKqgXQ5smgzIU857rLV7bMgVdrYsu3UfXDDLSzI7QPvzf6MFTFllX6Dx2rcsF13E01dqKPtJEM799g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
       "license": "MIT",
       "dependencies": {
-        "@react-pdf/png-js": "^3.0.0",
-        "jay-peg": "^1.1.1"
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
       }
     },
     "node_modules/@react-pdf/layout": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.2.tgz",
-      "integrity": "sha512-gNu2oh8MiGR+NJZYTJ4c4q0nWCESBI6rKFiodVhE7OeVAjtzZzd6l65wsN7HXdWJqOZD3ttD97iE+tf5SOd/Yg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
       "license": "MIT",
       "dependencies": {
-        "@react-pdf/fns": "3.1.2",
-        "@react-pdf/image": "^3.0.4",
-        "@react-pdf/primitives": "^4.1.1",
-        "@react-pdf/stylesheet": "^6.1.2",
-        "@react-pdf/textkit": "^6.1.0",
-        "@react-pdf/types": "^2.9.2",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
         "emoji-regex-xs": "^1.0.0",
         "queue": "^6.0.1",
         "yoga-layout": "^3.2.1"
       }
     },
     "node_modules/@react-pdf/pdfkit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.1.0.tgz",
-      "integrity": "sha512-Wm/IOAv0h/U5Ra94c/PltFJGcpTUd/fwVMVeFD6X9tTTPCttIwg0teRG1Lqq617J8K4W7jpL/B0HTH0mjp3QpQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/png-js": "^3.0.0",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
         "browserify-zlib": "^0.2.0",
-        "crypto-js": "^4.2.0",
         "fontkit": "^2.0.2",
         "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
         "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
         "vite-compatible-readable-stream": "^3.6.1"
       }
     },
-    "node_modules/@react-pdf/png-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
-      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-zlib": "^0.2.0"
-      }
-    },
     "node_modules/@react-pdf/primitives": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
-      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
       "license": "MIT"
     },
     "node_modules/@react-pdf/reconciler": {
@@ -1777,45 +1869,39 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
-      "version": "0.25.0-rc-603e6108-20241029",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
-      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
-      "license": "MIT"
-    },
     "node_modules/@react-pdf/render": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.2.tgz",
-      "integrity": "sha512-el5KYM1sH/PKcO4tRCIm8/AIEmhtraaONbwCrBhFdehoGv6JtgnXiMxHGAvZbI5kEg051GbyP+XIU6f6YbOu6Q==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "3.1.2",
-        "@react-pdf/primitives": "^4.1.1",
-        "@react-pdf/textkit": "^6.1.0",
-        "@react-pdf/types": "^2.9.2",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
         "abs-svg-path": "^0.1.1",
-        "color-string": "^1.9.1",
+        "color-string": "^2.1.4",
         "normalize-svg-path": "^1.1.0",
         "parse-svg-path": "^0.1.2",
         "svg-arc-to-cubic-bezier": "^3.2.0"
       }
     },
     "node_modules/@react-pdf/renderer": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.2.tgz",
-      "integrity": "sha512-EhPkj35gO9rXIyyx29W3j3axemvVY5RigMmlK4/6Ku0pXB8z9PEE/sz4ZBOShu2uot6V4xiCR3aG+t9IjJJlBQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "3.1.2",
-        "@react-pdf/font": "^4.0.4",
-        "@react-pdf/layout": "^4.4.2",
-        "@react-pdf/pdfkit": "^4.1.0",
-        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
         "@react-pdf/reconciler": "^2.0.0",
-        "@react-pdf/render": "^4.3.2",
-        "@react-pdf/types": "^2.9.2",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
         "events": "^3.3.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
@@ -1826,46 +1912,55 @@
       }
     },
     "node_modules/@react-pdf/stylesheet": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.2.tgz",
-      "integrity": "sha512-E3ftGRYUQGKiN3JOgtGsLDo0hGekA6dmkmi/MYACytmPTKxQRBSO3126MebmCq+t1rgU9uRlREIEawJ+8nzSbw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
       "license": "MIT",
       "dependencies": {
-        "@react-pdf/fns": "3.1.2",
-        "@react-pdf/types": "^2.9.2",
-        "color-string": "^1.9.1",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
         "hsl-to-hex": "^1.0.0",
         "media-engine": "^1.0.3",
         "postcss-value-parser": "^4.1.0"
       }
     },
-    "node_modules/@react-pdf/textkit": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.1.0.tgz",
-      "integrity": "sha512-sFlzDC9CDFrJsnL3B/+NHrk9+Advqk7iJZIStiYQDdskbow8GF/AGYrpIk+vWSnh35YxaGbHkqXq53XOxnyrjQ==",
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
       "license": "MIT",
       "dependencies": {
-        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
         "bidi-js": "^1.0.2",
         "hyphen": "^1.6.4",
         "unicode-properties": "^1.4.1"
       }
     },
     "node_modules/@react-pdf/types": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.2.tgz",
-      "integrity": "sha512-dufvpKId9OajLLbgn9q7VLUmyo1Jf+iyGk2ZHmCL8nIDtL8N1Ejh9TH7+pXXrR0tdie1nmnEb5Bz9U7g4hI4/g==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
       "license": "MIT",
       "dependencies": {
-        "@react-pdf/font": "^4.0.4",
-        "@react-pdf/primitives": "^4.1.1",
-        "@react-pdf/stylesheet": "^6.1.2"
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -1889,9 +1984,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1899,9 +1994,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
-      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -1913,9 +2008,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
-      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -1927,9 +2022,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
-      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1941,9 +2036,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
-      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1955,9 +2050,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
-      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1969,9 +2064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
-      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1983,9 +2078,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
-      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1997,9 +2092,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
-      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -2011,9 +2106,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
-      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -2025,9 +2120,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
-      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2039,9 +2134,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
-      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -2053,9 +2148,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
-      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -2067,9 +2162,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
-      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -2081,9 +2176,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
-      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -2095,9 +2190,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
-      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -2109,9 +2204,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
-      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -2123,9 +2218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
-      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -2137,9 +2232,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
-      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -2151,9 +2246,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
-      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -2165,9 +2260,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
-      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -2179,9 +2274,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
-      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -2193,9 +2288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
-      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -2207,9 +2302,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
-      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -2221,9 +2316,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
-      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -2235,9 +2330,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
-      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -2275,18 +2370,18 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2400,9 +2495,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
-      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2460,20 +2555,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2483,9 +2578,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -2499,16 +2594,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2520,18 +2615,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2542,18 +2637,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2564,9 +2659,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2577,21 +2672,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2602,13 +2697,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2620,21 +2715,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2644,7 +2739,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -2671,13 +2766,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2687,16 +2782,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2707,17 +2802,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2742,16 +2837,16 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -2763,9 +2858,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -2777,9 +2872,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -2791,9 +2886,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -2805,9 +2900,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -2819,9 +2914,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -2833,9 +2928,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -2847,9 +2942,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
@@ -2861,9 +2956,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
@@ -2874,10 +2969,38 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
@@ -2889,9 +3012,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
@@ -2903,9 +3026,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
@@ -2917,9 +3040,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
@@ -2931,9 +3054,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
@@ -2945,9 +3068,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
@@ -2958,10 +3081,24 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -2969,16 +3106,29 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -2990,9 +3140,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -3004,9 +3154,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -3018,14 +3168,14 @@
       ]
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -3039,8 +3189,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.8",
-        "vitest": "4.1.8"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3048,29 +3198,17 @@
         }
       }
     },
-    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@babel/types": "^7.29.0",
-        "source-map-js": "^1.2.1"
-      }
-    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3079,13 +3217,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3106,9 +3244,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3119,13 +3257,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3133,14 +3271,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3149,9 +3287,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3159,13 +3297,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3205,9 +3343,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3228,16 +3366,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3260,28 +3397,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3543,13 +3658,6 @@
         "js-tokens": "^10.0.0"
       }
     },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3577,9 +3685,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -3646,21 +3754,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3720,98 +3841,16 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/c12": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
-      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^16.6.1",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.4.2",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
-        "rc9": "^2.1.2"
-      },
-      "peerDependencies": {
-        "magicast": "^0.3.5"
-      },
-      "peerDependenciesMeta": {
-        "magicast": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/c12/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/c12/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/c12/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/c12/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3871,9 +3910,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001776",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
-      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4002,20 +4041,32 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/color-name": {
+    "node_modules/color-convert/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
       "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/commander": {
@@ -4053,9 +4104,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4129,12 +4180,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4481,18 +4526,18 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
-      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4565,9 +4610,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4633,6 +4678,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4652,16 +4716,16 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
+        "es-abstract": "^1.24.2",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -4673,7 +4737,7 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "safe-array-concat": "^1.1.3"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4687,9 +4751,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4728,15 +4792,17 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4746,9 +4812,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -4756,9 +4822,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4769,32 +4835,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -4874,13 +4940,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.16",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.16.tgz",
-      "integrity": "sha512-9fi/wwYuBQSm2vHDVE8PMPsKIR/xXVOlwMrRp16qra6S/LQVhZ452cjnkPZb6PN/SZ3yJUQp1L4bTYoublvBKw==",
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.19.tgz",
+      "integrity": "sha512-UZwkuhBCNxVZfo93MSHRDOVNWXooJJGcAUyTAVIp0+9QFhH4SqJxWY0s6Mk9C2kMi777HPMn3dseOrZshWpG9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.16",
+        "@next/eslint-plugin-next": "15.5.19",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -4902,15 +4968,15 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -4959,9 +5025,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5142,30 +5208,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-plugin-react/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5205,6 +5247,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -5326,9 +5392,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -5406,9 +5472,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -5442,9 +5508,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5452,7 +5518,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
+        "micromatch": "^4.0.4"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -5520,6 +5586,12 @@
         "debug": "^4.3.4",
         "filenamify-url": "2.1.2"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -5666,15 +5738,6 @@
         "unicode-trie": "^2.0.0"
       }
     },
-    "node_modules/fontkit/node_modules/@swc/helpers": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
-      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5741,18 +5804,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5837,9 +5903,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5865,6 +5931,28 @@
       },
       "bin": {
         "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -5933,12 +6021,12 @@
       }
     },
     "node_modules/grammy": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.41.1.tgz",
-      "integrity": "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.44.0.tgz",
+      "integrity": "sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==",
       "license": "MIT",
       "dependencies": {
-        "@grammyjs/types": "3.25.0",
+        "@grammyjs/types": "3.28.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.4.3",
         "node-fetch": "^2.7.0"
@@ -6035,9 +6123,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6047,9 +6135,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6256,12 +6344,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
-    },
     "node_modules/is-async-function": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
@@ -6352,13 +6434,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6394,6 +6476,22 @@
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6779,17 +6877,34 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6812,10 +6927,9 @@
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
@@ -6978,6 +7092,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6989,17 +7109,15 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -7019,9 +7137,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
-      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -7157,9 +7275,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -7295,47 +7413,28 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/node-cron": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
-      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.5.0.tgz",
+      "integrity": "sha512-4Trh+kjvbXokyJkwQumvD5YAgeJfgHLR/sKyu71uSmxfCR5QMO1hldpvmFZOICN5pLgNY+J5Y8+ar3XKo5/4tQ==",
       "license": "ISC",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7417,15 +7516,15 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
-      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
+      "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "tinyexec": "^1.1.1"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
@@ -7698,9 +7797,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/papaparse": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+      "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
       "license": "MIT"
     },
     "node_modules/parent-module": {
@@ -7851,6 +7950,14 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7865,7 +7972,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7906,6 +8012,28 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-import/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/postcss-js": {
@@ -8004,9 +8132,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8088,6 +8216,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -8247,16 +8381,23 @@
         "react": "^19.2.7"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -8300,15 +8441,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
-      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
       "license": "MIT",
       "workspaces": [
         "www"
       ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
@@ -8410,13 +8551,16 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.1",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -8484,32 +8628,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rollup": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
-      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8523,31 +8645,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.0",
-        "@rollup/rollup-android-arm64": "4.62.0",
-        "@rollup/rollup-darwin-arm64": "4.62.0",
-        "@rollup/rollup-darwin-x64": "4.62.0",
-        "@rollup/rollup-freebsd-arm64": "4.62.0",
-        "@rollup/rollup-freebsd-x64": "4.62.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
-        "@rollup/rollup-linux-arm64-musl": "4.62.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
-        "@rollup/rollup-linux-loong64-musl": "4.62.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
-        "@rollup/rollup-linux-x64-gnu": "4.62.0",
-        "@rollup/rollup-linux-x64-musl": "4.62.0",
-        "@rollup/rollup-openbsd-x64": "4.62.0",
-        "@rollup/rollup-openharmony-arm64": "4.62.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
-        "@rollup/rollup-win32-x64-gnu": "4.62.0",
-        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -8592,15 +8714,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -8673,15 +8795,15 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -8858,14 +8980,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -8877,13 +8999,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8935,15 +9057,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -9062,19 +9175,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9084,16 +9198,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9293,6 +9407,58 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9353,14 +9519,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9523,9 +9689,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9546,6 +9712,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
       "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9583,14 +9750,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -9629,17 +9795,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -9700,18 +9883,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9805,38 +9988,41 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/uri-js": {
@@ -10525,19 +10711,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -10565,12 +10751,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -10726,14 +10912,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -10781,22 +10967,35 @@
       "license": "ISC"
     },
     "node_modules/yahoo-finance2": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.13.2.tgz",
-      "integrity": "sha512-aAOJEjuLClfDxVPRKxjcwFoyzMr8BE/svgUqr5IjnQR+kppYbKO92Wl3SbAGz5DRghy6FiUfqi5FBDSBA/e2jg==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.15.3.tgz",
+      "integrity": "sha512-AFmVZ4ACg3QFT2a/hyJv4Scp2J45gm/6xetVgvUvXzZypqsqbgreXJad4i+qm0onj6yeCf2fPhvow7Eh0CwwzA==",
       "license": "MIT",
       "dependencies": {
         "@deno/shim-deno": "~0.18.0",
+        "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.26.0",
         "fetch-mock-cache": "npm:fetch-mock-cache@^2.1.3",
         "json-schema": "^0.4.0",
         "tough-cookie": "npm:tough-cookie@^5.1.1",
-        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3"
+        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3",
+        "zod": "npm:zod@^3.25.0"
       },
       "bin": {
-        "yahoo-finance": "esm/bin/yahoo-finance.js"
+        "yahoo-finance": "esm/bin/yahoo-finance.js",
+        "yahoo-finance-mcp": "esm/bin/yahoo-finance-mcp.js",
+        "yahoo-finance2": "esm/bin/yahoo-finance.js"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/yahoo-finance2/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/yocto-queue": {
@@ -10828,12 +11027,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@prisma/client": "^6.19.2",
     "@react-pdf/renderer": "^4.3.2",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.11",
     "dotenv": "^17.3.1",
     "grammy": "^1.41.1",
     "marked": "^17.0.4",
@@ -44,15 +44,22 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.8",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.28.1",
     "eslint": "^8",
     "eslint-config-next": "^15.5.16",
-    "postcss": "^8",
+    "postcss": "^8.5.10",
     "prisma": "^6.19.2",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.8"
+  },
+  "overrides": {
+    "js-yaml": "^4.2.0",
+    "postcss": "^8.5.10",
+    "next": {
+      "postcss": "^8.5.10"
+    }
   }
 }

--- a/src/app/ai/AIClient.tsx
+++ b/src/app/ai/AIClient.tsx
@@ -83,10 +83,13 @@ export default function AIClient() {
       const data = await res.json()
 
       if (!res.ok) {
-        throw new Error(data.error || 'AI 응답 실패')
+        throw new Error(data?.error || 'AI 응답 실패')
       }
 
-      const aiContent = data.response
+      const aiContent = data?.data?.response
+      if (!aiContent) {
+        throw new Error('AI 응답을 받지 못했습니다.')
+      }
       const aiMsg: Message = {
         id: generateId(),
         role: 'assistant',

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail } from '@/lib/api-response'
 
 export async function GET(request: Request, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -18,19 +19,13 @@ export async function GET(request: Request, props: { params: Promise<{ id: strin
     })
 
     if (!account) {
-      return NextResponse.json(
-        { error: '계좌를 찾을 수 없습니다.' },
-        { status: 404 }
-      )
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
-    return NextResponse.json(account)
+    return ok(account)
   } catch (error) {
     console.error('GET /api/accounts/[id] error:', error)
-    return NextResponse.json(
-      { error: '계좌 정보를 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('계좌 정보를 불러올 수 없습니다.', 500)
   }
 }
 
@@ -46,24 +41,24 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     const data: Record<string, unknown> = {}
 
     if (body.name !== undefined) {
       if (typeof body.name !== 'string' || !body.name.trim()) {
-        return NextResponse.json({ error: '계좌 이름을 입력해주세요.' }, { status: 400 })
+        return fail('계좌 이름을 입력해주세요.', 400)
       }
       data.name = body.name.trim()
     }
 
     if (body.strategy !== undefined) {
       if (body.strategy !== null && typeof body.strategy !== 'string') {
-        return NextResponse.json({ error: '전략은 문자열이어야 합니다.' }, { status: 400 })
+        return fail('전략은 문자열이어야 합니다.', 400)
       }
       data.strategy = typeof body.strategy === 'string' ? body.strategy.trim() || null : null
     }
@@ -74,13 +69,13 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       } else if (typeof body.horizon === 'number' && Number.isInteger(body.horizon) && body.horizon > 0) {
         data.horizon = body.horizon
       } else {
-        return NextResponse.json({ error: '투자 기간은 양의 정수여야 합니다.' }, { status: 400 })
+        return fail('투자 기간은 양의 정수여야 합니다.', 400)
       }
     }
 
     if (body.benchmarkTicker !== undefined) {
       if (body.benchmarkTicker !== null && typeof body.benchmarkTicker !== 'string') {
-        return NextResponse.json({ error: '벤치마크는 문자열이어야 합니다.' }, { status: 400 })
+        return fail('벤치마크는 문자열이어야 합니다.', 400)
       }
       data.benchmarkTicker = typeof body.benchmarkTicker === 'string' ? body.benchmarkTicker.trim() || null : null
     }
@@ -91,12 +86,12 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       } else if (typeof body.ownerAge === 'number' && Number.isInteger(body.ownerAge) && body.ownerAge >= 0) {
         data.ownerAge = body.ownerAge
       } else {
-        return NextResponse.json({ error: '나이는 0 이상의 정수여야 합니다.' }, { status: 400 })
+        return fail('나이는 0 이상의 정수여야 합니다.', 400)
       }
     }
 
     if (Object.keys(data).length === 0) {
-      return NextResponse.json({ error: '수정할 필드가 없습니다.' }, { status: 400 })
+      return fail('수정할 필드가 없습니다.', 400)
     }
 
     const updated = await prisma.account.update({
@@ -104,12 +99,12 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       data,
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
     console.error('PATCH /api/accounts/[id] error:', error)
-    return NextResponse.json({ error: '계좌 수정에 실패했습니다.' }, { status: 500 })
+    return fail('계좌 수정에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok } from '@/lib/api-response'
 
 export async function GET() {
   try {
@@ -13,7 +14,7 @@ export async function GET() {
       orderBy: { createdAt: 'asc' },
     })
 
-    return NextResponse.json(accounts)
+    return ok(accounts)
   } catch (error) {
     console.error('GET /api/accounts error:', error)
     return NextResponse.json(

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,6 +1,5 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export async function GET() {
   try {
@@ -17,9 +16,6 @@ export async function GET() {
     return ok(accounts)
   } catch (error) {
     console.error('GET /api/accounts error:', error)
-    return NextResponse.json(
-      { error: '계좌 목록을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('계좌 목록을 불러올 수 없습니다.', 500)
   }
 }

--- a/src/app/api/ai/ask/route.ts
+++ b/src/app/api/ai/ask/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import {
   askAdvisor,
   AdvisorTimeoutError,
   AdvisorError,
 } from '@/lib/ai/claude-advisor'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -21,31 +22,22 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { prompt } = body as { prompt?: unknown }
 
     if (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {
-      return NextResponse.json(
-        { error: '질문을 입력해주세요.' },
-        { status: 400 }
-      )
+      return fail('질문을 입력해주세요.', 400)
     }
 
     const result = await askAdvisor(prompt.trim())
 
-    return NextResponse.json({
+    return ok({
       response: result.response,
       model: result.model,
       durationMs: result.durationMs,
@@ -53,23 +45,14 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     if (error instanceof AdvisorTimeoutError) {
-      return NextResponse.json(
-        { error: 'AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.' },
-        { status: 504 }
-      )
+      return fail('AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.', 504)
     }
 
     if (error instanceof AdvisorError && isSafeError(error.message)) {
-      return NextResponse.json(
-        { error: error.message },
-        { status: 400 }
-      )
+      return fail(error.message, 400)
     }
 
     console.error('POST /api/ai/ask error:', error)
-    return NextResponse.json(
-      { error: 'AI 응답 처리에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('AI 응답 처리에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/alerts/config/route.ts
+++ b/src/app/api/alerts/config/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,13 +12,10 @@ export async function GET() {
     const configs = await prisma.alertConfig.findMany({
       orderBy: { key: 'asc' },
     })
-    return NextResponse.json({ configs })
+    return ok(configs)
   } catch (error) {
     console.error('GET /api/alerts/config error:', error)
-    return NextResponse.json(
-      { error: '알림 설정을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('알림 설정을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -31,42 +29,27 @@ export async function PUT(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: '잘못된 요청 형식입니다.' },
-        { status: 400 }
-      )
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { key, value } = body as { key?: unknown; value?: unknown }
 
     if (!key || typeof key !== 'string') {
-      return NextResponse.json(
-        { error: '설정 키를 지정해주세요.' },
-        { status: 400 }
-      )
+      return fail('설정 키를 지정해주세요.', 400)
     }
     if (value === undefined || value === null || String(value).trim() === '') {
-      return NextResponse.json(
-        { error: '값을 입력해주세요.' },
-        { status: 400 }
-      )
+      return fail('값을 입력해주세요.', 400)
     }
 
     const existing = await prisma.alertConfig.findUnique({
       where: { key },
     })
     if (!existing) {
-      return NextResponse.json(
-        { error: `존재하지 않는 설정입니다: ${key}` },
-        { status: 404 }
-      )
+      return fail(`존재하지 않는 설정입니다: ${key}`, 404)
     }
 
     const updated = await prisma.alertConfig.update({
@@ -74,12 +57,9 @@ export async function PUT(request: NextRequest) {
       data: { value: String(value) },
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/alerts/config error:', error)
-    return NextResponse.json(
-      { error: '알림 설정 변경에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('알림 설정 변경에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/assets/[id]/route.ts
+++ b/src/app/api/assets/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 function parseStrictDate(str: string): Date | null {
   const match = str.match(/^(\d{4})-(\d{2})-(\d{2})/)
@@ -19,18 +20,18 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
 
     const existing = await prisma.asset.findUnique({ where: { id } })
     if (!existing) {
-      return NextResponse.json({ error: '자산을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('자산을 찾을 수 없습니다.', 404)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { name, value, note, interestRate, maturityDate, owner, category, isLiability } =
@@ -41,34 +42,31 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
     const data: Record<string, unknown> = {}
     if (name !== undefined) {
       if (typeof name !== 'string' || !name.trim()) {
-        return NextResponse.json({ error: '유효한 자산명을 입력해주세요.' }, { status: 400 })
+        return fail('유효한 자산명을 입력해주세요.', 400)
       }
       data.name = name.trim()
     }
     if (owner !== undefined) {
       if (typeof owner !== 'string' || !owner.trim()) {
-        return NextResponse.json({ error: '유효한 소유자를 입력해주세요.' }, { status: 400 })
+        return fail('유효한 소유자를 입력해주세요.', 400)
       }
       data.owner = owner.trim()
     }
     if (category !== undefined && typeof category === 'string') {
       if (!VALID_CATEGORIES.includes(category)) {
-        return NextResponse.json(
-          { error: `유효한 카테고리: ${VALID_CATEGORIES.join(', ')}` },
-          { status: 400 }
-        )
+        return fail(`유효한 카테고리: ${VALID_CATEGORIES.join(', ')}`, 400)
       }
       data.category = category
     }
     if (isLiability !== undefined) {
       if (typeof isLiability !== 'boolean') {
-        return NextResponse.json({ error: 'isLiability는 boolean이어야 합니다.' }, { status: 400 })
+        return fail('isLiability는 boolean이어야 합니다.', 400)
       }
       data.isLiability = isLiability
     }
     if (value !== undefined) {
       if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-        return NextResponse.json({ error: '유효한 금액을 입력해주세요.' }, { status: 400 })
+        return fail('유효한 금액을 입력해주세요.', 400)
       }
       data.value = Math.round(value)
     }
@@ -79,7 +77,7 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
       } else if (typeof interestRate === 'number' && Number.isFinite(interestRate)) {
         data.interestRate = interestRate
       } else {
-        return NextResponse.json({ error: '이율은 숫자여야 합니다.' }, { status: 400 })
+        return fail('이율은 숫자여야 합니다.', 400)
       }
     }
     if (maturityDate !== undefined) {
@@ -88,21 +86,21 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
       } else if (typeof maturityDate === 'string') {
         const d = parseStrictDate(maturityDate)
         if (!d) {
-          return NextResponse.json({ error: '유효한 만기일을 입력해주세요. (YYYY-MM-DD)' }, { status: 400 })
+          return fail('유효한 만기일을 입력해주세요. (YYYY-MM-DD)', 400)
         }
         data.maturityDate = d
       }
     }
 
     if (Object.keys(data).length === 0) {
-      return NextResponse.json({ error: '변경할 항목이 없습니다.' }, { status: 400 })
+      return fail('변경할 항목이 없습니다.', 400)
     }
 
     const updated = await prisma.asset.update({ where: { id }, data })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/assets/[id] error:', error)
-    return NextResponse.json({ error: '자산 수정에 실패했습니다.' }, { status: 500 })
+    return fail('자산 수정에 실패했습니다.', 500)
   }
 }
 
@@ -113,13 +111,13 @@ export async function DELETE(_request: NextRequest, props: { params: Promise<{ i
 
     const existing = await prisma.asset.findUnique({ where: { id } })
     if (!existing) {
-      return NextResponse.json({ error: '자산을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('자산을 찾을 수 없습니다.', 404)
     }
 
     await prisma.asset.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     console.error('DELETE /api/assets/[id] error:', error)
-    return NextResponse.json({ error: '자산 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('자산 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest) {
       .filter((a) => a.isLiability)
       .reduce((sum, a) => sum + a.value, 0)
 
-    return NextResponse.json({
+    return ok({
       assets,
       totalAssets,
       totalLiabilities,
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('GET /api/assets error:', error)
-    return NextResponse.json({ error: '자산 목록을 불러올 수 없습니다.' }, { status: 500 })
+    return fail('자산 목록을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -57,40 +58,37 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { name, category, owner, value, isLiability, interestRate, maturityDate, note } =
       body as Record<string, unknown>
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
-      return NextResponse.json({ error: '자산명을 입력해주세요.' }, { status: 400 })
+      return fail('자산명을 입력해주세요.', 400)
     }
     if (!category || typeof category !== 'string' || !VALID_CATEGORIES.includes(category)) {
-      return NextResponse.json(
-        { error: `유효한 카테고리를 선택해주세요: ${VALID_CATEGORIES.join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`유효한 카테고리를 선택해주세요: ${VALID_CATEGORIES.join(', ')}`, 400)
     }
     if (!owner || typeof owner !== 'string' || (owner as string).trim().length === 0) {
-      return NextResponse.json({ error: '소유자를 입력해주세요.' }, { status: 400 })
+      return fail('소유자를 입력해주세요.', 400)
     }
     if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-      return NextResponse.json({ error: '유효한 금액을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 금액을 입력해주세요.', 400)
     }
     if (isLiability !== undefined && typeof isLiability !== 'boolean') {
-      return NextResponse.json({ error: 'isLiability는 boolean이어야 합니다.' }, { status: 400 })
+      return fail('isLiability는 boolean이어야 합니다.', 400)
     }
 
     // optional 필드 검증 (제공된 경우 타입/값 확인)
     let validatedInterestRate: number | null = null
     if (interestRate !== undefined && interestRate !== null) {
       if (typeof interestRate !== 'number' || !Number.isFinite(interestRate)) {
-        return NextResponse.json({ error: '이율은 숫자여야 합니다.' }, { status: 400 })
+        return fail('이율은 숫자여야 합니다.', 400)
       }
       validatedInterestRate = interestRate
     }
@@ -98,11 +96,11 @@ export async function POST(request: NextRequest) {
     let validatedMaturityDate: Date | null = null
     if (maturityDate !== undefined && maturityDate !== null) {
       if (typeof maturityDate !== 'string') {
-        return NextResponse.json({ error: '만기일은 YYYY-MM-DD 형식이어야 합니다.' }, { status: 400 })
+        return fail('만기일은 YYYY-MM-DD 형식이어야 합니다.', 400)
       }
       const d = parseStrictDate(maturityDate)
       if (!d) {
-        return NextResponse.json({ error: '유효하지 않은 만기일입니다.' }, { status: 400 })
+        return fail('유효하지 않은 만기일입니다.', 400)
       }
       validatedMaturityDate = d
     }
@@ -120,9 +118,9 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(asset, { status: 201 })
+    return ok(asset, { status: 201 })
   } catch (error) {
     console.error('POST /api/assets error:', error)
-    return NextResponse.json({ error: '자산 등록에 실패했습니다.' }, { status: 500 })
+    return fail('자산 등록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/backtest/route.ts
+++ b/src/app/api/backtest/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { runBacktest } from '@/lib/backtest/engine'
 import { PRESET_STRATEGIES } from '@/lib/backtest/presets'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 120
@@ -12,26 +13,23 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { ticker, strategyKey, days } = body as Record<string, unknown>
 
     if (!ticker || typeof ticker !== 'string') {
-      return NextResponse.json({ error: '종목 티커를 입력해주세요.' }, { status: 400 })
+      return fail('종목 티커를 입력해주세요.', 400)
     }
 
     const key = typeof strategyKey === 'string' ? strategyKey : 'rsi'
     const strategy = PRESET_STRATEGIES[key]
     if (!strategy) {
-      return NextResponse.json(
-        { error: `사용 가능한 전략: ${Object.keys(PRESET_STRATEGIES).join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`사용 가능한 전략: ${Object.keys(PRESET_STRATEGIES).join(', ')}`, 400)
     }
 
     const periodDays = typeof days === 'number' && Number.isInteger(days) && days >= 30 && days <= 3650
@@ -58,10 +56,9 @@ export async function POST(request: NextRequest) {
       commission: 0.0025,
     })
 
-    return NextResponse.json({ ...result, currency })
+    return ok({ ...result, currency })
   } catch (error) {
-    const msg = error instanceof Error ? error.message : '백테스트 실행 실패'
     console.error('POST /api/backtest error:', error)
-    return NextResponse.json({ error: msg }, { status: 500 })
+    return fail('백테스트 실행에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/budgets/[id]/route.ts
+++ b/src/app/api/budgets/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,12 +14,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     await prisma.budget.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 예산입니다.' }, { status: 404 })
+      return fail('존재하지 않는 예산입니다.', 404)
     }
     console.error('[api/budgets/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '예산 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('예산 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/budgets/route.ts
+++ b/src/app/api/budgets/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateBudgetInput } from '@/lib/budget-utils'
 import { yearMonthSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -21,11 +22,11 @@ export async function GET(request: NextRequest) {
     })
     if (!ymResult.success) {
       const errs = zodErrorsToValidation(ymResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { year, month } = ymResult.data
     if (year === undefined || month === undefined) {
-      return NextResponse.json({ error: 'year, month 파라미터가 필요합니다.' }, { status: 400 })
+      return fail('year, month 파라미터가 필요합니다.', 400)
     }
 
     // 예산 조회
@@ -158,7 +159,7 @@ export async function GET(request: NextRequest) {
       spentByGroup[gId].total += amt
     })
 
-    return NextResponse.json({
+    return ok({
       year,
       month,
       totalBudget,
@@ -168,7 +169,7 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[api/budgets] GET 실패:', error)
-    return NextResponse.json({ error: '예산 조회에 실패했습니다.' }, { status: 500 })
+    return fail('예산 조회에 실패했습니다.', 500)
   }
 }
 
@@ -184,10 +185,10 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     // 복사 액션
@@ -198,7 +199,7 @@ export async function POST(request: NextRequest) {
     // 일반 upsert
     const errors = validateBudgetInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const amount = body.amount as number
@@ -209,14 +210,14 @@ export async function POST(request: NextRequest) {
 
     // categoryId와 groupId 동시 설정 불가
     if (categoryId && groupId) {
-      return NextResponse.json({ error: '카테고리와 그룹을 동시에 지정할 수 없습니다.' }, { status: 400 })
+      return fail('카테고리와 그룹을 동시에 지정할 수 없습니다.', 400)
     }
 
     // 그룹 존재 확인
     if (groupId) {
       const grp = await prisma.categoryGroup.findUnique({ where: { id: groupId }, select: { id: true } })
       if (!grp) {
-        return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 400 })
+        return fail('존재하지 않는 그룹입니다.', 400)
       }
     }
 
@@ -227,10 +228,10 @@ export async function POST(request: NextRequest) {
         select: { id: true, type: true },
       })
       if (!cat) {
-        return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+        return fail('존재하지 않는 카테고리입니다.', 400)
       }
       if (cat.type !== 'expense') {
-        return NextResponse.json({ error: '예산은 소비 카테고리에만 설정할 수 있습니다.' }, { status: 400 })
+        return fail('예산은 소비 카테고리에만 설정할 수 있습니다.', 400)
       }
     }
 
@@ -252,13 +253,13 @@ export async function POST(request: NextRequest) {
       return { budget: created, created: true }
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    return NextResponse.json(result.budget, { status: result.created ? 201 : 200 })
+    return ok(result.budget, { status: result.created ? 201 : 200 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/budgets] POST 실패:', error)
-    return NextResponse.json({ error: '예산 저장에 실패했습니다.' }, { status: 500 })
+    return fail('예산 저장에 실패했습니다.', 500)
   }
 }
 
@@ -273,7 +274,7 @@ async function handleCopy(body: Record<string, unknown>) {
     !Number.isInteger(targetYear) || !Number.isInteger(targetMonth) ||
     sourceMonth < 1 || sourceMonth > 12 || targetMonth < 1 || targetMonth > 12
   ) {
-    return NextResponse.json({ error: '유효한 sourceYear, sourceMonth, targetYear, targetMonth를 입력해주세요.' }, { status: 400 })
+    return fail('유효한 sourceYear, sourceMonth, targetYear, targetMonth를 입력해주세요.', 400)
   }
 
   const sourceBudgets = await prisma.budget.findMany({
@@ -281,7 +282,7 @@ async function handleCopy(body: Record<string, unknown>) {
   })
 
   if (sourceBudgets.length === 0) {
-    return NextResponse.json({ error: '복사할 예산이 없습니다.' }, { status: 400 })
+    return fail('복사할 예산이 없습니다.', 400)
   }
 
   const copied = await prisma.$transaction(async (tx) => {
@@ -310,5 +311,5 @@ async function handleCopy(body: Record<string, unknown>) {
     return count
   }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-  return NextResponse.json({ copied, targetYear, targetMonth })
+  return ok({ copied, targetYear, targetMonth })
 }

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { CATEGORY_TYPES } from '@/lib/category-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -14,17 +15,17 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       where: { id: params.id },
     })
     if (!existing) {
-      return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('카테고리를 찾을 수 없습니다.', 404)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { name, type, icon, keywords, sortOrder, groupId } = body as Record<string, unknown>
@@ -33,39 +34,39 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     // type 검증 (트랜잭션 전에)
     if (isTypeChange) {
       if (typeof type !== 'string' || !(CATEGORY_TYPES as readonly string[]).includes(type)) {
-        return NextResponse.json({ error: '유효한 유형을 선택해주세요.' }, { status: 400 })
+        return fail('유효한 유형을 선택해주세요.', 400)
       }
     }
 
     // name 검증
     if (name !== undefined) {
       if (typeof name !== 'string' || !name.trim()) {
-        return NextResponse.json({ error: '카테고리 이름을 입력해주세요.' }, { status: 400 })
+        return fail('카테고리 이름을 입력해주세요.', 400)
       }
       if (name.trim().length > 50) {
-        return NextResponse.json({ error: '이름은 50자 이내로 입력해주세요.' }, { status: 400 })
+        return fail('이름은 50자 이내로 입력해주세요.', 400)
       }
     }
 
     if (icon !== undefined && icon !== null && typeof icon !== 'string') {
-      return NextResponse.json({ error: '아이콘은 문자열이어야 합니다.' }, { status: 400 })
+      return fail('아이콘은 문자열이어야 합니다.', 400)
     }
 
     if (keywords !== undefined && keywords !== null) {
       if (!Array.isArray(keywords)) {
-        return NextResponse.json({ error: '키워드는 배열이어야 합니다.' }, { status: 400 })
+        return fail('키워드는 배열이어야 합니다.', 400)
       }
       if (keywords.some((k: unknown) => typeof k !== 'string')) {
-        return NextResponse.json({ error: '키워드는 문자열 배열이어야 합니다.' }, { status: 400 })
+        return fail('키워드는 문자열 배열이어야 합니다.', 400)
       }
     }
 
     if (sortOrder !== undefined && sortOrder !== null) {
       if (typeof sortOrder !== 'number' || !Number.isInteger(sortOrder)) {
-        return NextResponse.json({ error: '정렬 순서는 정수여야 합니다.' }, { status: 400 })
+        return fail('정렬 순서는 정수여야 합니다.', 400)
       }
       if (sortOrder < 0 || sortOrder > 999) {
-        return NextResponse.json({ error: '정렬 순서는 0~999 범위여야 합니다.' }, { status: 400 })
+        return fail('정렬 순서는 0~999 범위여야 합니다.', 400)
       }
     }
 
@@ -103,7 +104,7 @@ export async function PUT(request: NextRequest, props: RouteParams) {
         }
         return tx.category.update({ where: { id: params.id }, data: updateDataWithType })
       }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
-      return NextResponse.json(updated)
+      return ok(updated)
     }
 
     const updated = await prisma.category.update({
@@ -111,32 +112,29 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       data: baseUpdateData,
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Error) {
       if (error.message === 'NOT_FOUND') {
-        return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+        return fail('카테고리를 찾을 수 없습니다.', 404)
       }
       if (error.message === 'HAS_LINKED_DATA') {
-        return NextResponse.json(
-          { error: '거래 또는 예산이 연결된 카테고리의 유형은 변경할 수 없습니다.' },
-          { status: 400 }
-        )
+        return fail('거래 또는 예산이 연결된 카테고리의 유형은 변경할 수 없습니다.', 400)
       }
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === 'P2002') {
-        return NextResponse.json({ error: '이미 존재하는 카테고리 이름입니다.' }, { status: 409 })
+        return fail('이미 존재하는 카테고리 이름입니다.', 409)
       }
       if (error.code === 'P2025') {
-        return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+        return fail('카테고리를 찾을 수 없습니다.', 404)
       }
       if (error.code === 'P2003') {
-        return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 400 })
+        return fail('존재하지 않는 그룹입니다.', 400)
       }
     }
     console.error('PUT /api/categories/[id] error:', error)
-    return NextResponse.json({ error: '카테고리 수정에 실패했습니다.' }, { status: 500 })
+    return fail('카테고리 수정에 실패했습니다.', 500)
   }
 }
 
@@ -148,35 +146,29 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
       include: { _count: { select: { transactions: true, budgets: true } } },
     })
     if (!existing) {
-      return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('카테고리를 찾을 수 없습니다.', 404)
     }
 
     if (existing._count.transactions > 0) {
-      return NextResponse.json(
-        { error: `${existing._count.transactions}건의 거래가 연결되어 삭제할 수 없습니다.` },
-        { status: 400 }
-      )
+      return fail(`${existing._count.transactions}건의 거래가 연결되어 삭제할 수 없습니다.`, 400)
     }
 
     if (existing._count.budgets > 0) {
-      return NextResponse.json(
-        { error: `${existing._count.budgets}건의 예산이 연결되어 삭제할 수 없습니다.` },
-        { status: 400 }
-      )
+      return fail(`${existing._count.budgets}건의 예산이 연결되어 삭제할 수 없습니다.`, 400)
     }
 
     await prisma.category.delete({ where: { id: params.id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === 'P2003') {
-        return NextResponse.json({ error: '연결된 데이터가 있어 삭제할 수 없습니다.' }, { status: 400 })
+        return fail('연결된 데이터가 있어 삭제할 수 없습니다.', 400)
       }
       if (error.code === 'P2025') {
-        return NextResponse.json({ error: '카테고리를 찾을 수 없습니다.' }, { status: 404 })
+        return fail('카테고리를 찾을 수 없습니다.', 404)
       }
     }
     console.error('DELETE /api/categories/[id] error:', error)
-    return NextResponse.json({ error: '카테고리 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('카테고리 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/categories/reorder/route.ts
+++ b/src/app/api/categories/reorder/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
+import { fail, noContent } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,17 +16,17 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { items } = body as { items?: unknown }
 
     if (!Array.isArray(items) || items.length === 0) {
-      return NextResponse.json({ error: 'items 배열이 필요합니다.' }, { status: 400 })
+      return fail('items 배열이 필요합니다.', 400)
     }
 
     const validItems: ReorderItem[] = []
@@ -39,10 +40,7 @@ export async function POST(request: NextRequest) {
         (item as ReorderItem).sortOrder > 999 ||
         !Number.isInteger((item as ReorderItem).sortOrder)
       ) {
-        return NextResponse.json(
-          { error: '각 항목은 id(string)와 sortOrder(0-999 정수)가 필요합니다.' },
-          { status: 400 }
-        )
+        return fail('각 항목은 id(string)와 sortOrder(0-999 정수)가 필요합니다.', 400)
       }
       validItems.push({ id: (item as ReorderItem).id, sortOrder: (item as ReorderItem).sortOrder })
     }
@@ -50,7 +48,7 @@ export async function POST(request: NextRequest) {
     // id 유니크 검증
     const uniqueIds = new Set(validItems.map((item) => item.id))
     if (uniqueIds.size !== validItems.length) {
-      return NextResponse.json({ error: '중복된 카테고리 ID가 있습니다.' }, { status: 400 })
+      return fail('중복된 카테고리 ID가 있습니다.', 400)
     }
 
     await prisma.$transaction(
@@ -62,18 +60,12 @@ export async function POST(request: NextRequest) {
       )
     )
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json(
-        { error: '존재하지 않는 카테고리가 포함되어 있습니다.' },
-        { status: 404 }
-      )
+      return fail('존재하지 않는 카테고리가 포함되어 있습니다.', 404)
     }
     console.error('POST /api/categories/reorder error:', error)
-    return NextResponse.json(
-      { error: '정렬 순서 변경에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('정렬 순서 변경에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { validateCategoryInput, generateSlug } from '@/lib/category-utils'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
       },
     })
 
-    return NextResponse.json({ categories })
+    return ok(categories)
   } catch (error) {
     console.error('GET /api/categories error:', error)
     return NextResponse.json(

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { validateCategoryInput, generateSlug } from '@/lib/category-utils'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,10 +28,7 @@ export async function GET(request: NextRequest) {
     return ok(categories)
   } catch (error) {
     console.error('GET /api/categories error:', error)
-    return NextResponse.json(
-      { error: '카테고리를 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('카테고리를 불러올 수 없습니다.', 500)
   }
 }
 
@@ -41,15 +38,15 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const errors = validateCategoryInput(body as Record<string, unknown>)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { name, type, icon, keywords, sortOrder, groupId } = body as Record<string, unknown>
@@ -78,34 +75,31 @@ export async function POST(request: NextRequest) {
             groupId: typeof groupId === 'string' ? groupId : null,
           },
         })
-        return NextResponse.json(category, { status: 201 })
+        return ok(category, { status: 201 })
       } catch (error) {
         if (error instanceof Prisma.PrismaClientKnownRequestError) {
           if (error.code === 'P2002') {
             const target = (error.meta?.target as string[]) ?? []
             if (target.includes('name')) {
-              return NextResponse.json({ error: '이미 존재하는 카테고리 이름입니다.' }, { status: 409 })
+              return fail('이미 존재하는 카테고리 이름입니다.', 409)
             }
             // slug 충돌 → 다음 attempt에서 suffix 추가
             if (attempt === MAX_SLUG_RETRIES - 1) {
-              return NextResponse.json({ error: '카테고리 생성에 실패했습니다. 다시 시도해주세요.' }, { status: 409 })
+              return fail('카테고리 생성에 실패했습니다. 다시 시도해주세요.', 409)
             }
             continue
           }
           if (error.code === 'P2003') {
-            return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 400 })
+            return fail('존재하지 않는 그룹입니다.', 400)
           }
         }
         throw error
       }
     }
 
-    return NextResponse.json({ error: '카테고리 생성에 실패했습니다.' }, { status: 500 })
+    return fail('카테고리 생성에 실패했습니다.', 500)
   } catch (error) {
     console.error('POST /api/categories error:', error)
-    return NextResponse.json(
-      { error: '카테고리 생성에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('카테고리 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/category-groups/[id]/route.ts
+++ b/src/app/api/category-groups/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -16,14 +17,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     const data: Record<string, unknown> = {}
     if (typeof body.name === 'string') {
       const name = body.name.trim()
-      if (!name) return NextResponse.json({ error: '그룹 이름을 입력해주세요.' }, { status: 400 })
-      if (name.length > 50) return NextResponse.json({ error: '이름은 50자 이내로 입력해주세요.' }, { status: 400 })
+      if (!name) return fail('그룹 이름을 입력해주세요.', 400)
+      if (name.length > 50) return fail('이름은 50자 이내로 입력해주세요.', 400)
       data.name = name
     }
     if (body.icon !== undefined) {
@@ -38,14 +39,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       data,
     })
 
-    return NextResponse.json(group)
+    return ok(group)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2025') return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 404 })
-      if (error.code === 'P2002') return NextResponse.json({ error: '이미 존재하는 그룹 이름입니다.' }, { status: 409 })
+      if (error.code === 'P2025') return fail('존재하지 않는 그룹입니다.', 404)
+      if (error.code === 'P2002') return fail('이미 존재하는 그룹 이름입니다.', 409)
     }
     console.error('[api/category-groups/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '그룹 수정에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 수정에 실패했습니다.', 500)
   }
 }
 
@@ -64,16 +65,16 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       const parts: string[] = []
       if (catCount > 0) parts.push(`${catCount}개의 카테고리`)
       if (budgetCount > 0) parts.push(`${budgetCount}개의 예산`)
-      return NextResponse.json({ error: `${parts.join(', ')}이 연결되어 삭제할 수 없습니다.` }, { status: 400 })
+      return fail(`${parts.join(', ')}이 연결되어 삭제할 수 없습니다.`, 400)
     }
 
     await prisma.categoryGroup.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 그룹입니다.' }, { status: 404 })
+      return fail('존재하지 않는 그룹입니다.', 404)
     }
     console.error('[api/category-groups/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '그룹 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/category-groups/route.ts
+++ b/src/app/api/category-groups/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,7 +13,7 @@ export async function GET() {
       orderBy: { sortOrder: 'asc' },
       include: { _count: { select: { categories: true } } },
     })
-    return NextResponse.json({ groups })
+    return ok(groups)
   } catch (error) {
     console.error('[api/category-groups] GET 실패:', error)
     return NextResponse.json({ error: '그룹 조회에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/category-groups/route.ts
+++ b/src/app/api/category-groups/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,7 +16,7 @@ export async function GET() {
     return ok(groups)
   } catch (error) {
     console.error('[api/category-groups] GET 실패:', error)
-    return NextResponse.json({ error: '그룹 조회에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 조회에 실패했습니다.', 500)
   }
 }
 
@@ -29,15 +29,15 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     const name = typeof body.name === 'string' ? body.name.trim() : ''
     if (!name) {
-      return NextResponse.json({ error: '그룹 이름을 입력해주세요.' }, { status: 400 })
+      return fail('그룹 이름을 입력해주세요.', 400)
     }
     if (name.length > 50) {
-      return NextResponse.json({ error: '이름은 50자 이내로 입력해주세요.' }, { status: 400 })
+      return fail('이름은 50자 이내로 입력해주세요.', 400)
     }
 
     const icon = typeof body.icon === 'string' ? body.icon.trim() || null : null
@@ -48,12 +48,12 @@ export async function POST(request: NextRequest) {
       data: { name, icon, sortOrder },
     })
 
-    return NextResponse.json(group, { status: 201 })
+    return ok(group, { status: 201 })
   } catch (error) {
     if ((error as { code?: string }).code === 'P2002') {
-      return NextResponse.json({ error: '이미 존재하는 그룹 이름입니다.' }, { status: 409 })
+      return fail('이미 존재하는 그룹 이름입니다.', 409)
     }
     console.error('[api/category-groups] POST 실패:', error)
-    return NextResponse.json({ error: '그룹 생성에 실패했습니다.' }, { status: 500 })
+    return fail('그룹 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/deposits/[id]/route.ts
+++ b/src/app/api/deposits/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -10,37 +11,37 @@ export async function PUT(request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.deposit.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '입금 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('입금 기록을 찾을 수 없습니다.', 404)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     const { amount, source, note, depositedAt } = body as Record<string, unknown>
 
     if (amount !== undefined && (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0)) {
-      return NextResponse.json({ error: '금액은 0보다 커야 합니다.' }, { status: 400 })
+      return fail('금액은 0보다 커야 합니다.', 400)
     }
     if (source !== undefined && (typeof source !== 'string' || !source.trim())) {
-      return NextResponse.json({ error: '출처를 입력해주세요.' }, { status: 400 })
+      return fail('출처를 입력해주세요.', 400)
     }
     if (depositedAt !== undefined && (typeof depositedAt !== 'string' || isNaN(Date.parse(depositedAt)))) {
-      return NextResponse.json({ error: '유효한 입금일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 입금일을 입력해주세요.', 400)
     }
     if (note !== undefined && note !== null && typeof note !== 'string') {
-      return NextResponse.json({ error: '메모는 문자열이어야 합니다.' }, { status: 400 })
+      return fail('메모는 문자열이어야 합니다.', 400)
     }
 
     if (typeof amount === 'number') {
       const roundedAmount = Math.round(amount)
       if (roundedAmount <= 0) {
-        return NextResponse.json({ error: '금액은 1원 이상이어야 합니다.' }, { status: 400 })
+        return fail('금액은 1원 이상이어야 합니다.', 400)
       }
     }
 
@@ -69,10 +70,10 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       return result
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/deposits/[id] error:', error)
-    return NextResponse.json({ error: '입금 수정에 실패했습니다.' }, { status: 500 })
+    return fail('입금 수정에 실패했습니다.', 500)
   }
 }
 
@@ -81,7 +82,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.deposit.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '입금 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('입금 기록을 찾을 수 없습니다.', 404)
     }
 
     await prisma.$transaction(async (tx) => {
@@ -95,9 +96,9 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
         })
       }
     })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     console.error('DELETE /api/deposits/[id] error:', error)
-    return NextResponse.json({ error: '입금 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('입금 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/deposits/route.ts
+++ b/src/app/api/deposits/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateDepositInput } from '@/lib/deposit-utils'
 import { isGiftSource } from '@/lib/tax/gift-tax'
 import { checkGiftTaxLimit } from '@/bot/notifications/budget-alert'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
-import { ok, fail } from '@/lib/api-response'
+import { ok, fail, paginated } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,14 +19,14 @@ export async function GET(request: NextRequest) {
     })
     if (!paginationResult.success) {
       const errs = zodErrorsToValidation(paginationResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { limit, offset } = paginationResult.data
 
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -57,13 +57,10 @@ export async function GET(request: NextRequest) {
       prisma.deposit.count({ where }),
     ])
 
-    return NextResponse.json({ deposits, total, limit, offset })
+    return paginated(deposits, total, limit, offset)
   } catch (error) {
     console.error('GET /api/deposits error:', error)
-    return NextResponse.json(
-      { error: '입금 내역을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('입금 내역을 불러올 수 없습니다.', 500)
   }
 }
 

--- a/src/app/api/deposits/route.ts
+++ b/src/app/api/deposits/route.ts
@@ -5,6 +5,7 @@ import { isGiftSource } from '@/lib/tax/gift-tax'
 import { checkGiftTaxLimit } from '@/bot/notifications/budget-alert'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -72,34 +73,34 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
     const errors = validateDepositInput(body as Record<string, unknown>)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { accountId, assetId, amount, source, note, depositedAt } = body as Record<string, unknown>
 
     if (note !== undefined && note !== null && typeof note !== 'string') {
-      return NextResponse.json({ error: '메모는 문자열이어야 합니다.' }, { status: 400 })
+      return fail('메모는 문자열이어야 합니다.', 400)
     }
 
     if (accountId) {
       const account = await prisma.account.findUnique({ where: { id: accountId as string } })
-      if (!account) return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      if (!account) return fail('계좌를 찾을 수 없습니다.', 404)
     }
     if (assetId) {
       const asset = await prisma.asset.findUnique({ where: { id: assetId as string } })
-      if (!asset) return NextResponse.json({ error: '자산을 찾을 수 없습니다.' }, { status: 404 })
+      if (!asset) return fail('자산을 찾을 수 없습니다.', 404)
     }
 
     const roundedAmount = Math.round(amount as number)
     if (roundedAmount <= 0) {
-      return NextResponse.json({ error: '금액은 1원 이상이어야 합니다.' }, { status: 400 })
+      return fail('금액은 1원 이상이어야 합니다.', 400)
     }
 
     const deposit = await prisma.$transaction(async (tx) => {
@@ -130,12 +131,9 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    return NextResponse.json(deposit, { status: 201 })
+    return ok(deposit, { status: 201 })
   } catch (error) {
     console.error('POST /api/deposits error:', error)
-    return NextResponse.json(
-      { error: '입금 기록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('입금 기록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/dividends/[id]/route.ts
+++ b/src/app/api/dividends/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calcAmountKRW } from '@/lib/dividend-utils'
 import { validateFxRateForUSD } from '@/lib/trade-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -12,33 +13,33 @@ export async function PUT(request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.dividend.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '배당 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('배당 기록을 찾을 수 없습니다.', 404)
     }
 
     const body = await request.json()
     const { exDate, payDate, amountGross, amountNet, taxAmount, fxRate, reinvested } = body
 
     if (amountGross !== undefined && (typeof amountGross !== 'number' || !Number.isFinite(amountGross) || amountGross <= 0)) {
-      return NextResponse.json({ error: '세전 금액은 0보다 커야 합니다.' }, { status: 400 })
+      return fail('세전 금액은 0보다 커야 합니다.', 400)
     }
     if (amountNet !== undefined && (typeof amountNet !== 'number' || !Number.isFinite(amountNet) || amountNet < 0)) {
-      return NextResponse.json({ error: '세후 금액은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('세후 금액은 0 이상이어야 합니다.', 400)
     }
     if (payDate !== undefined && (typeof payDate !== 'string' || isNaN(Date.parse(payDate)))) {
-      return NextResponse.json({ error: '유효한 지급일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 지급일을 입력해주세요.', 400)
     }
     if (exDate !== undefined && exDate !== null && (typeof exDate !== 'string' || isNaN(Date.parse(exDate)))) {
-      return NextResponse.json({ error: '유효한 기준일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 기준일을 입력해주세요.', 400)
     }
     if (taxAmount !== undefined && taxAmount !== null && (typeof taxAmount !== 'number' || !Number.isFinite(taxAmount) || taxAmount < 0)) {
-      return NextResponse.json({ error: '세금은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('세금은 0 이상이어야 합니다.', 400)
     }
     if (fxRate !== undefined && fxRate !== null && existing.currency === 'USD') {
       const fxError = validateFxRateForUSD(fxRate, 'USD 배당')
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
     if (reinvested !== undefined && typeof reinvested !== 'boolean') {
-      return NextResponse.json({ error: '재투자 여부는 true/false여야 합니다.' }, { status: 400 })
+      return fail('재투자 여부는 true/false여야 합니다.', 400)
     }
 
     // 최종 적용값 결정
@@ -51,16 +52,16 @@ export async function PUT(request: NextRequest, props: RouteParams) {
 
     // 교차 검증: amountNet <= amountGross, taxAmount <= amountGross
     if (nextNet > nextGross) {
-      return NextResponse.json({ error: '세후 금액이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세후 금액이 세전 금액을 초과할 수 없습니다.', 400)
     }
     if (nextTax != null && nextTax > nextGross) {
-      return NextResponse.json({ error: '세금이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세금이 세전 금액을 초과할 수 없습니다.', 400)
     }
 
     // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
     if (existing.currency === 'USD') {
       const fxError = validateFxRateForUSD(nextFxRate, 'USD 배당')
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
 
     // 서버 측 amountKRW 재계산
@@ -80,10 +81,10 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       },
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     console.error('PUT /api/dividends/[id] error:', error)
-    return NextResponse.json({ error: '배당 수정에 실패했습니다.' }, { status: 500 })
+    return fail('배당 수정에 실패했습니다.', 500)
   }
 }
 
@@ -92,13 +93,13 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
   try {
     const existing = await prisma.dividend.findUnique({ where: { id: params.id } })
     if (!existing) {
-      return NextResponse.json({ error: '배당 기록을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('배당 기록을 찾을 수 없습니다.', 404)
     }
 
     await prisma.dividend.delete({ where: { id: params.id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     console.error('DELETE /api/dividends/[id] error:', error)
-    return NextResponse.json({ error: '배당 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('배당 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/dividends/route.ts
+++ b/src/app/api/dividends/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 import { validateDividendInput, calcAmountKRW } from '@/lib/dividend-utils'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -66,7 +67,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const errors = validateDividendInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { accountId, displayName, exDate, payDate, amountGross, amountNet, taxAmount, currency, fxRate, reinvested } = body
@@ -74,21 +75,21 @@ export async function POST(request: NextRequest) {
 
     // 옵션 필드 타입 검증
     if (exDate !== undefined && exDate !== null && (typeof exDate !== 'string' || isNaN(Date.parse(exDate)))) {
-      return NextResponse.json({ error: '유효한 기준일을 입력해주세요.' }, { status: 400 })
+      return fail('유효한 기준일을 입력해주세요.', 400)
     }
     if (taxAmount !== undefined && taxAmount !== null && (typeof taxAmount !== 'number' || !Number.isFinite(taxAmount) || taxAmount < 0)) {
-      return NextResponse.json({ error: '세금은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('세금은 0 이상이어야 합니다.', 400)
     }
     if (reinvested !== undefined && reinvested !== null && typeof reinvested !== 'boolean') {
-      return NextResponse.json({ error: '재투자 여부는 true/false여야 합니다.' }, { status: 400 })
+      return fail('재투자 여부는 true/false여야 합니다.', 400)
     }
 
     // 교차 검증
     if (amountNet > amountGross) {
-      return NextResponse.json({ error: '세후 금액이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세후 금액이 세전 금액을 초과할 수 없습니다.', 400)
     }
     if (taxAmount != null && taxAmount > amountGross) {
-      return NextResponse.json({ error: '세금이 세전 금액을 초과할 수 없습니다.' }, { status: 400 })
+      return fail('세금이 세전 금액을 초과할 수 없습니다.', 400)
     }
 
     // 서버 측 amountKRW 재계산 (클라이언트 값 대신 서버 계산값 사용)
@@ -96,7 +97,7 @@ export async function POST(request: NextRequest) {
 
     const account = await prisma.account.findUnique({ where: { id: accountId } })
     if (!account) {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
     const dividend = await prisma.dividend.create({
@@ -116,12 +117,9 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(dividend, { status: 201 })
+    return ok(dividend, { status: 201 })
   } catch (error) {
     console.error('POST /api/dividends error:', error)
-    return NextResponse.json(
-      { error: '배당 기록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('배당 기록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/dividends/route.ts
+++ b/src/app/api/dividends/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateDividendInput, calcAmountKRW } from '@/lib/dividend-utils'
 import { paginationSchema, yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
-import { ok, fail } from '@/lib/api-response'
+import { ok, fail, paginated } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,14 +17,14 @@ export async function GET(request: NextRequest) {
     })
     if (!paginationResult.success) {
       const errs = zodErrorsToValidation(paginationResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { limit, offset } = paginationResult.data
 
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -52,13 +52,10 @@ export async function GET(request: NextRequest) {
       prisma.dividend.count({ where }),
     ])
 
-    return NextResponse.json({ dividends, total, limit, offset })
+    return paginated(dividends, total, limit, offset)
   } catch (error) {
     console.error('GET /api/dividends error:', error)
-    return NextResponse.json(
-      { error: '배당 내역을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('배당 내역을 불러올 수 없습니다.', 500)
   }
 }
 

--- a/src/app/api/dividends/summary/route.ts
+++ b/src/app/api/dividends/summary/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,7 +12,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data ?? new Date().getFullYear()
     const accountId = searchParams.get('accountId')
@@ -75,7 +76,7 @@ export async function GET(request: NextRequest) {
       byMonth[month].count += 1
     }
 
-    return NextResponse.json({
+    return ok({
       year,
       totalNetKRW: Math.round(totalNetKRW),
       totalTaxKRW: Math.round(totalTaxKRW),
@@ -87,9 +88,6 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('GET /api/dividends/summary error:', error)
-    return NextResponse.json(
-      { error: '배당 요약을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('배당 요약을 불러올 수 없습니다.', 500)
   }
 }

--- a/src/app/api/exports/deposits/route.ts
+++ b/src/app/api/exports/deposits/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toCSV, csvResponse } from '@/lib/csv'
 import { formatDate } from '@/lib/format'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -57,9 +58,6 @@ export async function GET(request: NextRequest) {
     return csvResponse(csv, `deposits${suffix}_${yearSuffix}.csv`)
   } catch (error) {
     console.error('GET /api/exports/deposits error:', error)
-    return new Response(JSON.stringify({ error: 'CSV 생성에 실패했습니다.' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return fail('CSV 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/exports/dividends/route.ts
+++ b/src/app/api/exports/dividends/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toCSV, csvResponse } from '@/lib/csv'
 import { formatDate } from '@/lib/format'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -60,9 +61,6 @@ export async function GET(request: NextRequest) {
     return csvResponse(csv, `dividends${suffix}_${yearSuffix}.csv`)
   } catch (error) {
     console.error('GET /api/exports/dividends error:', error)
-    return new Response(JSON.stringify({ error: 'CSV 생성에 실패했습니다.' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return fail('CSV 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/exports/trades/route.ts
+++ b/src/app/api/exports/trades/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toCSV, csvResponse } from '@/lib/csv'
 import { formatDate } from '@/lib/format'
 import { yearSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const yearResult = yearSchema.safeParse(searchParams.get('year'))
     if (!yearResult.success) {
       const errs = zodErrorsToValidation(yearResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const year = yearResult.data
 
@@ -63,9 +64,6 @@ export async function GET(request: NextRequest) {
     return csvResponse(csv, `trades${suffix}_${yearSuffix}.csv`)
   } catch (error) {
     console.error('GET /api/exports/trades error:', error)
-    return new Response(JSON.stringify({ error: 'CSV 생성에 실패했습니다.' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return fail('CSV 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/exports/vesting.ics/route.ts
+++ b/src/app/api/exports/vesting.ics/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { toVestingEvents, toKSTDateString } from '@/lib/vesting-events'
 import { buildICS, type ICSEvent } from '@/lib/ics'
+import { fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,6 +69,6 @@ export async function GET() {
     })
   } catch (error) {
     console.error('GET /api/exports/vesting.ics error:', error)
-    return NextResponse.json({ error: '캘린더 내보내기에 실패했습니다.' }, { status: 500 })
+    return fail('캘린더 내보내기에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/income-profiles/[id]/route.ts
+++ b/src/app/api/income-profiles/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import {
@@ -6,18 +6,19 @@ import {
   calcTaxableFromGross,
   type IncomeProfileInput,
 } from '@/lib/tax/income-profile-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 function handlePrismaError(error: unknown, context: string) {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     if (error.code === 'P2025') {
-      return NextResponse.json({ error: '프로필을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('프로필을 찾을 수 없습니다.', 404)
     }
     if (error.code === 'P2002') {
-      return NextResponse.json({ error: '해당 연도 프로필이 이미 존재합니다.' }, { status: 409 })
+      return fail('해당 연도 프로필이 이미 존재합니다.', 409)
     }
   }
   console.error(`${context} error:`, error)
-  return NextResponse.json({ error: `${context}에 실패했습니다.` }, { status: 500 })
+  return fail(`${context}에 실패했습니다.`, 500)
 }
 
 /** PUT /api/income-profiles/[id] — 수정 */
@@ -30,12 +31,12 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const errors = validateIncomeProfileInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { year, inputType, prepaidTax, note } = body as IncomeProfileInput
@@ -66,7 +67,7 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
       },
     })
 
-    return NextResponse.json(profile)
+    return ok(profile)
   } catch (error) {
     return handlePrismaError(error, '근로소득 프로필 수정')
   }
@@ -78,7 +79,7 @@ export async function DELETE(_request: NextRequest, props: { params: Promise<{ i
   try {
     const { id } = params
     await prisma.incomeProfile.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     return handlePrismaError(error, '근로소득 프로필 삭제')
   }

--- a/src/app/api/income-profiles/route.ts
+++ b/src/app/api/income-profiles/route.ts
@@ -6,6 +6,7 @@ import {
   calcTaxableFromGross,
   type IncomeProfileInput,
 } from '@/lib/tax/income-profile-utils'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,7 +16,7 @@ export async function GET() {
     const profiles = await prisma.incomeProfile.findMany({
       orderBy: { year: 'desc' },
     })
-    return NextResponse.json(profiles)
+    return ok(profiles)
   } catch (error) {
     console.error('GET /api/income-profiles error:', error)
     return NextResponse.json(

--- a/src/app/api/income-profiles/route.ts
+++ b/src/app/api/income-profiles/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import {
@@ -6,7 +6,7 @@ import {
   calcTaxableFromGross,
   type IncomeProfileInput,
 } from '@/lib/tax/income-profile-utils'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,10 +19,7 @@ export async function GET() {
     return ok(profiles)
   } catch (error) {
     console.error('GET /api/income-profiles error:', error)
-    return NextResponse.json(
-      { error: '근로소득 프로필 조회에 실패했습니다.' },
-      { status: 500 },
-    )
+    return fail('근로소득 프로필 조회에 실패했습니다.', 500)
   }
 }
 
@@ -33,12 +30,12 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const errors = validateIncomeProfileInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { year, inputType, prepaidTax, note } = body as IncomeProfileInput
@@ -69,18 +66,12 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(profile, { status: 201 })
+    return ok(profile, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-      return NextResponse.json(
-        { error: '해당 연도 프로필이 이미 존재합니다. 수정을 이용해주세요.' },
-        { status: 409 },
-      )
+      return fail('해당 연도 프로필이 이미 존재합니다. 수정을 이용해주세요.', 409)
     }
     console.error('POST /api/income-profiles error:', error)
-    return NextResponse.json(
-      { error: '근로소득 프로필 생성에 실패했습니다.' },
-      { status: 500 },
-    )
+    return fail('근로소득 프로필 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/networth/route.ts
+++ b/src/app/api/networth/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import {
   calcCurrentValueKRW,
   DEFAULT_FX_RATE_USD_KRW,
 } from '@/lib/format'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -76,7 +76,7 @@ export async function GET() {
       take: 12,
     })
 
-    return NextResponse.json({
+    return ok({
       netWorthKRW,
       stockValueKRW,
       assetValueKRW,
@@ -104,6 +104,6 @@ export async function GET() {
     })
   } catch (error) {
     console.error('GET /api/networth error:', error)
-    return NextResponse.json({ error: '순자산을 계산할 수 없습니다.' }, { status: 500 })
+    return fail('순자산을 계산할 수 없습니다.', 500)
   }
 }

--- a/src/app/api/performance/benchmark/backfill/route.ts
+++ b/src/app/api/performance/benchmark/backfill/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { backfillAllBenchmarks } from '@/lib/performance/benchmark'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,9 +10,9 @@ export const dynamic = 'force-dynamic'
 export async function POST() {
   try {
     const results = await backfillAllBenchmarks()
-    return NextResponse.json({ results }, { status: 201 })
+    return ok(results, { status: 201 })
   } catch (error) {
     console.error('POST /api/performance/benchmark/backfill error:', error)
-    return NextResponse.json({ error: '벤치마크 backfill에 실패했습니다.' }, { status: 500 })
+    return fail('벤치마크 backfill에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/performance/contribution/route.ts
+++ b/src/app/api/performance/contribution/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { calculateContribution } from '@/lib/performance/contribution'
 import { VALID_PERIODS } from '@/lib/performance/constants'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,20 +16,17 @@ export async function GET(request: NextRequest) {
     const period = searchParams.get('period') ?? '6M'
 
     if (!accountId) {
-      return NextResponse.json({ error: 'accountId는 필수입니다.' }, { status: 400 })
+      return fail('accountId는 필수입니다.', 400)
     }
 
     if (!VALID_PERIODS.includes(period)) {
-      return NextResponse.json(
-        { error: `유효한 기간: ${VALID_PERIODS.join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`유효한 기간: ${VALID_PERIODS.join(', ')}`, 400)
     }
 
     const result = await calculateContribution(accountId, period)
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     console.error('GET /api/performance/contribution error:', error)
-    return NextResponse.json({ error: '기여도 분석에 실패했습니다.' }, { status: 500 })
+    return fail('기여도 분석에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/performance/snapshots/route.ts
+++ b/src/app/api/performance/snapshots/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { takeAllSnapshots } from '@/lib/performance/snapshot'
 import { BENCHMARK_DISPLAY_NAMES } from '@/lib/performance/constants'
 import { dateRangeSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
     const accountId = searchParams.get('accountId')
 
     if (!accountId) {
-      return NextResponse.json({ error: 'accountId는 필수입니다.' }, { status: 400 })
+      return fail('accountId는 필수입니다.', 400)
     }
 
     const dateResult = dateRangeSchema.safeParse({
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest) {
     })
     if (!dateResult.success) {
       const errs = zodErrorsToValidation(dateResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { from, to } = dateResult.data
 
@@ -91,14 +92,14 @@ export async function GET(request: NextRequest) {
       normalizedValue: baseValue > 0 ? (s.totalValueKRW / baseValue) * 100 : 100,
     }))
 
-    return NextResponse.json({
+    return ok({
       snapshots: normalizedSnapshots,
       benchmark,
       benchmarkName,
     })
   } catch (error) {
     console.error('GET /api/performance/snapshots error:', error)
-    return NextResponse.json({ error: '스냅샷 데이터를 불러올 수 없습니다.' }, { status: 500 })
+    return fail('스냅샷 데이터를 불러올 수 없습니다.', 500)
   }
 }
 
@@ -109,9 +110,9 @@ export async function GET(request: NextRequest) {
 export async function POST() {
   try {
     const results = await takeAllSnapshots()
-    return NextResponse.json({ results }, { status: 201 })
+    return ok(results, { status: 201 })
   } catch (error) {
     console.error('POST /api/performance/snapshots error:', error)
-    return NextResponse.json({ error: '스냅샷 생성에 실패했습니다.' }, { status: 500 })
+    return fail('스냅샷 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/performance/twr/route.ts
+++ b/src/app/api/performance/twr/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { calculateTWR } from '@/lib/performance/twr'
 import { VALID_PERIODS } from '@/lib/performance/constants'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,20 +16,17 @@ export async function GET(request: NextRequest) {
     const period = searchParams.get('period') ?? '3M'
 
     if (!accountId) {
-      return NextResponse.json({ error: 'accountId는 필수입니다.' }, { status: 400 })
+      return fail('accountId는 필수입니다.', 400)
     }
 
     if (!VALID_PERIODS.includes(period)) {
-      return NextResponse.json(
-        { error: `유효한 기간: ${VALID_PERIODS.join(', ')}` },
-        { status: 400 }
-      )
+      return fail(`유효한 기간: ${VALID_PERIODS.join(', ')}`, 400)
     }
 
     const result = await calculateTWR(accountId, period)
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     console.error('GET /api/performance/twr error:', error)
-    return NextResponse.json({ error: 'TWR 계산에 실패했습니다.' }, { status: 500 })
+    return fail('TWR 계산에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/prices/krx-sync/route.ts
+++ b/src/app/api/prices/krx-sync/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { syncKrxStocks } from '@/lib/krx-stocks'
+import { ok, fail } from '@/lib/api-response'
 
 /** 최소 동기화 간격 (ms) — 10분 */
 const MIN_SYNC_INTERVAL_MS = 600_000
@@ -15,29 +15,23 @@ export async function POST() {
   try {
     const now = Date.now()
     if (now - lastSyncAt < MIN_SYNC_INTERVAL_MS) {
-      return NextResponse.json(
-        { error: 'KRX 동기화 간격이 너무 짧습니다. 10분 후 다시 시도해주세요.' },
-        { status: 429 }
-      )
+      return fail('KRX 동기화 간격이 너무 짧습니다. 10분 후 다시 시도해주세요.', 429)
     }
 
     if (isSyncing) {
-      return NextResponse.json(
-        { error: 'KRX 동기화가 이미 진행 중입니다.' },
-        { status: 429 }
-      )
+      return fail('KRX 동기화가 이미 진행 중입니다.', 429)
     }
 
     isSyncing = true
     try {
       const result = await syncKrxStocks()
       lastSyncAt = Date.now()
-      return NextResponse.json(result)
+      return ok(result)
     } finally {
       isSyncing = false
     }
   } catch (error) {
     console.error('[api] KRX 종목 동기화 실패:', error)
-    return NextResponse.json({ error: 'KRX 종목 동기화에 실패했습니다.' }, { status: 500 })
+    return fail('KRX 종목 동기화에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/prices/refresh/route.ts
+++ b/src/app/api/prices/refresh/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { refreshPrices } from '@/lib/price-fetcher'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,20 +12,14 @@ export async function POST() {
   try {
     const now = Date.now()
     if (now - lastRefreshAt < MIN_REFRESH_INTERVAL_MS) {
-      return NextResponse.json(
-        { error: '갱신 간격이 너무 짧습니다. 30초 후 다시 시도해주세요.' },
-        { status: 429 }
-      )
+      return fail('갱신 간격이 너무 짧습니다. 30초 후 다시 시도해주세요.', 429)
     }
 
     lastRefreshAt = now
     const result = await refreshPrices()
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     console.error('POST /api/prices/refresh error:', error)
-    return NextResponse.json(
-      { error: '주가 갱신에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('주가 갱신에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/prices/route.ts
+++ b/src/app/api/prices/route.ts
@@ -1,7 +1,6 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { getLastUpdatedAt } from '@/lib/format'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,9 +15,6 @@ export async function GET() {
     return ok({ prices, lastUpdatedAt })
   } catch (error) {
     console.error('GET /api/prices error:', error)
-    return NextResponse.json(
-      { error: '주가 정보를 불러오지 못했습니다.' },
-      { status: 500 }
-    )
+    return fail('주가 정보를 불러오지 못했습니다.', 500)
   }
 }

--- a/src/app/api/prices/route.ts
+++ b/src/app/api/prices/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { getLastUpdatedAt } from '@/lib/format'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,7 +13,7 @@ export async function GET() {
 
     const lastUpdatedAt = getLastUpdatedAt(prices)
 
-    return NextResponse.json({ prices, lastUpdatedAt })
+    return ok({ prices, lastUpdatedAt })
   } catch (error) {
     console.error('GET /api/prices error:', error)
     return NextResponse.json(

--- a/src/app/api/prices/search/route.ts
+++ b/src/app/api/prices/search/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { searchKrxByName } from '@/lib/krx-stocks'
 import { searchYahooByName } from '@/lib/price-fetcher'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,17 +14,14 @@ export async function GET(request: NextRequest) {
     const q = request.nextUrl.searchParams.get('q')?.trim()
 
     if (!q || q.length < 2) {
-      return NextResponse.json(
-        { error: '검색어는 2자 이상 입력해주세요.' },
-        { status: 400 }
-      )
+      return fail('검색어는 2자 이상 입력해주세요.', 400)
     }
 
     const hasKorean = /[가-힣]/.test(q)
 
     if (hasKorean) {
       const results = await searchKrxByName(q)
-      return NextResponse.json({
+      return ok({
         source: 'krx',
         results: results.map((r) => ({
           ticker: r.ticker,
@@ -34,7 +32,7 @@ export async function GET(request: NextRequest) {
     }
 
     const results = await searchYahooByName(q)
-    return NextResponse.json({
+    return ok({
       source: 'yahoo',
       results: results.map((r) => ({
         ticker: r.symbol,
@@ -45,6 +43,6 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[api] 종목 검색 실패:', error)
-    return NextResponse.json({ error: '종목 검색에 실패했습니다.' }, { status: 500 })
+    return fail('종목 검색에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/recurring/[id]/route.ts
+++ b/src/app/api/recurring/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateRecurringInput } from '@/lib/recurring-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -17,15 +18,15 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     const errors = validateRecurringInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const nextRunAt = body.nextRunAt
@@ -46,14 +47,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       },
     })
 
-    return NextResponse.json(item)
+    return ok(item)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2025') return NextResponse.json({ error: '존재하지 않는 반복 거래입니다.' }, { status: 404 })
-      if (error.code === 'P2003') return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      if (error.code === 'P2025') return fail('존재하지 않는 반복 거래입니다.', 404)
+      if (error.code === 'P2003') return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/recurring/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '반복 거래 수정에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 수정에 실패했습니다.', 500)
   }
 }
 
@@ -68,11 +69,11 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     if (typeof body.isActive !== 'boolean') {
-      return NextResponse.json({ error: 'isActive는 boolean이어야 합니다.' }, { status: 400 })
+      return fail('isActive는 boolean이어야 합니다.', 400)
     }
 
     const item = await prisma.recurringTransaction.update({
@@ -80,13 +81,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       data: { isActive: body.isActive },
     })
 
-    return NextResponse.json({ id: item.id, isActive: item.isActive })
+    return ok({ id: item.id, isActive: item.isActive })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 반복 거래입니다.' }, { status: 404 })
+      return fail('존재하지 않는 반복 거래입니다.', 404)
     }
     console.error('[api/recurring/[id]] PATCH 실패:', error)
-    return NextResponse.json({ error: '상태 변경에 실패했습니다.' }, { status: 500 })
+    return fail('상태 변경에 실패했습니다.', 500)
   }
 }
 
@@ -97,12 +98,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     await prisma.recurringTransaction.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 반복 거래입니다.' }, { status: 404 })
+      return fail('존재하지 않는 반복 거래입니다.', 404)
     }
     console.error('[api/recurring/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '반복 거래 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/recurring/route.ts
+++ b/src/app/api/recurring/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateRecurringInput } from '@/lib/recurring-utils'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -38,7 +38,7 @@ export async function GET() {
     return ok(serialized)
   } catch (error) {
     console.error('[api/recurring] GET 실패:', error)
-    return NextResponse.json({ error: '반복 거래 조회에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 조회에 실패했습니다.', 500)
   }
 }
 
@@ -51,15 +51,15 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
 
     const errors = validateRecurringInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const category = await prisma.category.findUnique({
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
       select: { id: true },
     })
     if (!category) {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
 
     const nextRunAt = body.nextRunAt
@@ -87,12 +87,12 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(item, { status: 201 })
+    return ok(item, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/recurring] POST 실패:', error)
-    return NextResponse.json({ error: '반복 거래 생성에 실패했습니다.' }, { status: 500 })
+    return fail('반복 거래 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/recurring/route.ts
+++ b/src/app/api/recurring/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateRecurringInput } from '@/lib/recurring-utils'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,7 +35,7 @@ export async function GET() {
       lastRunAt: r.lastRunAt?.toISOString() ?? null,
     }))
 
-    return NextResponse.json({ items: serialized })
+    return ok(serialized)
   } catch (error) {
     console.error('[api/recurring] GET 실패:', error)
     return NextResponse.json({ error: '반복 거래 조회에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/reports/[id]/download/route.ts
+++ b/src/app/api/reports/[id]/download/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { fail } from '@/lib/api-response'
 
 const REPORTS_DIR = path.join(process.cwd(), 'reports')
 
 /**
  * GET /api/reports/[id]/download — PDF 다운로드
+ *
+ * 성공 path 는 raw NextResponse(buffer) — Content-Disposition 헤더 필요.
+ * 에러 path 만 envelope (`fail()`).
  */
 export async function GET(_request: NextRequest, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -16,11 +20,11 @@ export async function GET(_request: NextRequest, props: { params: Promise<{ id: 
     })
 
     if (!report) {
-      return NextResponse.json({ error: '리포트를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('리포트를 찾을 수 없습니다.', 404)
     }
 
     if (!report.pdfPath) {
-      return NextResponse.json({ error: 'PDF가 아직 생성되지 않았습니다.' }, { status: 404 })
+      return fail('PDF가 아직 생성되지 않았습니다.', 404)
     }
 
     // path traversal 방지: basename만 사용
@@ -36,10 +40,10 @@ export async function GET(_request: NextRequest, props: { params: Promise<{ id: 
         },
       })
     } catch {
-      return NextResponse.json({ error: 'PDF 파일을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('PDF 파일을 찾을 수 없습니다.', 404)
     }
   } catch (error) {
     console.error('GET /api/reports/[id]/download error:', error)
-    return NextResponse.json({ error: '다운로드에 실패했습니다.' }, { status: 500 })
+    return fail('다운로드에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { generateReportPDF } from '@/lib/report/pdf-generator'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -17,7 +17,7 @@ export async function GET() {
     return ok(reports)
   } catch (error) {
     console.error('GET /api/reports error:', error)
-    return NextResponse.json({ error: '리포트 목록을 불러올 수 없습니다.' }, { status: 500 })
+    return fail('리포트 목록을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -31,26 +31,26 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '잘못된 요청 형식입니다.' }, { status: 400 })
+      return fail('잘못된 요청 형식입니다.', 400)
     }
 
     const { year, quarter } = body as { year?: unknown; quarter?: unknown }
 
     if (typeof year !== 'number' || !Number.isInteger(year) || year < 2020 || year > 2100) {
-      return NextResponse.json({ error: '유효한 연도를 입력해주세요.' }, { status: 400 })
+      return fail('유효한 연도를 입력해주세요.', 400)
     }
     if (typeof quarter !== 'number' || ![1, 2, 3, 4].includes(quarter)) {
-      return NextResponse.json({ error: '유효한 분기를 입력해주세요. (1~4)' }, { status: 400 })
+      return fail('유효한 분기를 입력해주세요. (1~4)', 400)
     }
 
     const { pdfPath, reportId } = await generateReportPDF(year, quarter)
-    return NextResponse.json({ reportId, pdfPath, message: '리포트 생성 완료' }, { status: 201 })
+    return ok({ reportId, pdfPath, message: '리포트 생성 완료' }, { status: 201 })
   } catch (error) {
     console.error('POST /api/reports error:', error)
-    return NextResponse.json({ error: '리포트 생성에 실패했습니다.' }, { status: 500 })
+    return fail('리포트 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { generateReportPDF } from '@/lib/report/pdf-generator'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -13,7 +14,7 @@ export async function GET() {
     const reports = await prisma.quarterlyReport.findMany({
       orderBy: [{ year: 'desc' }, { quarter: 'desc' }],
     })
-    return NextResponse.json({ reports })
+    return ok(reports)
   } catch (error) {
     console.error('GET /api/reports error:', error)
     return NextResponse.json({ error: '리포트 목록을 불러올 수 없습니다.' }, { status: 500 })

--- a/src/app/api/rsu/[id]/route.ts
+++ b/src/app/api/rsu/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -16,14 +17,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     if (typeof body.shares === 'number' && (!Number.isInteger(body.shares) || body.shares <= 0)) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
     if (typeof body.basisValue === 'number' && body.basisValue < 0) {
-      return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('기준금액은 0 이상이어야 합니다.', 400)
     }
 
     const data: Record<string, unknown> = {}
@@ -48,17 +49,17 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       })
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Error) {
-      if (error.message === 'NOT_FOUND') return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
-      if (error.message === 'NOT_PENDING') return NextResponse.json({ error: '베스팅 완료된 스케줄은 수정할 수 없습니다.' }, { status: 400 })
+      if (error.message === 'NOT_FOUND') return fail('존재하지 않는 RSU 스케줄입니다.', 404)
+      if (error.message === 'NOT_PENDING') return fail('베스팅 완료된 스케줄은 수정할 수 없습니다.', 400)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 RSU 스케줄입니다.', 404)
     }
     console.error('PUT /api/rsu/[id] error:', error)
-    return NextResponse.json({ error: 'RSU 스케줄 수정에 실패했습니다.' }, { status: 500 })
+    return fail('RSU 스케줄 수정에 실패했습니다.', 500)
   }
 }
 
@@ -77,16 +78,16 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       await tx.rSUSchedule.delete({ where: { id } })
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Error) {
-      if (error.message === 'NOT_FOUND') return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
-      if (error.message === 'NOT_PENDING') return NextResponse.json({ error: '베스팅 완료된 스케줄은 삭제할 수 없습니다.' }, { status: 400 })
+      if (error.message === 'NOT_FOUND') return fail('존재하지 않는 RSU 스케줄입니다.', 404)
+      if (error.message === 'NOT_PENDING') return fail('베스팅 완료된 스케줄은 삭제할 수 없습니다.', 400)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 RSU 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 RSU 스케줄입니다.', 404)
     }
     console.error('DELETE /api/rsu/[id] error:', error)
-    return NextResponse.json({ error: 'RSU 스케줄 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('RSU 스케줄 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/rsu/[id]/vest/route.ts
+++ b/src/app/api/rsu/[id]/vest/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW } from '@/lib/trade-utils'
+import { ok, fail } from '@/lib/api-response'
 
 const RSU_TICKER = '035720.KS'
 const RSU_DISPLAY_NAME = '카카오'
@@ -16,10 +17,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: '유효한 JSON 요청을 보내주세요.' },
-        { status: 400 }
-      )
+      return fail('유효한 JSON 요청을 보내주세요.', 400)
     }
 
     const { vestPrice, autoSell } = body as {
@@ -29,16 +27,10 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
 
     // 입력 검증
     if (typeof vestPrice !== 'number' || !Number.isFinite(vestPrice) || vestPrice <= 0) {
-      return NextResponse.json(
-        { error: '베스팅일 종가는 0보다 큰 숫자여야 합니다.' },
-        { status: 400 }
-      )
+      return fail('베스팅일 종가는 0보다 큰 숫자여야 합니다.', 400)
     }
     if (typeof autoSell !== 'boolean') {
-      return NextResponse.json(
-        { error: 'autoSell은 boolean이어야 합니다.' },
-        { status: 400 }
-      )
+      return fail('autoSell은 boolean이어야 합니다.', 400)
     }
 
     const result = await prisma.$transaction(async (tx) => {
@@ -147,26 +139,17 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       return { schedule: updated, holding }
     }, { isolationLevel: 'Serializable' })
 
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     if (error instanceof Error) {
       if (error.message === 'NOT_FOUND') {
-        return NextResponse.json(
-          { error: 'RSU 스케줄을 찾을 수 없습니다.' },
-          { status: 404 }
-        )
+        return fail('RSU 스케줄을 찾을 수 없습니다.', 404)
       }
       if (error.message === 'ALREADY_VESTED') {
-        return NextResponse.json(
-          { error: '이미 베스팅 처리된 스케줄입니다.' },
-          { status: 400 }
-        )
+        return fail('이미 베스팅 처리된 스케줄입니다.', 400)
       }
       if (error.message === 'INVALID_SELL_SHARES') {
-        return NextResponse.json(
-          { error: '매도 수량이 베스팅 수량을 초과합니다.' },
-          { status: 400 }
-        )
+        return fail('매도 수량이 베스팅 수량을 초과합니다.', 400)
       }
     }
     // Prisma Serializable 충돌 (P2034)
@@ -176,15 +159,9 @@ export async function POST(request: NextRequest, props: { params: Promise<{ id: 
       'code' in error &&
       (error as { code: string }).code === 'P2034'
     ) {
-      return NextResponse.json(
-        { error: '동시 요청이 충돌했습니다. 잠시 후 다시 시도해주세요.' },
-        { status: 409 }
-      )
+      return fail('동시 요청이 충돌했습니다. 잠시 후 다시 시도해주세요.', 409)
     }
     console.error('POST /api/rsu/[id]/vest error:', error)
-    return NextResponse.json(
-      { error: '베스팅 처리에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('베스팅 처리에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/rsu/route.ts
+++ b/src/app/api/rsu/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,7 +12,7 @@ export async function GET() {
       include: { account: { select: { id: true, name: true } } },
     })
 
-    return NextResponse.json({ schedules })
+    return ok(schedules)
   } catch (error) {
     console.error('GET /api/rsu error:', error)
     return NextResponse.json(

--- a/src/app/api/rsu/route.ts
+++ b/src/app/api/rsu/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,10 +15,7 @@ export async function GET() {
     return ok(schedules)
   } catch (error) {
     console.error('GET /api/rsu error:', error)
-    return NextResponse.json(
-      { error: 'RSU 스케줄을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('RSU 스케줄을 불러올 수 없습니다.', 500)
   }
 }
 
@@ -31,28 +28,28 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
 
     if (!body.accountId || typeof body.accountId !== 'string') {
-      return NextResponse.json({ error: '계좌를 선택해주세요.' }, { status: 400 })
+      return fail('계좌를 선택해주세요.', 400)
     }
     if (!body.vestingDate || typeof body.vestingDate !== 'string') {
-      return NextResponse.json({ error: '베스팅일을 입력해주세요.' }, { status: 400 })
+      return fail('베스팅일을 입력해주세요.', 400)
     }
     if (typeof body.shares !== 'number' || !Number.isInteger(body.shares) || body.shares <= 0) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
     if (typeof body.basisValue !== 'number' || body.basisValue < 0) {
-      return NextResponse.json({ error: '기준금액은 0 이상이어야 합니다.' }, { status: 400 })
+      return fail('기준금액은 0 이상이어야 합니다.', 400)
     }
 
     const shares = body.shares as number
     if (typeof body.sellShares === 'number' && (body.sellShares < 0 || body.sellShares > shares)) {
-      return NextResponse.json({ error: '매도 예정 수량은 0 이상, 총 수량 이하여야 합니다.' }, { status: 400 })
+      return fail('매도 예정 수량은 0 이상, 총 수량 이하여야 합니다.', 400)
     }
     if (typeof body.keepShares === 'number' && (body.keepShares < 0 || body.keepShares > shares)) {
-      return NextResponse.json({ error: '보유 예정 수량은 0 이상, 총 수량 이하여야 합니다.' }, { status: 400 })
+      return fail('보유 예정 수량은 0 이상, 총 수량 이하여야 합니다.', 400)
     }
 
     const schedule = await prisma.rSUSchedule.create({
@@ -70,12 +67,12 @@ export async function POST(request: NextRequest) {
       include: { account: { select: { id: true, name: true } } },
     })
 
-    return NextResponse.json(schedule, { status: 201 })
+    return ok(schedule, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 계좌입니다.' }, { status: 400 })
+      return fail('존재하지 않는 계좌입니다.', 400)
     }
     console.error('POST /api/rsu error:', error)
-    return NextResponse.json({ error: 'RSU 스케줄 생성에 실패했습니다.' }, { status: 500 })
+    return fail('RSU 스케줄 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/settings/whooing/mappings/route.ts
+++ b/src/app/api/settings/whooing/mappings/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,10 +12,10 @@ export async function GET() {
     const mappings = await prisma.whooingCategoryMap.findMany({
       include: { category: { select: { name: true, icon: true } } },
     })
-    return NextResponse.json({ mappings })
+    return ok(mappings)
   } catch (error) {
     console.error('[api/settings/whooing/mappings] GET 실패:', error)
-    return NextResponse.json({ error: '매핑 조회에 실패했습니다.' }, { status: 500 })
+    return fail('매핑 조회에 실패했습니다.', 500)
   }
 }
 
@@ -25,10 +26,10 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     if (!Array.isArray(body.mappings)) {
-      return NextResponse.json({ error: 'mappings 배열이 필요합니다.' }, { status: 400 })
+      return fail('mappings 배열이 필요합니다.', 400)
     }
 
     const mappings = body.mappings as { categoryId: string; whooingLeft: string; whooingRight?: string }[]
@@ -52,9 +53,9 @@ export async function PUT(request: NextRequest) {
       include: { category: { select: { name: true, icon: true } } },
     })
 
-    return NextResponse.json({ mappings: updated })
+    return ok(updated)
   } catch (error) {
     console.error('[api/settings/whooing/mappings] PUT 실패:', error)
-    return NextResponse.json({ error: '매핑 저장에 실패했습니다.' }, { status: 500 })
+    return fail('매핑 저장에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/settings/whooing/route.ts
+++ b/src/app/api/settings/whooing/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,14 +12,14 @@ const SINGLETON_ID = 'whooing-config'
 export async function GET() {
   try {
     const config = await prisma.whooingConfig.findUnique({ where: { id: SINGLETON_ID } })
-    return NextResponse.json({
+    return ok({
       webhookUrl: config?.webhookUrl ?? null,
       isActive: config?.isActive ?? false,
       defaultRight: config?.defaultRight ?? null,
     })
   } catch (error) {
     console.error('[api/settings/whooing] GET 실패:', error)
-    return NextResponse.json({ error: '후잉 설정 조회에 실패했습니다.' }, { status: 500 })
+    return fail('후잉 설정 조회에 실패했습니다.', 500)
   }
 }
 
@@ -28,7 +29,7 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const existing = await prisma.whooingConfig.findUnique({ where: { id: SINGLETON_ID } })
 
@@ -44,13 +45,13 @@ export async function PUT(request: NextRequest) {
       create: { id: SINGLETON_ID, ...data },
     })
 
-    return NextResponse.json({
+    return ok({
       webhookUrl: config.webhookUrl,
       isActive: config.isActive,
       defaultRight: config.defaultRight,
     })
   } catch (error) {
     console.error('[api/settings/whooing] PUT 실패:', error)
-    return NextResponse.json({ error: '후잉 설정 저장에 실패했습니다.' }, { status: 500 })
+    return fail('후잉 설정 저장에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/[id]/route.ts
+++ b/src/app/api/stock-options/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,7 +14,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const data: Record<string, unknown> = {}
     if (typeof body.ticker === 'string') data.ticker = body.ticker.trim()
@@ -29,7 +30,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     // remainingShares 재계산 (0 포함하므로 !== undefined 체크)
     if (data.totalShares !== undefined || data.cancelledShares !== undefined || data.adjustedShares !== undefined) {
       const existing = await prisma.stockOption.findUnique({ where: { id } })
-      if (!existing) return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 404 })
+      if (!existing) return fail('존재하지 않는 스톡옵션입니다.', 404)
       const total = (data.totalShares as number | undefined) ?? existing.totalShares
       const cancelled = (data.cancelledShares as number | undefined) ?? existing.cancelledShares
       const exercised = existing.exercisedShares
@@ -43,13 +44,13 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       include: { vestings: { orderBy: { vestingDate: 'asc' } }, account: { select: { name: true } } },
     })
 
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 404 })
+      return fail('존재하지 않는 스톡옵션입니다.', 404)
     }
     console.error('PUT /api/stock-options/[id] error:', error)
-    return NextResponse.json({ error: '스톡옵션 수정에 실패했습니다.' }, { status: 500 })
+    return fail('스톡옵션 수정에 실패했습니다.', 500)
   }
 }
 
@@ -63,12 +64,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       await tx.stockOptionVesting.deleteMany({ where: { stockOptionId: id } })
       await tx.stockOption.delete({ where: { id } })
     })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 404 })
+      return fail('존재하지 않는 스톡옵션입니다.', 404)
     }
     console.error('DELETE /api/stock-options/[id] error:', error)
-    return NextResponse.json({ error: '스톡옵션 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('스톡옵션 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/[id]/vestings/[vid]/route.ts
+++ b/src/app/api/stock-options/[id]/vestings/[vid]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string; vid: string }>
@@ -13,12 +14,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { id, vid } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     // parent 검증
     const existing = await prisma.stockOptionVesting.findUnique({ where: { id: vid } })
     if (!existing || existing.stockOptionId !== id) {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
 
     const data: Record<string, unknown> = {}
@@ -27,13 +28,13 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (body.note !== undefined) data.note = typeof body.note === 'string' ? body.note.trim() || null : null
 
     const updated = await prisma.stockOptionVesting.update({ where: { id: vid }, data })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
     console.error('PUT /api/stock-options/[id]/vestings/[vid] error:', error)
-    return NextResponse.json({ error: '행사 스케줄 수정에 실패했습니다.' }, { status: 500 })
+    return fail('행사 스케줄 수정에 실패했습니다.', 500)
   }
 }
 
@@ -51,23 +52,21 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const { id, vid } = await params
 
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const newStatus = body.status
     if (typeof newStatus !== 'string') {
-      return NextResponse.json({ error: 'status를 지정해주세요.' }, { status: 400 })
+      return fail('status를 지정해주세요.', 400)
     }
 
     const vesting = await prisma.stockOptionVesting.findUnique({ where: { id: vid } })
     if (!vesting || vesting.stockOptionId !== id) {
-      return NextResponse.json({ error: '베스팅을 찾을 수 없습니다.' }, { status: 404 })
+      return fail('베스팅을 찾을 수 없습니다.', 404)
     }
 
     const allowed = ALLOWED_TRANSITIONS[vesting.status]
     if (!allowed || !allowed.includes(newStatus)) {
-      return NextResponse.json({
-        error: `'${vesting.status}' → '${newStatus}' 전환은 허용되지 않습니다.`,
-      }, { status: 400 })
+      return fail(`'${vesting.status}' → '${newStatus}' 전환은 허용되지 않습니다.`, 400)
     }
 
     // pending → exercisable: 베스팅일 도래 검증 (KST 일 단위)
@@ -75,7 +74,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       const kst = new Date(Date.now() + 9 * 60 * 60 * 1000)
       const todayEnd = new Date(Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate() + 1))
       if (vesting.vestingDate >= todayEnd) {
-        return NextResponse.json({ error: '베스팅일이 아직 도래하지 않았습니다.' }, { status: 400 })
+        return fail('베스팅일이 아직 도래하지 않았습니다.', 400)
       }
     }
 
@@ -99,7 +98,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         })
         return tx.stockOptionVesting.findUniqueOrThrow({ where: { id: vid } })
       }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
-      return NextResponse.json(updated)
+      return ok(updated)
     }
 
     // 기타 상태 전환도 조건부 업데이트
@@ -108,19 +107,19 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       data: { status: newStatus },
     })
     if (result.count === 0) {
-      return NextResponse.json({ error: '이미 처리된 요청입니다.' }, { status: 409 })
+      return fail('이미 처리된 요청입니다.', 409)
     }
     const updated = await prisma.stockOptionVesting.findUniqueOrThrow({ where: { id: vid } })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Error && error.message === 'ALREADY_PROCESSED') {
-      return NextResponse.json({ error: '이미 처리된 요청입니다.' }, { status: 409 })
+      return fail('이미 처리된 요청입니다.', 409)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034') {
-      return NextResponse.json({ error: '동시 요청이 감지되었습니다. 다시 시도해주세요.' }, { status: 409 })
+      return fail('동시 요청이 감지되었습니다. 다시 시도해주세요.', 409)
     }
     console.error('PATCH /api/stock-options/[id]/vestings/[vid] error:', error)
-    return NextResponse.json({ error: '상태 변경에 실패했습니다.' }, { status: 500 })
+    return fail('상태 변경에 실패했습니다.', 500)
   }
 }
 
@@ -134,16 +133,16 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
     // parent 검증
     const existing = await prisma.stockOptionVesting.findUnique({ where: { id: vid } })
     if (!existing || existing.stockOptionId !== id) {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
 
     await prisma.stockOptionVesting.delete({ where: { id: vid } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 행사 스케줄입니다.' }, { status: 404 })
+      return fail('존재하지 않는 행사 스케줄입니다.', 404)
     }
     console.error('DELETE /api/stock-options/[id]/vestings/[vid] error:', error)
-    return NextResponse.json({ error: '행사 스케줄 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('행사 스케줄 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/[id]/vestings/route.ts
+++ b/src/app/api/stock-options/[id]/vestings/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,13 +14,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id: stockOptionId } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     if (!body.vestingDate || typeof body.vestingDate !== 'string') {
-      return NextResponse.json({ error: '행사가능일을 입력해주세요.' }, { status: 400 })
+      return fail('행사가능일을 입력해주세요.', 400)
     }
     if (typeof body.shares !== 'number' || !Number.isInteger(body.shares) || body.shares <= 0) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
 
     const vesting = await prisma.stockOptionVesting.create({
@@ -31,12 +32,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       },
     })
 
-    return NextResponse.json(vesting, { status: 201 })
+    return ok(vesting, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 스톡옵션입니다.' }, { status: 400 })
+      return fail('존재하지 않는 스톡옵션입니다.', 400)
     }
     console.error('POST /api/stock-options/[id]/vestings error:', error)
-    return NextResponse.json({ error: '행사 스케줄 추가에 실패했습니다.' }, { status: 500 })
+    return fail('행사 스케줄 추가에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/route.ts
+++ b/src/app/api/stock-options/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
     return ok(stockOptions)
   } catch (err) {
     console.error('GET /api/stock-options error:', err)
-    return NextResponse.json({ error: '스톡옵션 조회 실패' }, { status: 500 })
+    return fail('스톡옵션 조회 실패', 500)
   }
 }
 
@@ -42,15 +42,15 @@ export async function GET(request: Request) {
 export async function POST(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
-    if (!body.accountId || typeof body.accountId !== 'string') return NextResponse.json({ error: '계좌를 선택해주세요.' }, { status: 400 })
-    if (!body.ticker || typeof body.ticker !== 'string') return NextResponse.json({ error: '종목 티커를 입력해주세요.' }, { status: 400 })
-    if (!body.displayName || typeof body.displayName !== 'string') return NextResponse.json({ error: '종목명을 입력해주세요.' }, { status: 400 })
-    if (!body.grantDate || typeof body.grantDate !== 'string') return NextResponse.json({ error: '부여일을 입력해주세요.' }, { status: 400 })
-    if (!body.expiryDate || typeof body.expiryDate !== 'string') return NextResponse.json({ error: '만료일을 입력해주세요.' }, { status: 400 })
-    if (typeof body.strikePrice !== 'number' || body.strikePrice < 0) return NextResponse.json({ error: '행사가격은 0 이상이어야 합니다.' }, { status: 400 })
-    if (typeof body.totalShares !== 'number' || !Number.isInteger(body.totalShares) || body.totalShares <= 0) return NextResponse.json({ error: '총부여수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+    if (!body.accountId || typeof body.accountId !== 'string') return fail('계좌를 선택해주세요.', 400)
+    if (!body.ticker || typeof body.ticker !== 'string') return fail('종목 티커를 입력해주세요.', 400)
+    if (!body.displayName || typeof body.displayName !== 'string') return fail('종목명을 입력해주세요.', 400)
+    if (!body.grantDate || typeof body.grantDate !== 'string') return fail('부여일을 입력해주세요.', 400)
+    if (!body.expiryDate || typeof body.expiryDate !== 'string') return fail('만료일을 입력해주세요.', 400)
+    if (typeof body.strikePrice !== 'number' || body.strikePrice < 0) return fail('행사가격은 0 이상이어야 합니다.', 400)
+    if (typeof body.totalShares !== 'number' || !Number.isInteger(body.totalShares) || body.totalShares <= 0) return fail('총부여수량은 1 이상의 정수여야 합니다.', 400)
 
     const option = await prisma.stockOption.create({
       data: {
@@ -67,12 +67,12 @@ export async function POST(request: NextRequest) {
       include: { vestings: true, account: { select: { name: true } } },
     })
 
-    return NextResponse.json(option, { status: 201 })
+    return ok(option, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 계좌입니다.' }, { status: 400 })
+      return fail('존재하지 않는 계좌입니다.', 400)
     }
     console.error('POST /api/stock-options error:', error)
-    return NextResponse.json({ error: '스톡옵션 생성에 실패했습니다.' }, { status: 500 })
+    return fail('스톡옵션 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/stock-options/route.ts
+++ b/src/app/api/stock-options/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,7 +29,7 @@ export async function GET(request: Request) {
       orderBy: { grantDate: 'asc' },
     })
 
-    return NextResponse.json({ stockOptions })
+    return ok(stockOptions)
   } catch (err) {
     console.error('GET /api/stock-options error:', err)
     return NextResponse.json({ error: '스톡옵션 조회 실패' }, { status: 500 })

--- a/src/app/api/tax/gift/route.ts
+++ b/src/app/api/tax/gift/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calcGiftTaxSummary, GIFT_SOURCES } from '@/lib/tax/gift-tax'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -62,9 +62,9 @@ export async function GET() {
       }
     })
 
-    return NextResponse.json({ summaries })
+    return ok({ summaries })
   } catch (error) {
     console.error('GET /api/tax/gift error:', error)
-    return NextResponse.json({ error: '증여세 현황을 불러올 수 없습니다.' }, { status: 500 })
+    return fail('증여세 현황을 불러올 수 없습니다.', 500)
   }
 }

--- a/src/app/api/trades/[id]/route.ts
+++ b/src/app/api/trades/[id]/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, validateTradedAt, validateFxRateForUSD } from '@/lib/trade-utils'
 import { businessErrorResponse, isSafeBusinessError } from '@/lib/api-errors'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -73,29 +74,29 @@ export async function PUT(request: NextRequest, props: RouteParams) {
   try {
     const trade = await prisma.trade.findUnique({ where: { id: params.id } })
     if (!trade) {
-      return NextResponse.json({ error: '거래를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('거래를 찾을 수 없습니다.', 404)
     }
 
     const body = await request.json()
     const { shares, price, fxRate, note, tradedAt } = body
 
     if (shares !== undefined && (typeof shares !== 'number' || !Number.isFinite(shares) || shares <= 0 || !Number.isInteger(shares))) {
-      return NextResponse.json({ error: '수량은 1 이상의 정수여야 합니다.' }, { status: 400 })
+      return fail('수량은 1 이상의 정수여야 합니다.', 400)
     }
     if (price !== undefined && (typeof price !== 'number' || !Number.isFinite(price) || price <= 0)) {
-      return NextResponse.json({ error: '단가는 0보다 큰 숫자여야 합니다.' }, { status: 400 })
+      return fail('단가는 0보다 큰 숫자여야 합니다.', 400)
     }
     if (fxRate !== undefined && trade.currency === 'USD') {
       const fxError = validateFxRateForUSD(fxRate)
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
     if (tradedAt !== undefined) {
       if (typeof tradedAt !== 'string') {
-        return NextResponse.json({ error: '유효한 거래일을 입력해주세요.' }, { status: 400 })
+        return fail('유효한 거래일을 입력해주세요.', 400)
       }
       const tradedAtError = validateTradedAt(tradedAt)
       if (tradedAtError) {
-        return NextResponse.json({ error: tradedAtError }, { status: 400 })
+        return fail(tradedAtError, 400)
       }
     }
 
@@ -106,7 +107,7 @@ export async function PUT(request: NextRequest, props: RouteParams) {
     // USD는 최종 fxRate가 항상 양수 보장 — stored 값이 손상되었을 때 silent 0 차단
     if (trade.currency === 'USD') {
       const fxError = validateFxRateForUSD(updatedFxRate)
-      if (fxError) return NextResponse.json({ error: fxError }, { status: 400 })
+      if (fxError) return fail(fxError, 400)
     }
 
     const updatedTotalKRW = trade.currency === 'USD'
@@ -146,12 +147,12 @@ export async function PUT(request: NextRequest, props: RouteParams) {
       return { trade: updated, holding, holdingBefore }
     }, { isolationLevel: 'Serializable' })
 
-    return NextResponse.json(result)
+    return ok(result)
   } catch (error) {
     const businessResponse = businessErrorResponse(error)
     if (businessResponse) return businessResponse
     console.error('PUT /api/trades/[id] error:', error)
-    return NextResponse.json({ error: '거래 수정에 실패했습니다.' }, { status: 500 })
+    return fail('거래 수정에 실패했습니다.', 500)
   }
 }
 
@@ -160,7 +161,7 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
   try {
     const trade = await prisma.trade.findUnique({ where: { id: params.id } })
     if (!trade) {
-      return NextResponse.json({ error: '거래를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('거래를 찾을 수 없습니다.', 404)
     }
 
     await prisma.$transaction(async (tx) => {
@@ -172,12 +173,12 @@ export async function DELETE(_request: NextRequest, props: RouteParams) {
       )
     }, { isolationLevel: 'Serializable' })
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (isSafeBusinessError(error) && error.message.startsWith('보유 수량 부족')) {
-      return NextResponse.json({ error: '이 거래를 삭제하면 보유 수량이 음수가 됩니다.' }, { status: 400 })
+      return fail('이 거래를 삭제하면 보유 수량이 음수가 됩니다.', 400)
     }
     console.error('DELETE /api/trades/[id] error:', error)
-    return NextResponse.json({ error: '거래 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('거래 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/trades/import/route.ts
+++ b/src/app/api/trades/import/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { recalcHolding, calcTotalKRW, validateTradeInput } from '@/lib/trade-utils'
 import { normalizeMarket } from '@/lib/market-hours'
 import { businessErrorResponse } from '@/lib/api-errors'
+import { ok, fail } from '@/lib/api-response'
 import type { ImportResult } from '@/types/csv-import'
 
 export const dynamic = 'force-dynamic'
@@ -15,39 +16,33 @@ export async function POST(request: NextRequest) {
     const { accountId, market, currency, skipDuplicates, trades } = body
 
     if (!accountId || !market || !currency || !Array.isArray(trades)) {
-      return NextResponse.json(
-        { error: '필수 필드가 누락되었습니다.' },
-        { status: 400 }
-      )
+      return fail('필수 필드가 누락되었습니다.', 400)
     }
 
     if (!['US', 'KR'].includes(market)) {
-      return NextResponse.json({ error: '잘못된 시장입니다.' }, { status: 400 })
+      return fail('잘못된 시장입니다.', 400)
     }
     if (!['USD', 'KRW'].includes(currency)) {
-      return NextResponse.json({ error: '잘못된 통화입니다.' }, { status: 400 })
+      return fail('잘못된 통화입니다.', 400)
     }
     if (market === 'US' && currency !== 'USD') {
-      return NextResponse.json({ error: 'US 시장은 USD만 가능합니다.' }, { status: 400 })
+      return fail('US 시장은 USD만 가능합니다.', 400)
     }
     if (market === 'KR' && currency !== 'KRW') {
-      return NextResponse.json({ error: 'KR 시장은 KRW만 가능합니다.' }, { status: 400 })
+      return fail('KR 시장은 KRW만 가능합니다.', 400)
     }
 
     if (trades.length === 0) {
-      return NextResponse.json({ error: '임포트할 거래가 없습니다.' }, { status: 400 })
+      return fail('임포트할 거래가 없습니다.', 400)
     }
     if (trades.length > MAX_ROWS) {
-      return NextResponse.json(
-        { error: `최대 ${MAX_ROWS}건까지 임포트 가능합니다.` },
-        { status: 400 }
-      )
+      return fail(`최대 ${MAX_ROWS}건까지 임포트 가능합니다.`, 400)
     }
 
     // 계좌 존재 확인
     const account = await prisma.account.findUnique({ where: { id: accountId } })
     if (!account) {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
     // 각 행 검증
@@ -123,10 +118,7 @@ export async function POST(request: NextRequest) {
     for (const meta of existingMeta) {
       const normalizedExisting = normalizeMarket(meta.market, meta.ticker)
       if (normalizedExisting !== market || meta.currency !== currency) {
-        return NextResponse.json(
-          { error: `${meta.ticker}은(는) 이미 ${normalizedExisting}/${meta.currency}로 등록되어 있습니다.` },
-          { status: 400 }
-        )
+        return fail(`${meta.ticker}은(는) 이미 ${normalizedExisting}/${meta.currency}로 등록되어 있습니다.`, 400)
       }
     }
     // Holding 테이블도 검증 (Trade 없이 Holding만 있는 시드 데이터 대응)
@@ -137,10 +129,7 @@ export async function POST(request: NextRequest) {
     for (const h of existingHoldings) {
       const normalizedExisting = normalizeMarket(h.market, h.ticker)
       if (normalizedExisting !== market || h.currency !== currency) {
-        return NextResponse.json(
-          { error: `${h.ticker}은(는) 이미 ${normalizedExisting}/${h.currency}로 등록되어 있습니다.` },
-          { status: 400 }
-        )
+        return fail(`${h.ticker}은(는) 이미 ${normalizedExisting}/${h.currency}로 등록되어 있습니다.`, 400)
       }
     }
 
@@ -183,7 +172,7 @@ export async function POST(request: NextRequest) {
         failed: resultErrors.length > 0 ? trades.length - skipped : 0,
         errors: resultErrors,
       }
-      return NextResponse.json({ result }, { status: 201 })
+      return ok(result, { status: 201 })
     }
 
     // Serializable 트랜잭션: 일괄 생성 + Holding 재계산
@@ -302,14 +291,11 @@ export async function POST(request: NextRequest) {
       errors: resultErrors,
     }
 
-    return NextResponse.json({ result }, { status: 201 })
+    return ok(result, { status: 201 })
   } catch (error) {
     const businessResponse = businessErrorResponse(error)
     if (businessResponse) return businessResponse
     console.error('POST /api/trades/import error:', error)
-    return NextResponse.json(
-      { error: '거래 일괄 등록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('거래 일괄 등록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -1,11 +1,11 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { validateTradeInput } from '@/lib/trade-utils'
 import { createTrade } from '@/lib/trade-service'
 import { businessErrorResponse } from '@/lib/api-errors'
 import { paginationSchema, dateRangeSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
-import { ok, fail } from '@/lib/api-response'
+import { ok, fail, paginated } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     })
     if (!paginationResult.success) {
       const errs = zodErrorsToValidation(paginationResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { limit, offset } = paginationResult.data
 
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     })
     if (!dateResult.success) {
       const errs = zodErrorsToValidation(dateResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { from, to } = dateResult.data
 
@@ -64,13 +64,10 @@ export async function GET(request: NextRequest) {
       prisma.trade.count({ where }),
     ])
 
-    return NextResponse.json({ trades, total, limit, offset })
+    return paginated(trades, total, limit, offset)
   } catch (error) {
     console.error('GET /api/trades error:', error)
-    return NextResponse.json(
-      { error: '거래 내역을 불러올 수 없습니다.' },
-      { status: 500 }
-    )
+    return fail('거래 내역을 불러올 수 없습니다.', 500)
   }
 }
 

--- a/src/app/api/trades/route.ts
+++ b/src/app/api/trades/route.ts
@@ -5,6 +5,7 @@ import { createTrade } from '@/lib/trade-service'
 import { businessErrorResponse } from '@/lib/api-errors'
 import { paginationSchema, dateRangeSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -89,7 +90,7 @@ export async function POST(request: NextRequest) {
       displayName: normalizedDisplayName,
     })
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const { accountId, market, type, shares, price, currency, fxRate, note, tradedAt } = body
@@ -99,7 +100,7 @@ export async function POST(request: NextRequest) {
     // 계좌 존재 확인
     const account = await prisma.account.findUnique({ where: { id: accountId } })
     if (!account) {
-      return NextResponse.json({ error: '계좌를 찾을 수 없습니다.' }, { status: 404 })
+      return fail('계좌를 찾을 수 없습니다.', 404)
     }
 
     const result = await createTrade({
@@ -116,14 +117,11 @@ export async function POST(request: NextRequest) {
       tradedAt: new Date(tradedAt),
     })
 
-    return NextResponse.json(result, { status: 201 })
+    return ok(result, { status: 201 })
   } catch (error) {
     const businessResponse = businessErrorResponse(error)
     if (businessResponse) return businessResponse
     console.error('POST /api/trades error:', error)
-    return NextResponse.json(
-      { error: '거래 기록에 실패했습니다.' },
-      { status: 500 }
-    )
+    return fail('거래 기록에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateTransactionInput } from '@/lib/transaction-utils'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -17,14 +18,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
     const errors = validateTransactionInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const amount = body.amount as number
@@ -38,18 +39,18 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       select: { id: true, type: true },
     })
     if (!category) {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     if (txType && category.type !== 'transfer') {
-      return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('출금/입금은 이체 카테고리에서만 사용할 수 있습니다.', 400)
     }
     if (!txType && category.type === 'transfer') {
-      return NextResponse.json({ error: '이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.', 400)
     }
 
     const existing = await prisma.transaction.findUnique({ where: { id } })
     if (!existing) {
-      return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
+      return fail('존재하지 않는 내역입니다.', 404)
     }
 
     const transactedAt = body.transactedAt
@@ -95,7 +96,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       return result
     })
 
-    return NextResponse.json({
+    return ok({
       id: updated.id,
       amount: updated.amount,
       description: updated.description,
@@ -111,11 +112,11 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2025') return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
-      if (error.code === 'P2003') return NextResponse.json({ error: '존재하지 않는 카테고리 또는 자산입니다.' }, { status: 400 })
+      if (error.code === 'P2025') return fail('존재하지 않는 내역입니다.', 404)
+      if (error.code === 'P2003') return fail('존재하지 않는 카테고리 또는 자산입니다.', 400)
     }
     console.error('[api/transactions/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '내역 수정에 실패했습니다.' }, { status: 500 })
+    return fail('내역 수정에 실패했습니다.', 500)
   }
 }
 
@@ -143,15 +144,15 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       await tx.transaction.delete({ where: { id } })
     })
 
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Error && error.message === 'NOT_FOUND') {
-      return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
+      return fail('존재하지 않는 내역입니다.', 404)
     }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 내역입니다.' }, { status: 404 })
+      return fail('존재하지 않는 내역입니다.', 404)
     }
     console.error('[api/transactions/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '내역 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('내역 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/transactions/analysis/route.ts
+++ b/src/app/api/transactions/analysis/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { yearMonthSchema } from '@/lib/zod-schemas'
 import { zodErrorsToValidation } from '@/lib/zod-utils'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,11 +30,11 @@ export async function GET(request: NextRequest) {
     })
     if (!ymResult.success) {
       const errs = zodErrorsToValidation(ymResult.error)
-      return NextResponse.json({ error: errs[0].message, errors: errs }, { status: 400 })
+      return fail(errs[0].message, 400)
     }
     const { year, month } = ymResult.data
     if (year === undefined || month === undefined) {
-      return NextResponse.json({ error: 'year, month 파라미터가 필요합니다.' }, { status: 400 })
+      return fail('year, month 파라미터가 필요합니다.', 400)
     }
 
     // 카테고리 → 그룹 매핑
@@ -173,7 +174,7 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    return NextResponse.json({
+    return ok({
       monthCompare,
       prevMonthSummary: {
         totalExpense: prevExpenseTotal,
@@ -187,7 +188,7 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[api/transactions/analysis] GET 실패:', error)
-    return NextResponse.json({ error: '분석 데이터 조회에 실패했습니다.' }, { status: 500 })
+    return fail('분석 데이터 조회에 실패했습니다.', 500)
   }
 }
 

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateTransactionInput } from '@/lib/transaction-utils'
 import { sendToWhooing } from '@/lib/whooing-webhook'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -216,14 +217,14 @@ export async function POST(request: NextRequest) {
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
     }
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return NextResponse.json({ error: '유효한 JSON 객체가 아닙니다.' }, { status: 400 })
+      return fail('유효한 JSON 객체가 아닙니다.', 400)
     }
     const errors = validateTransactionInput(body)
     if (errors.length > 0) {
-      return NextResponse.json({ error: errors[0].message, errors }, { status: 400 })
+      return fail(errors[0].message, 400)
     }
 
     const amount = body.amount as number
@@ -240,22 +241,22 @@ export async function POST(request: NextRequest) {
       select: { id: true, name: true, icon: true, type: true },
     })
     if (!category) {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
 
     // transfer 유형 ↔ transfer 카테고리 일치 검증
     if (txType && category.type !== 'transfer') {
-      return NextResponse.json({ error: '출금/입금은 이체 카테고리에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('출금/입금은 이체 카테고리에서만 사용할 수 있습니다.', 400)
     }
     if (!txType && category.type === 'transfer') {
-      return NextResponse.json({ error: '이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.' }, { status: 400 })
+      return fail('이체 카테고리는 출금/입금 유형에서만 사용할 수 있습니다.', 400)
     }
 
     // 자산 존재 확인 (transfer 유형)
     if (linkedAssetId) {
       const asset = await prisma.asset.findUnique({ where: { id: linkedAssetId }, select: { id: true } })
       if (!asset) {
-        return NextResponse.json({ error: '존재하지 않는 자산입니다.' }, { status: 400 })
+        return fail('존재하지 않는 자산입니다.', 400)
       }
     }
 
@@ -300,7 +301,7 @@ export async function POST(request: NextRequest) {
       console.error('[whooing] 전송 실패:', err)
     }
 
-    return NextResponse.json({
+    return ok({
       id: transaction.id,
       amount: transaction.amount,
       description: transaction.description,
@@ -316,9 +317,9 @@ export async function POST(request: NextRequest) {
     }, { status: 201 })
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') {
-      return NextResponse.json({ error: '존재하지 않는 카테고리입니다.' }, { status: 400 })
+      return fail('존재하지 않는 카테고리입니다.', 400)
     }
     console.error('[api/transactions] POST 실패:', error)
-    return NextResponse.json({ error: '내역 생성에 실패했습니다.' }, { status: 500 })
+    return fail('내역 생성에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { validateTransactionInput } from '@/lib/transaction-utils'
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     const sp = request.nextUrl.searchParams
     const rawType = sp.get('type')
     if (rawType && rawType !== 'expense' && rawType !== 'income') {
-      return NextResponse.json({ error: 'type은 expense 또는 income만 허용됩니다.' }, { status: 400 })
+      return fail('type은 expense 또는 income만 허용됩니다.', 400)
     }
     const type = rawType ?? undefined
     const yearStr = sp.get('year')
@@ -107,13 +107,10 @@ export async function GET(request: NextRequest) {
 
     // listOnly 모드: 페이지 이동 시 집계 스킵
     if (listOnly) {
-      return NextResponse.json({
-        transactions: serialized,
-        total,
-        offset,
-        limit,
-        year,
-      })
+      return ok(
+        { transactions: serialized, year },
+        { meta: { total, limit, offset } },
+      )
     }
 
     // 집계 조회 (필터 변경 시에만)
@@ -184,25 +181,25 @@ export async function GET(request: NextRequest) {
       .filter((r): r is NonNullable<typeof r> => r !== null)
       .sort((a, b) => b.total - a.total)
 
-    return NextResponse.json({
-      transactions: serialized,
-      total,
-      offset,
-      limit,
-      summary: {
-        totalExpense,
-        totalIncome,
-        net: totalIncome - totalExpense,
-        count: filteredCount,
-        currency: 'KRW',
+    return ok(
+      {
+        transactions: serialized,
+        summary: {
+          totalExpense,
+          totalIncome,
+          net: totalIncome - totalExpense,
+          count: filteredCount,
+          currency: 'KRW',
+        },
+        byMonth,
+        byCategory,
+        year,
       },
-      byMonth,
-      byCategory,
-      year,
-    })
+      { meta: { total, limit, offset } },
+    )
   } catch (error) {
     console.error('[api/transactions] GET 실패:', error)
-    return NextResponse.json({ error: '거래 내역 조회에 실패했습니다.' }, { status: 500 })
+    return fail('거래 내역 조회에 실패했습니다.', 500)
   }
 }
 

--- a/src/app/api/transactions/suggest/route.ts
+++ b/src/app/api/transactions/suggest/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { matchCategory, suggestByHistory } from '@/lib/category-matcher'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,12 +30,12 @@ export async function GET(request: NextRequest) {
     const sp = request.nextUrl.searchParams
     const q = sp.get('q')?.trim()?.slice(0, MAX_QUERY_LENGTH)
     if (!q || q.length < 2) {
-      return NextResponse.json({ suggestions: [] })
+      return ok({ suggestions: [] })
     }
 
     const rawType = sp.get('type')
     if (rawType && !VALID_TYPES.has(rawType)) {
-      return NextResponse.json({ error: 'type은 expense 또는 income이어야 합니다.' }, { status: 400 })
+      return fail('type은 expense 또는 income이어야 합니다.', 400)
     }
     const types: Array<'expense' | 'income'> =
       rawType ? [rawType as 'expense' | 'income'] : ['expense', 'income']
@@ -69,9 +70,9 @@ export async function GET(request: NextRequest) {
 
     const suggestions = [...keywordSuggestions, ...historySuggestions].slice(0, MAX_SUGGESTIONS)
 
-    return NextResponse.json({ suggestions })
+    return ok({ suggestions })
   } catch (error) {
     console.error('[suggest] error:', error)
-    return NextResponse.json({ error: '추천 조회에 실패했습니다.' }, { status: 500 })
+    return fail('추천 조회에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/watchlist/[id]/route.ts
+++ b/src/app/api/watchlist/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { ok, fail, noContent } from '@/lib/api-response'
 
 interface RouteParams {
   params: Promise<{ id: string }>
@@ -13,22 +14,22 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const data: Record<string, unknown> = {}
     if (typeof body.displayName === 'string') {
       const name = body.displayName.trim()
-      if (!name) return NextResponse.json({ error: '종목명을 입력해주세요.' }, { status: 400 })
+      if (!name) return fail('종목명을 입력해주세요.', 400)
       data.displayName = name
     }
     if (typeof body.market === 'string') {
       const validMarkets = ['US', 'KR']
-      if (!validMarkets.includes(body.market.trim())) return NextResponse.json({ error: '시장은 US 또는 KR만 허용됩니다.' }, { status: 400 })
+      if (!validMarkets.includes(body.market.trim())) return fail('시장은 US 또는 KR만 허용됩니다.', 400)
       data.market = body.market.trim()
     }
     if (typeof body.strategy === 'string') {
       const validStrategies = ['swing', 'momentum', 'value', 'scalp']
-      if (!validStrategies.includes(body.strategy)) return NextResponse.json({ error: '유효한 전략을 선택해주세요.' }, { status: 400 })
+      if (!validStrategies.includes(body.strategy)) return fail('유효한 전략을 선택해주세요.', 400)
       data.strategy = body.strategy
     }
     if (body.memo !== undefined) data.memo = typeof body.memo === 'string' ? body.memo.trim() || null : null
@@ -40,17 +41,17 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const low = data.entryLow as number | null | undefined
     const high = data.entryHigh as number | null | undefined
     if (low !== undefined && high !== undefined && low !== null && high !== null && low > high) {
-      return NextResponse.json({ error: '매수 구간 하한은 상한보다 작아야 합니다.' }, { status: 400 })
+      return fail('매수 구간 하한은 상한보다 작아야 합니다.', 400)
     }
 
     const updated = await prisma.watchlist.update({ where: { id }, data })
-    return NextResponse.json(updated)
+    return ok(updated)
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 관심종목입니다.' }, { status: 404 })
+      return fail('존재하지 않는 관심종목입니다.', 404)
     }
     console.error('[api/watchlist/[id]] PUT 실패:', error)
-    return NextResponse.json({ error: '관심종목 수정에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 수정에 실패했습니다.', 500)
   }
 }
 
@@ -61,12 +62,12 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params
     await prisma.watchlist.delete({ where: { id } })
-    return new NextResponse(null, { status: 204 })
+    return noContent()
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
-      return NextResponse.json({ error: '존재하지 않는 관심종목입니다.' }, { status: 404 })
+      return fail('존재하지 않는 관심종목입니다.', 404)
     }
     console.error('[api/watchlist/[id]] DELETE 실패:', error)
-    return NextResponse.json({ error: '관심종목 삭제에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 삭제에 실패했습니다.', 500)
   }
 }

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { ok } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,7 +30,7 @@ export async function GET() {
       updatedAt: i.updatedAt.toISOString(),
     }))
 
-    return NextResponse.json({ items: serialized })
+    return ok(serialized)
   } catch (error) {
     console.error('[api/watchlist] GET 실패:', error)
     return NextResponse.json({ error: '관심종목 조회에 실패했습니다.' }, { status: 500 })

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { ok } from '@/lib/api-response'
+import { ok, fail } from '@/lib/api-response'
 
 export const dynamic = 'force-dynamic'
 
@@ -33,7 +33,7 @@ export async function GET() {
     return ok(serialized)
   } catch (error) {
     console.error('[api/watchlist] GET 실패:', error)
-    return NextResponse.json({ error: '관심종목 조회에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 조회에 실패했습니다.', 500)
   }
 }
 
@@ -43,17 +43,17 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     let body: Record<string, unknown>
-    try { body = await request.json() } catch { return NextResponse.json({ error: '유효한 JSON 형식이 아닙니다.' }, { status: 400 }) }
+    try { body = await request.json() } catch { return fail('유효한 JSON 형식이 아닙니다.', 400) }
 
     const ticker = typeof body.ticker === 'string' ? body.ticker.trim() : ''
     const displayName = typeof body.displayName === 'string' ? body.displayName.trim() : ''
     const market = typeof body.market === 'string' ? body.market.trim() : ''
 
-    if (!ticker) return NextResponse.json({ error: '종목 티커를 입력해주세요.' }, { status: 400 })
-    if (!displayName) return NextResponse.json({ error: '종목명을 입력해주세요.' }, { status: 400 })
+    if (!ticker) return fail('종목 티커를 입력해주세요.', 400)
+    if (!displayName) return fail('종목명을 입력해주세요.', 400)
 
     const validMarkets = ['US', 'KR']
-    if (!validMarkets.includes(market)) return NextResponse.json({ error: '시장은 US 또는 KR만 허용됩니다.' }, { status: 400 })
+    if (!validMarkets.includes(market)) return fail('시장은 US 또는 KR만 허용됩니다.', 400)
 
     const validStrategies = ['swing', 'momentum', 'value', 'scalp']
     const strategy = typeof body.strategy === 'string' && validStrategies.includes(body.strategy) ? body.strategy : 'swing'
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
     const entryHigh = typeof body.entryHigh === 'number' && body.entryHigh > 0 ? body.entryHigh : null
 
     if (entryLow !== null && entryHigh !== null && entryLow > entryHigh) {
-      return NextResponse.json({ error: '매수 구간 하한은 상한보다 작아야 합니다.' }, { status: 400 })
+      return fail('매수 구간 하한은 상한보다 작아야 합니다.', 400)
     }
 
     const item = await prisma.watchlist.create({
@@ -79,12 +79,12 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    return NextResponse.json(item, { status: 201 })
+    return ok(item, { status: 201 })
   } catch (error) {
     if ((error as { code?: string }).code === 'P2002') {
-      return NextResponse.json({ error: '이미 등록된 종목입니다.' }, { status: 409 })
+      return fail('이미 등록된 종목입니다.', 409)
     }
     console.error('[api/watchlist] POST 실패:', error)
-    return NextResponse.json({ error: '관심종목 추가에 실패했습니다.' }, { status: 500 })
+    return fail('관심종목 추가에 실패했습니다.', 500)
   }
 }

--- a/src/app/backtest/BacktestClient.tsx
+++ b/src/app/backtest/BacktestClient.tsx
@@ -85,8 +85,10 @@ export default function BacktestClient() {
         body: JSON.stringify({ ticker: ticker.trim().toUpperCase(), strategyKey, days }),
       })
       const data = await res.json()
-      if (!res.ok) throw new Error(data.error || '백테스트 실패')
-      setResult(data)
+      if (!res.ok) throw new Error(data?.error || '백테스트 실패')
+      const payload = data?.data
+      if (!payload) throw new Error('백테스트 결과를 받지 못했습니다.')
+      setResult(payload)
     } catch (err) {
       setError(err instanceof Error ? err.message : '알 수 없는 오류')
     } finally {

--- a/src/app/budgets/BudgetsClient.tsx
+++ b/src/app/budgets/BudgetsClient.tsx
@@ -57,7 +57,8 @@ export default function BudgetsClient() {
     try {
       const res = await fetch(`/api/budgets?year=${year}&month=${month}`, { signal: controller.signal })
       if (res.ok) {
-        setData(await res.json())
+        const json = await res.json()
+        if (json?.data) setData(json.data)
       }
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') return

--- a/src/app/budgets/BudgetsClient.tsx
+++ b/src/app/budgets/BudgetsClient.tsx
@@ -77,8 +77,8 @@ export default function BudgetsClient() {
     fetch('/api/categories')
       .then((res) => res.ok ? res.json() : null)
       .then((d) => {
-        if (d?.categories) {
-          setCategories(d.categories)
+        if (Array.isArray(d?.data)) {
+          setCategories(d.data)
         }
       })
       .catch(() => {})

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -104,8 +104,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
       .catch(() => {})
     fetch('/api/assets')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        const list = data?.assets ?? data
+      .then((json) => {
+        const list = json?.data?.assets
         if (Array.isArray(list)) setAssets(list)
       })
       .catch(() => {})

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -148,7 +148,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
         try {
           const analysisRes = await fetch(`/api/transactions/analysis?year=${y}&month=${m}`, { signal: controller.signal })
           if (analysisRes.ok) {
-            setAnalysisData(await analysisRes.json())
+            const aJson = await analysisRes.json()
+            setAnalysisData(aJson?.data ?? null)
           } else {
             setAnalysisData(null)
           }

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -51,6 +51,40 @@ interface ApiResponse {
   year: number
 }
 
+interface TransactionsEnvelope {
+  success: boolean
+  data?: {
+    transactions: TransactionRow[]
+    summary?: ApiResponse['summary']
+    byMonth?: MonthlyData[]
+    byCategory?: CategoryData[]
+    year: number
+  }
+  meta?: { total: number; limit: number; offset: number }
+}
+
+/**
+ * 27-D envelope 응답을 컴포넌트가 사용하는 flat shape 로 변환.
+ *
+ * 전체 모드 (listOnly 미지정) 응답 전용 — summary/byMonth/byCategory 가 반드시 포함된다.
+ * listOnly 응답은 setData prev merge 패턴으로 별도 처리 (handlePageChange).
+ */
+function fullEnvelopeToFlat(env: TransactionsEnvelope): ApiResponse | null {
+  if (!env?.data || !env?.meta) return null
+  const d = env.data
+  if (!d.summary || !d.byMonth || !d.byCategory) return null
+  return {
+    transactions: d.transactions,
+    total: env.meta.total,
+    limit: env.meta.limit,
+    offset: env.meta.offset,
+    summary: d.summary,
+    byMonth: d.byMonth,
+    byCategory: d.byCategory,
+    year: d.year,
+  }
+}
+
 interface ExpensesClientProps {
   initialData: ApiResponse
 }
@@ -125,22 +159,26 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
 
       const res = await fetch(`/api/transactions?${params}`, { signal: controller.signal })
       if (res.ok) {
-        const json: ApiResponse = await res.json()
-        // 삭제 후 offset >= total이면 마지막 유효 페이지로 보정
-        if (requestOffset > 0 && json.transactions.length === 0 && json.total > 0) {
-          const corrected = Math.max(0, Math.floor((json.total - 1) / json.limit) * json.limit)
-          setOffset(corrected)
-          // 보정된 offset으로 재조회
-          const retryParams = new URLSearchParams({ year: String(y), offset: String(corrected) })
-          if (m) retryParams.set('month', String(m))
-          if (t !== 'all') retryParams.set('type', t)
-          const retryRes = await fetch(`/api/transactions?${retryParams}`, { signal: controller.signal })
-          if (retryRes.ok) {
-            setData(await retryRes.json())
+        const env: TransactionsEnvelope = await res.json()
+        const flat = fullEnvelopeToFlat(env)
+        if (flat) {
+          // 삭제 후 offset >= total이면 마지막 유효 페이지로 보정
+          if (requestOffset > 0 && flat.transactions.length === 0 && flat.total > 0) {
+            const corrected = Math.max(0, Math.floor((flat.total - 1) / flat.limit) * flat.limit)
+            setOffset(corrected)
+            // 보정된 offset으로 재조회
+            const retryParams = new URLSearchParams({ year: String(y), offset: String(corrected) })
+            if (m) retryParams.set('month', String(m))
+            if (t !== 'all') retryParams.set('type', t)
+            const retryRes = await fetch(`/api/transactions?${retryParams}`, { signal: controller.signal })
+            if (retryRes.ok) {
+              const retryFlat = fullEnvelopeToFlat(await retryRes.json())
+              if (retryFlat) setData(retryFlat)
+            }
+          } else {
+            setData(flat)
+            setOffset(requestOffset)
           }
-        } else {
-          setData(json)
-          setOffset(requestOffset)
         }
       }
       // 월 선택 시 분석 데이터도 조회 (소비 탭 또는 전체 탭에서만)
@@ -199,12 +237,16 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
 
       const res = await fetch(`/api/transactions?${params}`, { signal: controller.signal })
       if (res.ok) {
-        const json = await res.json()
-        setData((prev) => ({
-          ...prev,
-          transactions: json.transactions,
-          total: json.total,
-        }))
+        const env: TransactionsEnvelope = await res.json()
+        if (env?.data && env?.meta) {
+          setData((prev) => ({
+            ...prev,
+            transactions: env.data!.transactions,
+            total: env.meta!.total,
+          }))
+        } else {
+          setOffset(prevOffset)
+        }
       } else {
         setOffset(prevOffset)
       }

--- a/src/app/expenses/ExpensesClient.tsx
+++ b/src/app/expenses/ExpensesClient.tsx
@@ -90,8 +90,8 @@ export default function ExpensesClient({ initialData }: ExpensesClientProps) {
   useEffect(() => {
     fetch('/api/categories')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        const cats = data?.categories
+      .then((json) => {
+        const cats = json?.data
         if (Array.isArray(cats)) {
           setCategories(cats.map((c: { id: string; name: string; icon: string | null; type: string }) => ({
             id: c.id,

--- a/src/app/networth/NetWorthClient.tsx
+++ b/src/app/networth/NetWorthClient.tsx
@@ -77,8 +77,9 @@ export default function NetWorthClient() {
         if (!r.ok) throw new Error('API error')
         return r.json()
       })
-      .then((d) => {
-        if (d.breakdown) setData(d)
+      .then((json) => {
+        const d = json?.data
+        if (d?.breakdown) setData(d)
       })
       .catch(console.error)
       .finally(() => setLoading(false))

--- a/src/app/performance/PerformanceClient.tsx
+++ b/src/app/performance/PerformanceClient.tsx
@@ -52,8 +52,8 @@ export default function PerformanceClient({ accounts, hasSnapshots }: Performanc
     setLoadingChart(true)
     try {
       const res = await fetch(`/api/performance/snapshots?accountId=${selectedAccount}`)
-      const data = await res.json()
-      setSnapshotData(data)
+      const json = await res.json()
+      setSnapshotData(json?.data ?? null)
     } catch (error) {
       console.error('Failed to fetch snapshots:', error)
     } finally {
@@ -66,19 +66,19 @@ export default function PerformanceClient({ accounts, hasSnapshots }: Performanc
     try {
       const results = await Promise.all(
         accounts.map(async (a) => {
-          const res = await fetch(`/api/performance/twr?accountId=${a.id}&period=${period}`)
-          if (!res.ok) {
-            return {
-              accountId: a.id,
-              accountName: a.name,
-              twr: null,
-              benchmarkReturn: null,
-              alpha: null,
-              benchmarkTicker: null,
-              snapshotCount: 0,
-            }
+          const fallback = {
+            accountId: a.id,
+            accountName: a.name,
+            twr: null,
+            benchmarkReturn: null,
+            alpha: null,
+            benchmarkTicker: null,
+            snapshotCount: 0,
           }
-          return res.json()
+          const res = await fetch(`/api/performance/twr?accountId=${a.id}&period=${period}`)
+          if (!res.ok) return fallback
+          const json = await res.json()
+          return json?.data ?? fallback
         })
       )
       setTwrData(results)
@@ -94,8 +94,8 @@ export default function PerformanceClient({ accounts, hasSnapshots }: Performanc
     setLoadingContrib(true)
     try {
       const res = await fetch(`/api/performance/contribution?accountId=${selectedAccount}&period=${period}`)
-      const data = await res.json()
-      setContributionData(data)
+      const json = await res.json()
+      setContributionData(json?.data ?? null)
     } catch (error) {
       console.error('Failed to fetch contribution:', error)
     } finally {

--- a/src/app/recurring/RecurringClient.tsx
+++ b/src/app/recurring/RecurringClient.tsx
@@ -25,8 +25,8 @@ export default function RecurringClient() {
     try {
       const res = await fetch('/api/recurring')
       if (res.ok) {
-        const data = await res.json()
-        setItems(data.items ?? [])
+        const json = await res.json()
+        setItems(Array.isArray(json.data) ? json.data : [])
       }
     } catch (e) {
       console.error('[recurring] 조회 실패:', e)
@@ -40,8 +40,8 @@ export default function RecurringClient() {
   useEffect(() => {
     fetch('/api/categories')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        if (data?.categories) setCategories(data.categories)
+      .then((json) => {
+        if (Array.isArray(json?.data)) setCategories(json.data)
       })
       .catch(() => {})
   }, [])

--- a/src/app/reports/ReportsClient.tsx
+++ b/src/app/reports/ReportsClient.tsx
@@ -28,7 +28,7 @@ export default function ReportsClient() {
         if (!r.ok) throw new Error('API error')
         return r.json()
       })
-      .then((d) => setReports(d.reports ?? []))
+      .then((d) => setReports(Array.isArray(d?.data) ? d.data : []))
       .catch(console.error)
       .finally(() => setLoading(false))
   }

--- a/src/app/reports/ReportsClient.tsx
+++ b/src/app/reports/ReportsClient.tsx
@@ -45,8 +45,8 @@ export default function ReportsClient() {
         body: JSON.stringify({ year: genYear, quarter: genQuarter }),
       })
       if (!res.ok) {
-        const data = await res.json()
-        alert(data.error || '리포트 생성 실패')
+        const data = await res.json().catch(() => null)
+        alert(data?.error ?? '리포트 생성 실패')
         return
       }
       fetchReports()

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -33,8 +33,8 @@ export default function SettingsClient() {
     try {
       const res = await fetch('/api/accounts')
       if (res.ok) {
-        const data = await res.json()
-        setAccounts(Array.isArray(data) ? data : [])
+        const json = await res.json()
+        setAccounts(Array.isArray(json.data) ? json.data : [])
       }
     } catch (e) {
       console.error('[settings] 계좌 조회 실패:', e)

--- a/src/app/watchlist/WatchlistClient.tsx
+++ b/src/app/watchlist/WatchlistClient.tsx
@@ -15,8 +15,8 @@ export default function WatchlistClient() {
     try {
       const res = await fetch('/api/watchlist')
       if (res.ok) {
-        const data = await res.json()
-        setItems(data.items ?? [])
+        const json = await res.json()
+        setItems(Array.isArray(json.data) ? json.data : [])
       }
     } catch (e) {
       console.error('[watchlist] 조회 실패:', e)

--- a/src/components/category/CategoryEditPanel.tsx
+++ b/src/components/category/CategoryEditPanel.tsx
@@ -30,8 +30,8 @@ export default function CategoryEditPanel({ category, onClose }: CategoryEditPan
   useEffect(() => {
     fetch('/api/category-groups')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => {
-        if (data?.groups) setGroups(data.groups)
+      .then((json) => {
+        if (Array.isArray(json?.data)) setGroups(json.data)
       })
       .catch(() => {})
   }, [])

--- a/src/components/dividend/DividendForm.tsx
+++ b/src/components/dividend/DividendForm.tsx
@@ -74,8 +74,8 @@ export default function DividendForm({ accounts }: DividendFormProps) {
     if (!isUSD) return
     fetch('/api/prices')
       .then((r) => r.json())
-      .then((data) => {
-        const fx = data.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
+      .then((json) => {
+        const fx = json?.data?.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
         if (fx) setFxRate(String(Math.round(fx.price)))
       })
       .catch(() => {})

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -106,8 +106,8 @@ export default function TransactionForm({
           { signal: controller.signal }
         )
         if (res.ok) {
-          const data = await res.json()
-          setSuggestions(data.suggestions ?? [])
+          const json = await res.json()
+          setSuggestions(json?.data?.suggestions ?? [])
         } else {
           setSuggestions([])
         }

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -45,8 +45,8 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
     try {
       const res = await fetch('/api/rsu')
       if (res.ok) {
-        const data = await res.json()
-        setSchedules(data.schedules ?? [])
+        const json = await res.json()
+        setSchedules(Array.isArray(json.data) ? json.data : [])
       }
     } catch {}
   }

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -74,7 +74,12 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
         return
       }
 
-      const { schedule: updated } = await res.json()
+      const json = await res.json()
+      const updated = json?.data?.schedule
+      if (!updated) {
+        setError('베스팅 처리 결과를 받지 못했습니다.')
+        return
+      }
 
       setSchedules((prev) =>
         prev.map((s) =>

--- a/src/components/settings/AlertConfigEditor.tsx
+++ b/src/components/settings/AlertConfigEditor.tsx
@@ -18,7 +18,7 @@ export default function AlertConfigEditor() {
   useEffect(() => {
     fetch('/api/alerts/config')
       .then((res) => res.ok ? res.json() : null)
-      .then((data) => { if (data?.configs) setConfigs(data.configs) })
+      .then((json) => { if (Array.isArray(json?.data)) setConfigs(json.data) })
       .catch(() => {})
   }, [])
 

--- a/src/components/settings/IncomeProfileManager.tsx
+++ b/src/components/settings/IncomeProfileManager.tsx
@@ -21,7 +21,10 @@ export default function IncomeProfileManager() {
   const fetchProfiles = useCallback(async () => {
     try {
       const res = await fetch('/api/income-profiles')
-      if (res.ok) setProfiles(await res.json())
+      if (res.ok) {
+        const json = await res.json()
+        setProfiles(Array.isArray(json?.data) ? json.data : [])
+      }
     } catch {}
   }, [])
 

--- a/src/components/settings/WhooingSettings.tsx
+++ b/src/components/settings/WhooingSettings.tsx
@@ -38,17 +38,19 @@ export default function WhooingSettings() {
       fetch('/api/settings/whooing').then((r) => r.ok ? r.json() : null),
       fetch('/api/settings/whooing/mappings').then((r) => r.ok ? r.json() : null),
       fetch('/api/categories').then((r) => r.ok ? r.json() : null),
-    ]).then(([cfg, maps, cats]) => {
+    ]).then(([cfgRes, mapsRes, cats]) => {
+      const cfg = cfgRes?.data
+      const mapsArr = mapsRes?.data
       if (cfg) {
         setConfig(cfg)
         setWebhookUrl(cfg.webhookUrl ?? '')
         setDefaultRight(cfg.defaultRight ?? '')
         setIsActive(cfg.isActive)
       }
-      if (maps?.mappings) {
-        setMappings(maps.mappings)
+      if (Array.isArray(mapsArr)) {
+        setMappings(mapsArr)
         const local: Record<string, { left: string; right: string }> = {}
-        for (const m of maps.mappings as CategoryMapping[]) {
+        for (const m of mapsArr as CategoryMapping[]) {
           local[m.categoryId] = { left: m.whooingLeft, right: m.whooingRight ?? '' }
         }
         setLocalMappings(local)
@@ -68,8 +70,8 @@ export default function WhooingSettings() {
         body: JSON.stringify({ webhookUrl: webhookUrl.trim() || null, isActive, defaultRight: defaultRight.trim() || null }),
       })
       if (res.ok) {
-        const data = await res.json()
-        setConfig(data)
+        const json = await res.json()
+        if (json?.data) setConfig(json.data)
       }
     } finally {
       setSaving(false)
@@ -88,8 +90,8 @@ export default function WhooingSettings() {
         body: JSON.stringify({ mappings: arr }),
       })
       if (res.ok) {
-        const data = await res.json()
-        setMappings(data.mappings)
+        const json = await res.json()
+        if (Array.isArray(json?.data)) setMappings(json.data)
       }
     } finally {
       setSavingMappings(false)

--- a/src/components/settings/WhooingSettings.tsx
+++ b/src/components/settings/WhooingSettings.tsx
@@ -53,8 +53,8 @@ export default function WhooingSettings() {
         }
         setLocalMappings(local)
       }
-      if (cats?.categories) {
-        setCategories(cats.categories)
+      if (Array.isArray(cats?.data)) {
+        setCategories(cats.data)
       }
     }).catch(() => {})
   }, [])

--- a/src/components/trade/EditPanel.tsx
+++ b/src/components/trade/EditPanel.tsx
@@ -89,7 +89,8 @@ export default function EditPanel({ trade, onClose }: EditPanelProps) {
         return
       }
 
-      const result = await res.json().catch(() => null)
+      const json = await res.json().catch(() => null)
+      const result = json?.data
       if (result?.holding !== undefined && result?.holdingBefore !== undefined) {
         const diff = formatHoldingEditDiff({
           ticker: trade.ticker,

--- a/src/components/trade/TradeForm.tsx
+++ b/src/components/trade/TradeForm.tsx
@@ -163,7 +163,8 @@ export default function TradeForm({ accounts }: TradeFormProps) {
         return
       }
 
-      const result = await res.json().catch(() => null)
+      const json = await res.json().catch(() => null)
+      const result = json?.data
       if (result?.holding !== undefined && result?.holdingBefore !== undefined) {
         const diff = formatHoldingDiff({
           ticker,

--- a/src/components/trade/TradeForm.tsx
+++ b/src/components/trade/TradeForm.tsx
@@ -80,8 +80,8 @@ export default function TradeForm({ accounts }: TradeFormProps) {
     if (!isUSD) return
     fetch('/api/prices')
       .then((r) => r.json())
-      .then((data) => {
-        const fx = data.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
+      .then((json) => {
+        const fx = json?.data?.prices?.find((p: { ticker: string }) => p.ticker === 'USDKRW=X')
         if (fx) setFxRate(String(Math.round(fx.price)))
       })
       .catch(() => {})

--- a/src/components/trade/import/ImportWizard.tsx
+++ b/src/components/trade/import/ImportWizard.tsx
@@ -60,9 +60,10 @@ export default function ImportWizard({ accounts }: ImportWizardProps) {
             `/api/trades?accountId=${accountId}&limit=${limit}&offset=${offset}`,
             { signal: controller.signal }
           )
-          const data = await res.json()
-          if (data.trades && data.trades.length > 0) {
-            for (const t of data.trades as Array<{ ticker: string; type: string; tradedAt: string; shares: number; price: number }>) {
+          const json = await res.json()
+          const trades = Array.isArray(json?.data) ? json.data : []
+          if (trades.length > 0) {
+            for (const t of trades as Array<{ ticker: string; type: string; tradedAt: string; shares: number; price: number }>) {
               allTrades.push({
                 ticker: t.ticker,
                 type: t.type,
@@ -72,7 +73,7 @@ export default function ImportWizard({ accounts }: ImportWizardProps) {
               })
             }
             offset += limit
-            hasMore = data.trades.length === limit
+            hasMore = trades.length === limit
           } else {
             hasMore = false
           }

--- a/src/components/trade/import/StepValidation.tsx
+++ b/src/components/trade/import/StepValidation.tsx
@@ -84,11 +84,16 @@ export default function StepValidation({
 
       const data = await res.json()
       if (!res.ok) {
-        setSubmitError(data.error ?? '임포트에 실패했습니다.')
+        setSubmitError(data?.error ?? '임포트에 실패했습니다.')
         return
       }
 
-      onNext(data.result as ImportResult)
+      const result = data?.data as ImportResult | undefined
+      if (!result) {
+        setSubmitError('임포트 결과를 받지 못했습니다.')
+        return
+      }
+      onNext(result)
     } catch {
       setSubmitError('네트워크 오류가 발생했습니다.')
     } finally {

--- a/src/lib/__tests__/api-errors.test.ts
+++ b/src/lib/__tests__/api-errors.test.ts
@@ -43,12 +43,12 @@ describe('isSafeBusinessError', () => {
 })
 
 describe('businessErrorResponse', () => {
-  it('화이트리스트 매칭 시 400 + 메시지 응답', async () => {
+  it('화이트리스트 매칭 시 400 + envelope 응답', async () => {
     const res = businessErrorResponse(new Error('보유 수량 부족: 5주'))
     expect(res).not.toBeNull()
     expect(res?.status).toBe(400)
     const body = await res?.json()
-    expect(body).toEqual({ error: '보유 수량 부족: 5주' })
+    expect(body).toEqual({ success: false, error: '보유 수량 부족: 5주' })
   })
 
   it('화이트리스트 외부는 null 반환', () => {

--- a/src/lib/__tests__/api-response.test.ts
+++ b/src/lib/__tests__/api-response.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { ok, fail, noContent, paginated } from '../api-response'
+
+describe('ok — 단순 성공', () => {
+  it('data 임베드 + success: true + status 200', async () => {
+    const res = ok({ id: 'abc', name: 'Test' })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toContain('application/json')
+    const body = await res.json()
+    expect(body).toEqual({ success: true, data: { id: 'abc', name: 'Test' } })
+  })
+
+  it('status 옵션으로 201 Created', async () => {
+    const res = ok({ id: 'new' }, { status: 201 })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toEqual({ id: 'new' })
+  })
+
+  it('meta 옵션 포함 시 응답에 meta 노출', async () => {
+    const res = ok([1, 2, 3], { meta: { total: 100, limit: 10, offset: 20 } })
+    const body = await res.json()
+    expect(body).toEqual({
+      success: true,
+      data: [1, 2, 3],
+      meta: { total: 100, limit: 10, offset: 20 },
+    })
+  })
+
+  it('meta 미지정 시 응답에 meta 키 없음', async () => {
+    const res = ok({ x: 1 })
+    const body = await res.json()
+    expect(body.meta).toBeUndefined()
+  })
+
+  it('null 데이터도 임베드', async () => {
+    const res = ok(null)
+    const body = await res.json()
+    expect(body).toEqual({ success: true, data: null })
+  })
+})
+
+describe('fail — 실패 응답', () => {
+  it('error 메시지 + success: false + status 400', async () => {
+    const res = fail('잘못된 요청')
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({ success: false, error: '잘못된 요청' })
+  })
+
+  it('status 옵션으로 404', async () => {
+    const res = fail('Not Found', 404)
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBe('Not Found')
+  })
+
+  it('status 500 (서버 오류)', async () => {
+    const res = fail('서버 오류', 500)
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('noContent — 본문 없는 응답', () => {
+  it('기본 status 204 + 빈 body', async () => {
+    const res = noContent()
+    expect(res.status).toBe(204)
+    const text = await res.text()
+    expect(text).toBe('')
+  })
+
+  it('205 / 304 status 허용', () => {
+    expect(noContent(205).status).toBe(205)
+    expect(noContent(304).status).toBe(304)
+  })
+
+  it('body 허용 status 는 throw', () => {
+    expect(() => noContent(200)).toThrow(/no-body status/)
+    expect(() => noContent(400)).toThrow(/no-body status/)
+  })
+})
+
+describe('ok — no-body status 자동 분기', () => {
+  it('status 204 시 NextResponse.json TypeError 회피 (data 무시)', async () => {
+    const res = ok({ should: 'be-ignored' }, { status: 204 })
+    expect(res.status).toBe(204)
+    expect(await res.text()).toBe('')
+  })
+
+  it('status 304 도 자동 분기', async () => {
+    const res = ok(null, { status: 304 })
+    expect(res.status).toBe(304)
+    expect(await res.text()).toBe('')
+  })
+
+  it('no-body status 시 meta 도 운반 불가 (silent drop, 의도된 동작)', async () => {
+    // RFC 9110: 204/205/304 는 body 자체가 없으므로 meta 도 표현 불가.
+    // 호출자가 실수로 전달해도 status 가 우선 — body 없이 통과.
+    const res = ok([1, 2, 3], { status: 204, meta: { total: 100, limit: 10, offset: 0 } })
+    expect(res.status).toBe(204)
+    expect(await res.text()).toBe('')
+  })
+})
+
+describe('paginated — 페이지네이션 응답', () => {
+  it('data + meta + status 200', async () => {
+    const res = paginated([{ a: 1 }, { a: 2 }], 50, 10, 0)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      success: true,
+      data: [{ a: 1 }, { a: 2 }],
+      meta: { total: 50, limit: 10, offset: 0 },
+    })
+  })
+
+  it('빈 데이터도 통과 (total=0)', async () => {
+    const res = paginated([], 0, 10, 0)
+    const body = await res.json()
+    expect(body.data).toEqual([])
+    expect(body.meta).toEqual({ total: 0, limit: 10, offset: 0 })
+  })
+
+  it('status 옵션으로 201 (드물지만 가능)', async () => {
+    const res = paginated([], 0, 10, 0, 201)
+    expect(res.status).toBe(201)
+  })
+})

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { fail } from './api-response'
 
 // 사용자에게 노출해도 안전한 비즈니스 예외 메시지를 식별하는 화이트리스트.
 // 새 메시지를 추가할 때는 우연 매칭을 피하기 위해 메시지 형식을 명시적으로 잠근다.
@@ -14,5 +15,5 @@ export function isSafeBusinessError(err: unknown): err is Error {
 
 export function businessErrorResponse(err: unknown): NextResponse | null {
   if (!isSafeBusinessError(err)) return null
-  return NextResponse.json({ error: err.message }, { status: 400 })
+  return fail(err.message, 400)
 }

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,96 @@
+/**
+ * API 응답 envelope `ApiResponse<T>` 와 헬퍼.
+ *
+ * 9차 마일스톤 (Phase 27) 의 기반 인프라. 라우트/클라이언트 마이그는 후속 sub-phase
+ * (27-B/C/D) 에서 점진 적용. 이 파일 자체는 라우트 변경 0건이라 호환성 100% 보장.
+ *
+ * 사용 예:
+ *   import { ok, fail, paginated } from '@/lib/api-response'
+ *
+ *   // 단순 성공
+ *   return ok({ id: '...', name: '...' })
+ *
+ *   // 201 Created
+ *   return ok(created, { status: 201 })
+ *
+ *   // 페이지네이션
+ *   return paginated(trades, total, limit, offset)
+ *
+ *   // 실패
+ *   return fail('거래를 찾을 수 없습니다.', 404)
+ */
+
+import { NextResponse } from 'next/server'
+
+export interface ApiResponseMeta {
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: ApiResponseMeta
+}
+
+interface OkOptions {
+  status?: number
+  meta?: ApiResponseMeta
+}
+
+/**
+ * No-body HTTP status. Response 생성자가 body 동봉을 거부하므로 별도 처리.
+ * RFC 9110 §15.4.5 (304), RFC 9110 §15.3.5 (204), §15.3.6 (205).
+ */
+const NO_BODY_STATUSES = new Set([204, 205, 304])
+
+/**
+ * 본문 없는 성공 응답 (HTTP 204 No Content 기본).
+ * DELETE / 빈 ack 용. status 옵션으로 205, 304 도 사용 가능.
+ */
+export function noContent(status = 204): NextResponse {
+  if (!NO_BODY_STATUSES.has(status)) {
+    throw new Error(`noContent() requires a no-body status (204/205/304), got ${status}`)
+  }
+  return new NextResponse(null, { status })
+}
+
+/**
+ * 성공 응답. status 미지정 시 200.
+ *
+ * status 가 no-body (204/205/304) 면 자동으로 noContent() 와 동일하게 처리.
+ * 이때 data 와 meta 는 운반 불가하므로 무시된다 (의도된 동작 — RFC 9110 § 15 가
+ * body 자체를 허용하지 않음).
+ */
+export function ok<T>(data: T, options?: OkOptions): NextResponse {
+  const status = options?.status ?? 200
+  // no-body status 는 NextResponse.json 이 TypeError 를 던지므로 자동 분기
+  if (NO_BODY_STATUSES.has(status)) {
+    return noContent(status)
+  }
+  const body: ApiResponse<T> = { success: true, data }
+  if (options?.meta) body.meta = options.meta
+  return NextResponse.json(body, { status })
+}
+
+/** 실패 응답. status 미지정 시 400. */
+export function fail(error: string, status = 400): NextResponse {
+  const body: ApiResponse<never> = { success: false, error }
+  return NextResponse.json(body, { status })
+}
+
+/**
+ * 페이지네이션 성공 응답.
+ * meta 에 total/limit/offset 포함.
+ */
+export function paginated<T>(
+  data: T[],
+  total: number,
+  limit: number,
+  offset: number,
+  status = 200,
+): NextResponse {
+  return ok(data, { status, meta: { total, limit, offset } })
+}


### PR DESCRIPTION
## v0.8.0 — Phase 27 + 28: ApiResponse envelope 전면 도입

v0.7.0 (Phase 26) 이후 24 커밋 누적 — **9차 + 10차 두 마일스톤** 분량.

## 핵심 변경: 응답 envelope `ApiResponse<T>` 전면 도입

모든 API 라우트가 통일된 envelope (`{ success, data?, error?, meta? }`) 으로 응답하도록 70+ 라우트 + 40+ 클라이언트 fetcher 마이그.

```ts
// 헬퍼: @/lib/api-response
ok(data)                                  // 200
ok(created, { status: 201 })              // 201
paginated(items, total, limit, offset)    // 200 + meta
noContent()                               // 204
fail(error, status)                       // 에러
```

예외 1건: `reports/[id]/download` PDF success path (Content-Disposition raw Response — 의도된 파일 응답 패턴).

## 9차 마일스톤 (Phase 27) — 핵심 도메인 53+ 라우트

- **27-A**: ApiResponse 헬퍼 + 16 단위 테스트
- **27-B**: 단순 GET 라우트 (10 라우트 + 13 fetcher, atomic)
- **27-C-1~5**: POST/PUT/DELETE 5 sub-PR
  - C-1 Watchlist/Recurring/Settings/IncomeProfile (7 라우트)
  - C-2 Category/Budget/Asset (9 라우트)
  - C-3 Dividend/Deposit/Transaction (9 라우트)
  - C-4 RSU/StockOption (7 라우트)
  - C-5 Trade (3 라우트 + api-errors 헬퍼 통일)
- **27-D**: pagination + 복잡한 GET (8 라우트, transactions 집계 포함)
- **27-E**: 가이드 문서 (`.claude/rules/api-routes.md`, `CLAUDE.md`)

## 10차 마일스톤 (Phase 28) — 잔여 16 라우트

- **28-A**: accounts (2 라우트)
- **28-B**: networth + reports + tax/gift (4 라우트, PDF raw 유지)
- **28-C**: performance/* (4 라우트)
- **28-D**: prices/* (4 라우트, 429 throttle 보존)
- **28-E**: ai/ask + backtest (2 라우트) + 가이드 "전체 완료" 표기

## 그 외 변경

- 보안: Dependabot 4건 패치 (dompurify/esbuild/js-yaml/postcss)
- backtest: `error.message` 누출 차단 (보안 규칙 준수)

## 호환성

- 자체 운영 (모바일/외부 클라이언트 없음) — public API break 없음
- 봇/cron/MCP 는 lib 직접 호출 — HTTP 응답 shape 변경 영향 없음

## 통계

- 102 files changed, +3,448 / −1,917
- 162 단위 테스트 모두 통과
- 코드 리뷰: 모든 sub-PR P0/P1/P2 = 0건 통과