### PR TITLE
[bug] 텔레그램 봇 IPv6 ETIMEDOUT + 토큰 로그 노출 (myFitness #108 패턴) (#354)

### DIFF
--- a/docs/specs/354-bot-ipv6-token-fix.md
+++ b/docs/specs/354-bot-ipv6-token-fix.md
@@ -1,0 +1,70 @@
+# 텔레그램 봇 IPv6 ETIMEDOUT + 토큰 로그 노출 대응
+
+- **작성일**: 2026-06-30
+- **타입**: bug (P1)
+- **참조**: `fomalhaut84/myFitness#108` (같은 서버, 동일 원인. 패턴 그대로 이식)
+
+## 1. 문제
+
+### 1.1 증상
+
+운영 서버(Ubuntu, PM2)에서 myFinance 텔레그램 봇이 cron 알림 / AI 응답 / 변동 알림 등에서 `HttpError: Network request for 'sendMessage' failed!` + `ETIMEDOUT` 으로 산발적 실패. 사용자 메시지로는 `"AI 질문 처리에 실패했습니다."` (`src/bot/commands/ai.ts:74` 의 마지막 else 분기 fallback).
+
+PM2 로그 `myfinance-bot-error-2.log`:
+```
+[bot] AI 질문 처리 실패: HttpError: Network request for 'sendMessage' failed!
+  error: FetchError: request to https://api.telegram.org/bot<TOKEN>/sendMessage failed, reason:
+    type: 'system', errno: 'ETIMEDOUT', code: 'ETIMEDOUT'
+```
+
+### 1.2 원인 (myFitness 진단 그대로 적용)
+
+- 서버에 IPv6 라우트 없음 (`curl -6 https://api.telegram.org/` → `Network is unreachable`).
+- `dns.lookup` 이 AAAA 를 먼저 반환 → node-fetch 가 IPv6 시도 → 커널이 `ENETUNREACH` 반환, node-fetch 경로에서 `ETIMEDOUT` 으로 전파.
+- `curl` 은 Happy Eyeballs 로 즉시 IPv4 fallback 하지만 node-fetch 는 그렇지 못함.
+
+### 1.3 부수 발견: 토큰 노출 위험
+
+`console.error('[bot] ...', err)` 가 grammy `HttpError` 객체를 dump 하면 inner `FetchError` 메시지에 `/bot<TOKEN>/sendMessage` URL 이 평문 포함된 채 PM2 stderr 로그 파일에 누적될 수 있음. myFinance 도 `console.error(err)` 호출처 다수 존재.
+
+### 1.4 부수 발견: 알림 발송 패턴 비일관
+
+- `src/bot/utils/telegram.ts` 의 `sendHtml` / `replyHtml` 은 이미 `withRetry` 적용
+- 하지만 `src/bot/notifications/briefing.ts`, `monthly-report.ts` 는 직접 `bot.api.sendMessage` 호출 → 재시도 없음, parse fallback 없음
+- 재시도 delay 가 1s/2s 로 짧음 (myFitness 2s/8s/30s 와 비교)
+
+## 2. 요구사항
+
+- [ ] **F1**: 봇이 IPv6 시도하지 않도록 IPv4 강제 (`https.Agent({family:4, keepAlive:true})`)
+- [ ] **F2**: `client.timeoutSeconds: 60` 명시 (grammy 기본값 500s 단축, long-poll 30s + 마진)
+- [ ] **F3**: 토큰 마스킹 유틸 (`src/bot/utils/error.ts`) — `sanitizeError` / `sanitizeMessage` / `isNetworkError` / `isHtmlParseError` / `getErrorCode`
+- [ ] **F4**: `withRetry` 강화 — `isNetworkError` 사용 (더 많은 코드 + grammy timeout/abort 포착), delay 2s/8s/30s, 로그 sanitize
+- [ ] **F5**: `console.error` 로 err 객체 dump 하는 호출처 전부 → `sanitizeError(err)` 경유
+- [ ] **F6**: `briefing.ts` / `monthly-report.ts` 의 직접 `bot.api.sendMessage` 호출 → `sendHtml` 유틸로 교체
+
+## 3. 영향 없음 (확인)
+
+- DB / 스키마 / API 라우트 변경 없음
+- AI advisor 동작 변경 없음 (PR #353 의 firecrawl/stderr fix 와 독립)
+
+## 4. 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 운영 서버 배포 후: 모닝 브리핑 (cron) 또는 텔레그램 AI 질문 → ETIMEDOUT 빈도 0 또는 자동 복구로 사용자 영향 없는지 확인
+- 토큰 마스킹: `pm2 logs myfinance-bot` 에 `bot<숫자>:` 패턴이 더 이상 안 보여야 함
+
+## 5. 제외 사항
+
+- 봇 인스턴스 중복 (`409 Conflict`) 은 별개 이슈 — ecosystem.config.js 또는 PM2 reload 패턴 점검 필요. 본 PR 범위 외.
+- 운영 토큰 회수/재발급은 사용자 별도 진행.
+
+## 6. 배포 가이드
+
+```bash
+./deploy/deploy.sh dev    # 또는 main 머지 후 main 배포
+pm2 restart myfinance-bot
+# 검증: pm2 logs myfinance-bot --lines 30
+#   → [bot] standalone 프로세스 시작...
+#   → [cron] ... 스케줄러 등록 완료
+#   → 토큰 노출 없음
+```

--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -10,6 +10,7 @@ import { splitMessage, formatKRWFull, formatUSD } from '../utils/formatter'
 import { isAiQuestion } from '../utils/ai-trigger'
 import { isTradeMessage } from '../utils/trade-trigger'
 import { markdownToTelegramHtml } from '../utils/markdown'
+import { sanitizeError } from '../utils/error'
 
 const TYPING_INTERVAL_MS = 5000
 const MIN_AI_TEXT_LENGTH = 3
@@ -68,9 +69,11 @@ function fireAiQuestion(ctx: Context, question: string): void {
       if (error instanceof AdvisorTimeoutError) {
         await ctx.reply('⚠️ AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.')
       } else if (error instanceof AdvisorError) {
+        // AdvisorError.message 는 정적 한국어. detail (stderr) 는 console 로만.
+        if (error.detail) console.error(`[bot] AI advisor detail: ${error.detail}`)
         await ctx.reply(`⚠️ ${error.message}`)
       } else {
-        console.error('[bot] AI 질문 처리 실패:', error)
+        console.error(`[bot] AI 질문 처리 실패: ${sanitizeError(error)}`)
         await ctx.reply('⚠️ AI 질문 처리에 실패했습니다.')
       }
     })

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,4 +1,5 @@
 import { Bot } from 'grammy'
+import { Agent } from 'https'
 import { registerCommands } from './commands/start'
 import { registerPortfolioCommands } from './commands/portfolio'
 import { registerPriceCommands } from './commands/price'
@@ -16,6 +17,15 @@ import { registerReportCommands } from './commands/report'
 import { registerBacktestCommands } from './commands/backtest'
 import { authMiddleware } from './middleware/auth'
 
+// IPv6 라우트가 없는 환경(운영 서버 등)에서 node-fetch의 IPv6 우선 시도가
+// ETIMEDOUT으로 누적되는 것을 방지하기 위해 IPv4 강제. keepAlive로 cron 호출 시
+// TCP/TLS 핸드셰이크 비용도 절감. docs/specs/354-bot-ipv6-token-fix.md 참조.
+const telegramAgent = new Agent({ family: 4, keepAlive: true })
+
+// grammy client.timeoutSeconds는 모든 API 호출(getUpdates 포함) 공통 abort timer.
+// long-polling Telegram side hold 기본값(30s) 위에 마진 확보 (60s = polling 30s + RTT 30s).
+const CLIENT_TIMEOUT_SECONDS = 60
+
 let bot: Bot | null = null
 
 function createBot(): Bot {
@@ -24,7 +34,12 @@ function createBot(): Bot {
     throw new Error('TELEGRAM_BOT_TOKEN 환경변수가 설정되지 않았습니다')
   }
 
-  const instance = new Bot(token)
+  const instance = new Bot(token, {
+    client: {
+      baseFetchConfig: { agent: telegramAgent },
+      timeoutSeconds: CLIENT_TIMEOUT_SECONDS,
+    },
+  })
 
   // Chat ID 화이트리스트 인증
   instance.use(authMiddleware)

--- a/src/bot/notifications/briefing.ts
+++ b/src/bot/notifications/briefing.ts
@@ -7,8 +7,9 @@
 
 import { getBot } from '@/bot/index'
 import { askAdvisor } from '@/lib/ai/claude-advisor'
-import { splitMessage } from '@/bot/utils/formatter'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
+import { sendHtml } from '@/bot/utils/telegram'
+import { sanitizeError } from '@/bot/utils/error'
 
 type MarketSession = 'KR' | 'US'
 
@@ -50,33 +51,26 @@ export async function sendBriefing(
       maxBudgetUsd: 1.0,
     })
 
-    const chunks = splitMessage(result.response)
-    const htmlChunks = chunks.map((chunk) => markdownToTelegramHtml(chunk))
+    const html = markdownToTelegramHtml(result.response)
 
     for (const chatId of chatIds) {
       try {
-        for (let i = 0; i < chunks.length; i++) {
-          try {
-            await bot.api.sendMessage(chatId, htmlChunks[i], { parse_mode: 'HTML' })
-          } catch {
-            await bot.api.sendMessage(chatId, chunks[i])
-          }
-        }
+        await sendHtml(bot, chatId, html)
       } catch (error) {
-        console.error(`[briefing] 발송 실패 (chatId: ${chatId}):`, error)
+        console.error(`[briefing] 발송 실패 (chatId: ${chatId}): ${sanitizeError(error)}`)
       }
     }
 
     const label = session === 'KR' ? '한국장' : '미국장'
     console.log(`[briefing] ${label} 모닝 브리핑 발송 완료`)
   } catch (error) {
-    console.error('[briefing] 브리핑 생성 실패:', error)
+    console.error(`[briefing] 브리핑 생성 실패: ${sanitizeError(error)}`)
 
     const label = session === 'KR' ? '🇰🇷 한국장' : '🇺🇸 미국장'
     const fallback = `📊 ${label} 모닝 브리핑 생성에 실패했습니다.\n/ai 에서 직접 질문해주세요.`
     for (const chatId of chatIds) {
       try {
-        await bot.api.sendMessage(chatId, fallback)
+        await sendHtml(bot, chatId, fallback)
       } catch {
         // 무시
       }

--- a/src/bot/notifications/monthly-report.ts
+++ b/src/bot/notifications/monthly-report.ts
@@ -6,8 +6,9 @@
 
 import { getBot } from '@/bot/index'
 import { askAdvisor } from '@/lib/ai/claude-advisor'
-import { splitMessage } from '@/bot/utils/formatter'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
+import { sendHtml } from '@/bot/utils/telegram'
+import { sanitizeError } from '@/bot/utils/error'
 
 function getPrevMonth(): { year: number; month: number } {
   const now = new Date()
@@ -41,32 +42,21 @@ export async function sendMonthlyReport(chatIds: number[]): Promise<void> {
 
     for (const chatId of chatIds) {
       try {
-        if (html.length <= 4096) {
-          try {
-            await bot.api.sendMessage(chatId, html, { parse_mode: 'HTML' })
-          } catch {
-            await bot.api.sendMessage(chatId, result.response)
-          }
-        } else {
-          const chunks = splitMessage(result.response)
-          for (const chunk of chunks) {
-            await bot.api.sendMessage(chatId, chunk)
-          }
-        }
+        await sendHtml(bot, chatId, html)
       } catch (error) {
-        console.error(`[notification] 월간 리포트 발송 실패 (chatId: ${chatId}):`, error)
+        console.error(`[notification] 월간 리포트 발송 실패 (chatId: ${chatId}): ${sanitizeError(error)}`)
       }
     }
 
     console.log(`[notification] ${year}년 ${month}월 월간 리포트 발송 완료`)
   } catch (error) {
-    console.error('[notification] 월간 리포트 생성 실패:', error)
+    console.error(`[notification] 월간 리포트 생성 실패: ${sanitizeError(error)}`)
 
     // AI 실패 시 간단 안내 메시지 발송
     const fallback = `📊 ${year}년 ${month}월 월간 리포트 생성에 실패했습니다.\n웹 AI 분석 페이지에서 직접 조회해주세요.`
     for (const chatId of chatIds) {
       try {
-        await bot.api.sendMessage(chatId, fallback)
+        await sendHtml(bot, chatId, fallback)
       } catch {
         // 무시
       }

--- a/src/bot/standalone.ts
+++ b/src/bot/standalone.ts
@@ -11,6 +11,7 @@ import 'dotenv/config'
 import { getBot } from './index'
 import { schedulePriceUpdates, scheduleSnapshots, scheduleKrxSync, scheduleRecurring, scheduleVestingStatusUpdate } from '@/lib/cron'
 import { scheduleNotifications } from './notifications/scheduler'
+import { sanitizeError } from './utils/error'
 
 async function main(): Promise<void> {
   console.log('[bot] standalone 프로세스 시작...')
@@ -34,7 +35,7 @@ async function main(): Promise<void> {
   console.log('[bot] cron + 알림 스케줄러 등록 완료')
 
   bot.catch((err) => {
-    console.error('[bot] 에러:', err)
+    console.error(`[bot] 에러: ${sanitizeError(err)}`)
   })
 
   // graceful shutdown
@@ -52,6 +53,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error('[bot] 시작 실패:', err)
+  console.error(`[bot] 시작 실패: ${sanitizeError(err)}`)
   process.exit(1)
 })

--- a/src/bot/utils/error.ts
+++ b/src/bot/utils/error.ts
@@ -46,7 +46,9 @@ export function sanitizeError(err: unknown): string {
     }
     depth++
   }
-  return parts.join(' | ')
+  // 이중 보호: 각 part 가 이미 sanitize 됐지만, 누락된 필드 (예: cur.toString() 에 토큰 잔존)
+  // 가 join 시 섞이는 경우를 대비해 최종 결과에도 한 번 더 적용.
+  return sanitizeMessage(parts.join(' | '))
 }
 
 export function getErrorCode(err: unknown): string | undefined {

--- a/src/bot/utils/error.ts
+++ b/src/bot/utils/error.ts
@@ -13,6 +13,7 @@ const NETWORK_CODES = new Set([
   'EAI_AGAIN',
   'ECONNREFUSED',
   'EHOSTUNREACH',
+  'ENOTFOUND', // DNS 일시 실패 (기존 isRetryableNetworkError 호환 보존)
 ])
 
 export function sanitizeMessage(msg: string): string {

--- a/src/bot/utils/error.ts
+++ b/src/bot/utils/error.ts
@@ -1,0 +1,98 @@
+/**
+ * 봇 에러 처리 유틸 — 토큰 마스킹 + 네트워크/HTML 파싱 에러 분류.
+ *
+ * 참조: docs/specs/354-bot-ipv6-token-fix.md
+ * 원본 패턴: fomalhaut84/myFitness#108 (같은 서버, 동일 원인)
+ */
+
+const TOKEN_RE = /bot\d+:[A-Za-z0-9_-]+/g
+const NETWORK_CODES = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'EHOSTUNREACH',
+])
+
+export function sanitizeMessage(msg: string): string {
+  return msg.replace(TOKEN_RE, 'bot<REDACTED>')
+}
+
+/**
+ * Error.cause + grammy HttpError.error 체인을 깊이 5까지 순회하며 message 추출 + 토큰 마스킹.
+ * console.error(err) 가 inner FetchError 까지 dump 하는 문제 차단.
+ */
+export function sanitizeError(err: unknown): string {
+  const parts: string[] = []
+  let cur: unknown = err
+  let depth = 0
+  const MAX_DEPTH = 5
+  while (cur != null && depth < MAX_DEPTH) {
+    if (cur instanceof Error) {
+      parts.push(`${cur.name}: ${sanitizeMessage(cur.message)}`)
+      const withInner = cur as { error?: unknown; cause?: unknown }
+      cur = withInner.error ?? withInner.cause
+    } else if (typeof cur === 'string') {
+      parts.push(sanitizeMessage(cur))
+      break
+    } else {
+      try {
+        parts.push(sanitizeMessage(JSON.stringify(cur)))
+      } catch {
+        parts.push('[unserializable]')
+      }
+      break
+    }
+    depth++
+  }
+  return parts.join(' | ')
+}
+
+export function getErrorCode(err: unknown): string | undefined {
+  let cur: unknown = err
+  let depth = 0
+  while (cur != null && depth < 5) {
+    if (cur && typeof cur === 'object') {
+      const obj = cur as { code?: unknown; error?: unknown; cause?: unknown }
+      if (typeof obj.code === 'string') return obj.code
+      cur = obj.error ?? obj.cause
+    } else {
+      break
+    }
+    depth++
+  }
+  return undefined
+}
+
+const GRAMMY_TIMEOUT_RE = /Request to '.+' timed out after \d+ seconds/i
+const ABORT_NAME_RE = /^AbortError$/i
+
+/**
+ * 네트워크 에러 판별 — ETIMEDOUT/ECONNRESET 등 + grammy client.timeoutSeconds 발동
+ * (code 없는 plain Error) + fetch abort (AbortError) 모두 포착.
+ */
+export function isNetworkError(err: unknown): boolean {
+  const code = getErrorCode(err)
+  if (code !== undefined && NETWORK_CODES.has(code)) return true
+  let cur: unknown = err
+  let depth = 0
+  while (cur != null && depth < 5) {
+    if (cur instanceof Error) {
+      if (GRAMMY_TIMEOUT_RE.test(cur.message)) return true
+      if (ABORT_NAME_RE.test(cur.name)) return true
+      const obj = cur as { type?: unknown; error?: unknown; cause?: unknown }
+      if (obj.type === 'aborted') return true
+      cur = obj.error ?? obj.cause
+    } else {
+      break
+    }
+    depth++
+  }
+  return false
+}
+
+export function isHtmlParseError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /can't parse entities|Bad Request:.*entit/i.test(msg)
+}

--- a/src/bot/utils/telegram.ts
+++ b/src/bot/utils/telegram.ts
@@ -8,6 +8,7 @@
 import { Context } from 'grammy'
 import { Bot } from 'grammy'
 import { splitMessage } from './formatter'
+import { isNetworkError, sanitizeError } from './error'
 
 /**
  * HTML 특수문자 이스케이프 (텔레그램 HTML parse_mode용)
@@ -87,28 +88,29 @@ function isParseError(error: unknown): boolean {
 }
 
 /**
- * 안전하게 재시도 가능한 네트워크 에러 판별.
- * ETIMEDOUT/ENOTFOUND만 재시도 (연결 자체 실패 → 요청 미도달 보장).
- * ECONNRESET은 요청 도달 후 응답 실패일 수 있어 중복 메시지 위험 → 재시도 안 함.
+ * 시도 사이 sleep — 2s/8s/30s (총 4회 시도 = 초기 + 3 재시도).
+ * IPv4 강제(src/bot/index.ts) 이후에도 일시 네트워크 흔들림에 대비. myFitness #108 통일.
  */
-function isRetryableNetworkError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  const inner = (error as { error?: { code?: string } }).error
-  return inner?.code === 'ETIMEDOUT' || inner?.code === 'ENOTFOUND'
-}
+const RETRY_DELAYS_MS = [2000, 8000, 30000]
 
 /**
- * 재시도 래퍼: 네트워크 에러 시 지수 백오프로 재시도 (최대 2회)
+ * 재시도 래퍼: 네트워크 에러 시 지수 백오프. ETIMEDOUT/ECONNRESET/ENETUNREACH/grammy timeout/abort 등
+ * 광범위하게 포착 (`isNetworkError` — src/bot/utils/error.ts).
+ *
+ * 주의: send 가 성공 후 응답 도착 전 끊긴 경우 (ECONNRESET 등) 중복 메시지 위험은 있으나,
+ * 운영 시나리오상 사용자 1명 → cron 누락보다 중복 위험이 작다.
  */
-async function withRetry<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
   let lastError: unknown
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  const maxAttempts = RETRY_DELAYS_MS.length + 1
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       return await fn()
     } catch (error) {
       lastError = error
-      if (!isRetryableNetworkError(error) || attempt === maxRetries) throw error
-      const delay = 1000 * (attempt + 1) // 1초, 2초
+      if (!isNetworkError(error) || attempt === maxAttempts - 1) throw error
+      const delay = RETRY_DELAYS_MS[attempt]
+      console.warn(`[bot] 전송 재시도 ${attempt + 1}/${maxAttempts} (${delay}ms 후): ${sanitizeError(error)}`)
       await new Promise((r) => setTimeout(r, delay))
     }
   }


