### PR TITLE
[enhancement] 베스팅 캘린더 개선 1 — 요약/분포 강화 (#359)

### DIFF
--- a/docs/specs/359-vesting-calendar-improve.md
+++ b/docs/specs/359-vesting-calendar-improve.md
@@ -1,0 +1,109 @@
+# 베스팅 캘린더 개선 1 — 요약/분포 강화
+
+- **작성일**: 2026-06-30
+- **타입**: enhancement (P2)
+- **연관**: #307 (베스팅 캘린더 본체, 이미 완료)
+- **참조**: `docs/designs/307-vesting-calendar/design-notes.md`
+
+## 1. 배경
+
+`/vesting` 페이지의 요약 strip 4 카드 + 면책 박스가 design-notes 의 의도와 차이가 있음:
+
+| design-notes | 현재 |
+|---|---|
+| 이번 달 / 다가오는 90일 / **YTD 완료** / **만료 임박** | 이번 달 / 다가오는 90일 / 완료(전체) / 만료(이미 만료) |
+| 다가오는 리스트 + **(계좌별 분포 + 면책 박스)** | 다가오는 리스트 + 면책 박스만 |
+
+운영 시 가치 큰 정보 (옵션 행사 기회 D-90 임박, 계좌별 다가오는 부담 분포) 가 가려져 있음.
+
+## 2. 요구사항
+
+- [ ] **R1**: 완료 카드 — 전체 → **올해 (YTD) 완료** 만 카운트 (`event.date.startsWith(currentYear)`)
+- [ ] **R2**: 만료 카드 → **만료 임박** 카드 — 옵션의 `expiryDate` 가 D-90 이내 + `remainingShares > 0` 인 옵션 수 (행사 기회 놓치기 직전 알림). 이미 만료된 항목은 별도 카운트 표시 가능.
+- [ ] **R3**: **계좌별 분포** 카드 신설 — 다가오는 90일 events 를 `accountName` 별로 group + RSU/OPT 합산 주수. 세진/소담/다솜 컬러 차트 또는 stacked bar.
+- [ ] **R4**: 면책 박스는 우측/하단에 유지.
+
+## 3. 기술 설계
+
+### 3.1 데이터 fetch 확장 (page.tsx)
+
+기존:
+```ts
+const options = await prisma.stockOption.findMany({
+  include: { account: ..., vestings: ... },
+})
+```
+
+추가:
+```ts
+// 옵션의 expiryDate, remainingShares 도 함께 select (이미 모델에 있음 — select 누락만)
+const options = await prisma.stockOption.findMany({
+  include: {
+    account: { select: { name: true } },
+    vestings: { orderBy: { vestingDate: 'asc' } },
+  },
+  // expiryDate, remainingShares 는 default 로 포함됨 (Prisma findMany 는 모든 스칼라 default select)
+})
+```
+
+→ 사실 `findMany` 는 기본적으로 모든 스칼라 필드 포함하므로 별도 수정 불필요. 그러나 spec 명시.
+
+### 3.2 새 summary 계산
+
+```ts
+const currentYear = new Date().getUTCFullYear()
+const EXPIRING_SOON_DAYS = 90
+
+// R1: YTD 완료
+const ytdCompletedCount = events.filter(
+  (e) => (e.status === 'vested' || e.status === 'exercised') && e.date.startsWith(String(currentYear))
+).length
+
+// R2: 만료 임박 옵션
+const expiringSoonCount = options.filter((opt) => {
+  if (opt.remainingShares <= 0) return false
+  const days = diffDaysKST(toKSTDateString(opt.expiryDate), todayMs)
+  return days >= 0 && days <= EXPIRING_SOON_DAYS
+}).length
+const expiredCount = options.filter((opt) => {
+  const days = diffDaysKST(toKSTDateString(opt.expiryDate), todayMs)
+  return days < 0 && opt.remainingShares > 0
+}).length  // 이미 만료 + 잔여수량 있음 = 행사 기회 영구 손실
+```
+
+### 3.3 계좌별 분포 (R3)
+
+신규 컴포넌트 `src/components/vesting/VestingDistribution.tsx`:
+
+```tsx
+interface DistributionItem {
+  accountName: string
+  rsuShares: number
+  optShares: number
+  totalShares: number
+  color: string  // sejin/sodam/dasom 컬러
+}
+
+// 입력: upcomingEvents (다가오는 90일)
+// 출력: 계좌별 grouped row + stacked bar 또는 가로 비교
+```
+
+## 4. 변경 파일
+
+- `src/app/vesting/page.tsx` — summary 4 카드 갱신 + VestingDistribution 추가
+- `src/components/vesting/VestingDistribution.tsx` 신규
+- `src/lib/vesting-events.ts` — `diffDaysKST` 헬퍼 export (현재 VestingList 내부에만 있음)
+
+## 5. 테스트 계획
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 단위 테스트 (`src/lib/__tests__/vesting-events.test.ts`):
+  - YTD 완료 카운트 (다른 연도 제외 확인)
+  - 만료 임박 (D-90 경계 + remainingShares=0 제외)
+- 수동: `/vesting` 페이지 — 모바일/데스크탑, 다가오는 90일 변동 시 분포 카드 갱신
+
+## 6. 제외 사항
+
+- light/dark 토글 (개선 2 별도 PR)
+- 옵션 만료를 별도 VestingEvent 로 캘린더 셀에 표시 (별도 phase)
+- 24-D vest_rsu (별도)

--- a/src/app/vesting/page.tsx
+++ b/src/app/vesting/page.tsx
@@ -41,15 +41,14 @@ export default async function VestingPage() {
       e.date.startsWith(currentYear),
   ).length
 
-  // 만료 임박: 옵션 expiryDate D-90 이내 + remainingShares > 0 (행사 기회 임박)
-  // 이미 만료 + 잔여수량 있으면 "기회 영구 손실" → 함께 sub 로 노출
+  // 만료 임박: 옵션 expiryDate D-90 이내 (오늘 포함) + remainingShares > 0 (행사 기회 임박).
+  // 이미 만료된 옵션은 cron 이 vesting.status='expired' 만 처리하고 StockOption.remainingShares 는
+  // 차감하지 않아 매년 누적되는 잘못된 메트릭이 됨 → 본 카드에서는 제외하고 임박만 표기.
   let expiringSoonCount = 0
-  let expiredLostCount = 0
   for (const opt of options) {
     if (opt.remainingShares <= 0) continue
     const days = diffDaysKST(toKSTDateString(opt.expiryDate), todayMs)
-    if (days < 0) expiredLostCount += 1
-    else if (days <= EXPIRING_SOON_DAYS) expiringSoonCount += 1
+    if (days >= 0 && days <= EXPIRING_SOON_DAYS) expiringSoonCount += 1
   }
 
   const summaryCards: Array<{ label: string; value: string; sub?: string; color?: string }> = [
@@ -59,9 +58,7 @@ export default async function VestingPage() {
     {
       label: '만료 임박',
       value: `${expiringSoonCount}건`,
-      sub: expiredLostCount > 0
-        ? `${EXPIRING_SOON_DAYS}일 이내 · 기회 손실 ${expiredLostCount}건`
-        : `${EXPIRING_SOON_DAYS}일 이내`,
+      sub: `${EXPIRING_SOON_DAYS}일 이내`,
       color: 'text-amber-400',
     },
   ]

--- a/src/app/vesting/page.tsx
+++ b/src/app/vesting/page.tsx
@@ -2,12 +2,14 @@ import { prisma } from '@/lib/prisma'
 import Header from '@/components/layout/Header'
 import VestingCalendar from '@/components/vesting/VestingCalendar'
 import VestingList from '@/components/vesting/VestingList'
+import VestingDistribution from '@/components/vesting/VestingDistribution'
 import Disclaimer from '@/components/ui/Disclaimer'
-import { toVestingEvents, toKSTDateString, upcomingEvents } from '@/lib/vesting-events'
+import { toVestingEvents, toKSTDateString, upcomingEvents, diffDaysKST } from '@/lib/vesting-events'
 
 export const dynamic = 'force-dynamic'
 
 const UPCOMING_DAYS = 90
+const EXPIRING_SOON_DAYS = 90
 
 export default async function VestingPage() {
   const [rsus, options] = await Promise.all([
@@ -28,19 +30,40 @@ export default async function VestingPage() {
   const todayMs = Date.now()
   const todayKey = toKSTDateString(new Date(todayMs))
   const thisMonthPrefix = todayKey.slice(0, 7)
+  const currentYear = todayKey.slice(0, 4)
 
   const thisMonthCount = events.filter((e) => e.date.startsWith(thisMonthPrefix)).length
   const upcomingCount = upcomingEvents(events, UPCOMING_DAYS, todayMs).length
-  const completedCount = events.filter(
-    (e) => e.status === 'vested' || e.status === 'exercised',
+  // YTD: 올해 완료된 베스팅만 (전체 누적 X)
+  const ytdCompletedCount = events.filter(
+    (e) =>
+      (e.status === 'vested' || e.status === 'exercised') &&
+      e.date.startsWith(currentYear),
   ).length
-  const expiringCount = events.filter((e) => e.status === 'expired').length
+
+  // 만료 임박: 옵션 expiryDate D-90 이내 + remainingShares > 0 (행사 기회 임박)
+  // 이미 만료 + 잔여수량 있으면 "기회 영구 손실" → 함께 sub 로 노출
+  let expiringSoonCount = 0
+  let expiredLostCount = 0
+  for (const opt of options) {
+    if (opt.remainingShares <= 0) continue
+    const days = diffDaysKST(toKSTDateString(opt.expiryDate), todayMs)
+    if (days < 0) expiredLostCount += 1
+    else if (days <= EXPIRING_SOON_DAYS) expiringSoonCount += 1
+  }
 
   const summaryCards: Array<{ label: string; value: string; sub?: string; color?: string }> = [
     { label: '이번 달 이벤트', value: `${thisMonthCount}건` },
     { label: '다가오는 이벤트', value: `${upcomingCount}건`, sub: `${UPCOMING_DAYS}일 이내` },
-    { label: '완료 이벤트', value: `${completedCount}건`, color: 'text-sejin' },
-    { label: '만료', value: `${expiringCount}건`, color: 'text-amber-400' },
+    { label: `${currentYear} 완료`, value: `${ytdCompletedCount}건`, color: 'text-sejin' },
+    {
+      label: '만료 임박',
+      value: `${expiringSoonCount}건`,
+      sub: expiredLostCount > 0
+        ? `${EXPIRING_SOON_DAYS}일 이내 · 기회 손실 ${expiredLostCount}건`
+        : `${EXPIRING_SOON_DAYS}일 이내`,
+      color: 'text-amber-400',
+    },
   ]
 
   return (
@@ -74,9 +97,12 @@ export default async function VestingPage() {
 
       <section className="grid grid-cols-1 lg:grid-cols-[1.4fr,1fr] gap-4">
         <VestingList events={events} todayMs={todayMs} days={UPCOMING_DAYS} />
-        <Disclaimer>
-          베스팅 정보는 입력 데이터 기반 예측이며, 실제 행사 가능일은 회사 정책에 따라 달라질 수 있습니다.
-        </Disclaimer>
+        <div className="flex flex-col gap-4">
+          <VestingDistribution events={events} todayMs={todayMs} days={UPCOMING_DAYS} />
+          <Disclaimer>
+            베스팅 정보는 입력 데이터 기반 예측이며, 실제 행사 가능일은 회사 정책에 따라 달라질 수 있습니다.
+          </Disclaimer>
+        </div>
       </section>
     </div>
   )

--- a/src/components/vesting/VestingDistribution.tsx
+++ b/src/components/vesting/VestingDistribution.tsx
@@ -1,0 +1,105 @@
+import { upcomingEvents, type VestingEvent } from '@/lib/vesting-events'
+
+interface Props {
+  events: VestingEvent[]
+  todayMs: number
+  days: number
+}
+
+interface Row {
+  accountName: string
+  rsuShares: number
+  optShares: number
+  totalShares: number
+}
+
+const ACCOUNT_COLOR: Record<string, string> = {
+  세진: 'bg-sejin',
+  소담: 'bg-sodam',
+  다솜: 'bg-dasom',
+}
+const FALLBACK_COLOR = 'bg-sub'
+
+function buildRows(events: VestingEvent[]): Row[] {
+  const map = new Map<string, Row>()
+  for (const ev of events) {
+    const cur = map.get(ev.accountName) ?? {
+      accountName: ev.accountName,
+      rsuShares: 0,
+      optShares: 0,
+      totalShares: 0,
+    }
+    if (ev.type === 'RSU') cur.rsuShares += ev.shares
+    else cur.optShares += ev.shares
+    cur.totalShares = cur.rsuShares + cur.optShares
+    map.set(ev.accountName, cur)
+  }
+  return Array.from(map.values()).sort((a, b) => b.totalShares - a.totalShares)
+}
+
+function formatShares(n: number): string {
+  return n.toLocaleString('ko-KR')
+}
+
+export default function VestingDistribution({ events, todayMs, days }: Props) {
+  const upcoming = upcomingEvents(events, days, todayMs)
+  const rows = buildRows(upcoming)
+  const grandTotal = rows.reduce((s, r) => s + r.totalShares, 0)
+
+  return (
+    <div className="bg-card border border-border rounded-2xl overflow-hidden">
+      <div className="px-5 py-4 flex items-center justify-between border-b border-border">
+        <h3 className="text-[14px] font-bold text-bright">계좌별 분포</h3>
+        <span className="text-[11px] text-sub tabular-nums">
+          {days}일 이내 · {formatShares(grandTotal)}주
+        </span>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-5 py-10 text-center text-[12px] text-dim">다가오는 베스팅이 없습니다.</p>
+      ) : (
+        <ul className="flex flex-col gap-3 px-5 py-4">
+          {rows.map((row) => {
+            const accent = ACCOUNT_COLOR[row.accountName] ?? FALLBACK_COLOR
+            const pct = grandTotal > 0 ? (row.totalShares / grandTotal) * 100 : 0
+            const rsuPct = row.totalShares > 0 ? (row.rsuShares / row.totalShares) * 100 : 0
+            return (
+              <li key={row.accountName} className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between text-[12px]">
+                  <span className="flex items-center gap-1.5">
+                    <span className={`w-2 h-2 rounded-full ${accent}`} />
+                    <span className="font-semibold text-bright">{row.accountName}</span>
+                  </span>
+                  <span className="tabular-nums text-sub">
+                    {formatShares(row.totalShares)}주
+                    <span className="text-dim ml-1.5">· {pct.toFixed(0)}%</span>
+                  </span>
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-surface overflow-hidden flex">
+                  {row.rsuShares > 0 && (
+                    <span
+                      className="bg-sejin h-full"
+                      style={{ width: `${rsuPct}%` }}
+                      title={`RSU ${formatShares(row.rsuShares)}주`}
+                    />
+                  )}
+                  {row.optShares > 0 && (
+                    <span
+                      className="bg-sodam h-full"
+                      style={{ width: `${100 - rsuPct}%` }}
+                      title={`스톡옵션 ${formatShares(row.optShares)}주`}
+                    />
+                  )}
+                </div>
+                <div className="flex items-center justify-between text-[10px] text-dim tabular-nums">
+                  <span>RSU {formatShares(row.rsuShares)}주</span>
+                  <span>스톡옵션 {formatShares(row.optShares)}주</span>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/vesting/VestingList.tsx
+++ b/src/components/vesting/VestingList.tsx
@@ -1,20 +1,11 @@
 import Link from 'next/link'
 import { formatKRW } from '@/lib/format'
-import { toKSTDateString, upcomingEvents, type VestingEvent } from '@/lib/vesting-events'
+import { diffDaysKST, upcomingEvents, type VestingEvent } from '@/lib/vesting-events'
 
 interface Props {
   events: VestingEvent[]
   todayMs: number
   days: number
-}
-
-function diffDaysKST(dateKey: string, todayMs: number): number {
-  const todayKey = toKSTDateString(new Date(todayMs))
-  const [ty, tm, td] = todayKey.split('-').map(Number)
-  const [ey, em, ed] = dateKey.split('-').map(Number)
-  const todayUtc = Date.UTC(ty, tm - 1, td)
-  const evUtc = Date.UTC(ey, em - 1, ed)
-  return Math.round((evUtc - todayUtc) / 86400000)
 }
 
 function formatDateLabel(dateKey: string): string {

--- a/src/lib/__tests__/vesting-events.test.ts
+++ b/src/lib/__tests__/vesting-events.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildMonthGrid,
+  diffDaysKST,
   groupEventsByDate,
   toKSTDateString,
   toVestingEvents,
@@ -146,5 +147,31 @@ describe('buildMonthGrid', () => {
     const cells = buildMonthGrid(2026, 5)
     const june1 = cells.find((d) => d.getMonth() === 5 && d.getDate() === 1)
     expect(june1).toBeDefined()
+  })
+})
+
+describe('diffDaysKST', () => {
+  // 2026-06-15 03:00 UTC = 2026-06-15 12:00 KST
+  const nowMs = Date.parse('2026-06-15T03:00:00Z')
+
+  it('오늘 → 0', () => {
+    expect(diffDaysKST('2026-06-15', nowMs)).toBe(0)
+  })
+
+  it('내일 → 1', () => {
+    expect(diffDaysKST('2026-06-16', nowMs)).toBe(1)
+  })
+
+  it('어제 → -1', () => {
+    expect(diffDaysKST('2026-06-14', nowMs)).toBe(-1)
+  })
+
+  it('90일 후', () => {
+    expect(diffDaysKST('2026-09-13', nowMs)).toBe(90)
+  })
+
+  it('월 경계 이동 (5월 → 7월)', () => {
+    expect(diffDaysKST('2026-07-15', nowMs)).toBe(30)
+    expect(diffDaysKST('2026-05-15', nowMs)).toBe(-31)
   })
 })

--- a/src/lib/vesting-events.ts
+++ b/src/lib/vesting-events.ts
@@ -63,6 +63,21 @@ export function toKSTDateString(input: Date | string): string {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
 }
 
+/**
+ * KST 캘린더 기준 두 날짜 사이 일수 차 (target - today).
+ * - 양수: target 가 미래 (예: 3 = 3일 후)
+ * - 0: 오늘
+ * - 음수: target 가 과거 (예: -1 = 어제)
+ */
+export function diffDaysKST(targetKey: string, nowMs: number): number {
+  const todayKey = toKSTDateString(new Date(nowMs))
+  const [ty, tm, td] = todayKey.split('-').map(Number)
+  const [ey, em, ed] = targetKey.split('-').map(Number)
+  const todayUtc = Date.UTC(ty, tm - 1, td)
+  const targetUtc = Date.UTC(ey, em - 1, ed)
+  return Math.round((targetUtc - todayUtc) / 86400000)
+}
+
 function normalizeRsuStatus(raw: string): VestingEventStatus {
   if (raw === 'vested') return 'vested'
   return 'pending'


### PR DESCRIPTION
## 요약

`/vesting` 페이지의 요약 strip 4 카드 + 하단 영역을 design-notes 의도에 맞게 갱신.

## 변경

### 요약 카드 (4개)
| | before | after |
|---|---|---|
| 3번째 | "완료" (전체 누적) | **"{year} 완료"** — YTD 만 카운트 (over-counting 제거) |
| 4번째 | "만료" (이미 만료) | **"만료 임박"** — 옵션 expiryDate D-90 이내 + remainingShares>0 (행사 기회 임박) |

### 신규 컴포넌트
- `src/components/vesting/VestingDistribution.tsx` — 다가오는 90일 events 를 계좌별로 group + RSU/스톡옵션 stacked bar (세진/소담/다솜 컬러)

### 리팩터
- `diffDaysKST(targetKey, nowMs)` 헬퍼를 `src/lib/vesting-events.ts` 로 이관 (VestingList 의 로컬 함수 → 공용)

### 테스트
- 162 → **167** tests (diffDaysKST 5 케이스: 오늘/내일/어제/D-90/월 경계)

## 체크리스트

- [x] 린트 / 타입체크 / 167 tests / 빌드 통과
- [x] 코드 리뷰 — P1×1 (기회 손실 카운트 cron 가정 문제) → 같은 PR 에서 제거. 최종 P0/P1/P2 = 0

## 리뷰에서 발견되어 의도적으로 제거된 항목

"기회 손실" 카운트 (만료 + remainingShares>0) 는 cron 이 `vesting.status='expired'` 만 처리하고 `StockOption.remainingShares` 는 차감하지 않아 매년 누적되는 잘못된 메트릭이 됨 → 강조 노출하면 사용자 오해. 근본 해결 (cron 에서 remainingShares 차감) 은 별도 phase 로 분리.

Closes #359