### PR TITLE
[enhancement] 베스팅 캘린더 light/dark 토글 + contrast 보강 (#363)

### DIFF
--- a/docs/specs/363-vesting-theme-toggle.md
+++ b/docs/specs/363-vesting-theme-toggle.md
@@ -1,0 +1,46 @@
+# 베스팅 캘린더 light/dark 토글 + 컬러 contrast 보강
+
+- **작성일**: 2026-06-30
+- **타입**: enhancement (P2)
+- **참조**: `docs/designs/307-vesting-calendar/design-notes.md` 의 "light/dark 토글" 항목
+
+## 1. 배경
+
+design-notes 명시:
+- 다크 기본 + light 토글 즉시 반영
+- 헤더에 테마 토글
+- Tailwind utility (amber-50 등) 도 `dark:` prefix 또는 CSS 변수 mix
+
+진단:
+- next-themes + ThemeProvider + ThemeToggle 인프라는 **이미 존재** (사이드바 + 모바일 BottomTab 등록)
+- 베스팅 캘린더 페이지의 일부 색상은 **다크 고정 가정** — light 모드에서 contrast 약함:
+  - `text-red-400/80` (일요일 헤더) — light 에서 옅음
+  - `text-red-400` (일요일 셀) — light 에서 옅음
+  - `bg-amber-500/10 ring-amber-500/40` (오늘 셀) — light bg 위에서 살짝 약함
+  - `text-amber-400` (만료 임박 카드) — light 에서 옅음
+
+## 2. 요구사항
+
+- [ ] **R1**: 베스팅 캘린더 Header 에도 `ThemeToggle` 추가 (design-notes "헤더 토글" 의도, 이미 사이드바에 있지만 페이지에서도 한 번 더)
+- [ ] **R2**: 다크 고정 색상 4 곳에 `dark:` variant 추가 — light 모드에서 진한 shade 사용
+
+## 3. 변경
+
+### `src/app/vesting/page.tsx`
+- `ThemeToggle` import + Header children 에 추가 (캘린더 내보내기 버튼 옆)
+- 만료 임박 카드 컬러: `text-amber-400` → `text-amber-600 dark:text-amber-400`
+
+### `src/components/vesting/VestingCalendar.tsx`
+- 일요일 헤더: `text-red-400/80` → `text-red-500/80 dark:text-red-400/80`
+- 일요일 셀: `text-red-400` → `text-red-500 dark:text-red-400`
+- 오늘 셀: `bg-amber-500/10 ring-amber-500/40` → `bg-amber-500/10 dark:bg-amber-500/15 ring-amber-500/50 dark:ring-amber-500/40`
+
+## 4. 검증
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동: `/vesting` 페이지 다크/라이트 토글 → 색상 contrast 자연스러운지
+
+## 5. 제외 사항
+
+- 다른 페이지 light 색상 검수 — 별도 phase
+- next-themes 인프라 자체 (이미 존재)

--- a/src/app/vesting/page.tsx
+++ b/src/app/vesting/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import Header from '@/components/layout/Header'
+import ThemeToggle from '@/components/theme/ThemeToggle'
 import VestingCalendar from '@/components/vesting/VestingCalendar'
 import VestingList from '@/components/vesting/VestingList'
 import VestingDistribution from '@/components/vesting/VestingDistribution'
@@ -59,20 +60,23 @@ export default async function VestingPage() {
       label: '만료 임박',
       value: `${expiringSoonCount}건`,
       sub: `${EXPIRING_SOON_DAYS}일 이내`,
-      color: 'text-amber-400',
+      color: 'text-amber-600 dark:text-amber-400',
     },
   ]
 
   return (
     <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[1080px] flex flex-col gap-6">
       <Header title="베스팅 캘린더">
-        <a
-          href="/api/exports/vesting.ics"
-          download="vesting.ics"
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-semibold text-sub border border-border hover:bg-surface hover:text-bright transition-colors"
-        >
-          📅 캘린더 내보내기
-        </a>
+        <div className="flex items-center gap-1.5">
+          <a
+            href="/api/exports/vesting.ics"
+            download="vesting.ics"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-semibold text-sub border border-border hover:bg-surface hover:text-bright transition-colors"
+          >
+            📅 캘린더 내보내기
+          </a>
+          <ThemeToggle />
+        </div>
       </Header>
 
       <section className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/components/vesting/VestingCalendar.tsx
+++ b/src/components/vesting/VestingCalendar.tsx
@@ -80,7 +80,7 @@ export default function VestingCalendar({ events, todayMs }: Props) {
 
       <div className="grid grid-cols-7 px-2 pt-3 pb-2 text-[10px] font-bold text-dim tracking-[1.2px] uppercase">
         {WEEKDAYS.map((d, i) => (
-          <div key={d} className={`px-3 ${i === 0 ? 'text-red-400/80' : ''}`}>
+          <div key={d} className={`px-3 ${i === 0 ? 'text-red-500/80 dark:text-red-400/80' : ''}`}>
             {d}
           </div>
         ))}
@@ -94,11 +94,13 @@ export default function VestingCalendar({ events, todayMs }: Props) {
           const dayEvents = byDate.get(key) ?? []
           const dow = d.getDay()
 
-          const dayColor = dow === 0 ? 'text-red-400' : otherMonth ? 'text-dim' : 'text-sub'
+          const dayColor = dow === 0
+            ? 'text-red-500 dark:text-red-400'
+            : otherMonth ? 'text-dim' : 'text-sub'
           const cellClass = [
             'rounded-lg px-2.5 py-2 min-h-[88px] sm:min-h-[104px] flex flex-col gap-1.5 transition-colors',
             otherMonth ? 'opacity-40' : 'hover:bg-surface',
-            isToday ? 'bg-amber-500/10 ring-1 ring-inset ring-amber-500/40' : '',
+            isToday ? 'bg-amber-500/10 dark:bg-amber-500/15 ring-1 ring-inset ring-amber-500/50 dark:ring-amber-500/40' : '',
           ].filter(Boolean).join(' ')
 
           return (


### PR DESCRIPTION
## 요약

베스팅 캘린더의 light/dark 토글 마무리. 인프라는 이미 있어서 작은 보강:

- `/vesting` Header 에 `ThemeToggle` 추가 (design-notes "헤더 토글" 의도, 사이드바 토글 외에 페이지에서도 한 번 더 노출)
- 다크 가정 색상 4곳에 `dark:` variant 추가 — light 모드에서 contrast 자연스럽게

## 변경

| 위치 | before | after |
|---|---|---|
| 만료 임박 카드 | `text-amber-400` | `text-amber-600 dark:text-amber-400` |
| 일요일 헤더 | `text-red-400/80` | `text-red-500/80 dark:text-red-400/80` |
| 일요일 셀 | `text-red-400` | `text-red-500 dark:text-red-400` |
| 오늘 셀 | `bg-amber-500/10 ring-amber-500/40` | `bg-amber-500/10 dark:bg-amber-500/15 ring-amber-500/50 dark:ring-amber-500/40` |

## 체크리스트

- [x] 린트 / 타입체크 / 167 tests / 빌드 ✅
- [x] 인프라 (next-themes + ThemeProvider + ThemeToggle) 이미 존재 — 활용만

Closes #363