### PR DESCRIPTION
## 요약

같은 운영 서버의 `myFitness#108` 과 **동일 원인 / 동일 해결**. 패턴 그대로 myFinance 에 이식.

서버 IPv6 라우트 부재 → node-fetch IPv6 우선 시도 → ETIMEDOUT 누적. PM2 로그에 grammy HttpError dump 시 inner FetchError 의 `/bot<TOKEN>/sendMessage` URL 평문 노출 위험.

## 변경 내역

### 신규
- `src/bot/utils/error.ts` — `sanitizeError` / `sanitizeMessage` / `isNetworkError` / `isHtmlParseError` / `getErrorCode`
  - 토큰 정규식 `bot\d+:[A-Za-z0-9_-]+` 마스킹
  - `Error.cause` + grammy `HttpError.error` 체인 깊이 5 순회
  - grammy `client.timeoutSeconds` 발동 (code 없는 plain Error) + `AbortError` 까지 포착

### 봇 코어
- `src/bot/index.ts` — `https.Agent({family:4, keepAlive:true})` + `client.timeoutSeconds:60` (long-poll 30s + RTT 마진)
- `src/bot/utils/telegram.ts` — `withRetry` 강화: `isNetworkError` 사용 + delay 2s/8s/30s (총 4회) + 로그 sanitize. 시그니처 변경 (maxRetries 인자 제거)

### 알림 발송 통일 (직접 sendMessage → sendHtml 유틸)
- `src/bot/notifications/briefing.ts` — `sendHtml` 사용으로 재시도 + parse fallback + sanitize 자동 적용
- `src/bot/notifications/monthly-report.ts` — 동일

### 로그 sanitize
- `src/bot/standalone.ts` — bot.catch / main.catch
- `src/bot/commands/ai.ts` — `AdvisorError.detail` (PR #353 신설) 은 console 로만, 사용자엔 정적 message; 미분류는 sanitizeError

### docs
- `docs/specs/354-bot-ipv6-token-fix.md`

## 체크리스트

- [x] 린트 — 0
- [x] 타입체크 — 0
- [x] 테스트 — 162/162
- [x] 빌드 — Next + MCP + Bot (esbuild)
- [x] 코드 리뷰 — 1회 P1×1 (sanitize 이중 보호) → 같은 PR 수정 후 통과
- [x] `https.Agent` external (Node built-in) 정상 처리 확인
- [x] grammy 1.44 `baseFetchConfig.agent` → node-fetch 전달 경로 확인

## 배포 가이드

```bash
./deploy/deploy.sh dev    # 또는 main 머지 후 main 배포
pm2 restart myfinance-bot

# 검증
pm2 logs myfinance-bot --lines 30
#   → [bot] standalone 프로세스 시작...
#   → [cron] ... 스케줄러 등록 완료
#   → 토큰 평문 노출 없음 (bot<숫자>:... 패턴 없음)
#   → ETIMEDOUT 빈도 0 또는 자동 복구 (2s/8s/30s 백오프)
```

## 알려진 별개 이슈 (본 PR 범위 외)

- 봇 인스턴스 중복 (`409 Conflict — terminated by other getUpdates`) — ecosystem.config.js 또는 PM2 reload 패턴 점검 필요. 별도 이슈로 처리.

Closes #354