### PR TITLE
[ci] 운영 배포 자동화 — GitHub Actions on Release publish (#366)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,122 @@
+name: Deploy on Release
+
+# 운영 배포 자동화 — GitHub Release publish 시 운영 서버에서 deploy.sh 실행.
+# 매 릴리즈마다 사용자가 ssh + git pull + npm run build + pm2 restart 수동 진행
+# 누락 → 코드/dist 불일치 → 운영 장애 위험. myFitness #137 패턴 그대로 이식.
+# 스펙: docs/specs/366-deploy-automation.md
+# 트리거: release.published (자동), workflow_dispatch (수동 재실행, inputs.tag 필요).
+
+on:
+  release:
+    types: [published]
+  # 진단/수동 재실행 트리거 — GitHub release event 가 어떤 이유로 발동 안 했을 때
+  # Actions UI 의 "Run workflow" 로 수동 실행. tag 입력 (예: v0.8.3) 지정.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy (예: v0.8.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# 동일 릴리즈/재시도가 겹치면 동일 worktree(node_modules/dist/pm2)에서 deploy.sh 가
+# 동시 실행되어 빌드 손상/PM2 race 위험. 직렬화로 차단. 진행 중 새 release publish 시
+# 새 deploy는 큐잉되어 이전 완료 후 시작.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: SSH Deploy
+    runs-on: ubuntu-latest
+    # 정식 릴리즈(prerelease/draft 아님) 만 운영 배포.
+    # draft 는 publish 이벤트 자체가 안 뜨지만 명시적 가드.
+    # workflow_dispatch 는 항상 통과 (운영자가 의도적으로 트리거).
+    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    steps:
+      # Fingerprint secret 누락/typo 시 ssh-action 이 빈 문자열로 진행 → InsecureIgnoreHostKey
+      # default → MITM 재개. 사전 검증으로 차단.
+      - name: Preflight — require host fingerprint
+        env:
+          DEPLOY_SSH_FINGERPRINT: ${{ secrets.DEPLOY_SSH_FINGERPRINT }}
+        run: |
+          if [[ -z "$DEPLOY_SSH_FINGERPRINT" ]]; then
+            echo "ERROR: DEPLOY_SSH_FINGERPRINT secret is empty. SSH MITM 위험 → 배포 중단." >&2
+            echo "운영자: 스펙 docs/specs/366-deploy-automation.md §3.3 의 ssh-keygen -lf 명령으로 추출 후 GitHub Secrets 등록." >&2
+            exit 1
+          fi
+          echo "Fingerprint secret present (length=${#DEPLOY_SSH_FINGERPRINT})"
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.2
+        env:
+          # release event 면 release.tag_name, workflow_dispatch 면 inputs.tag.
+          # 직접 script에 expand 시 shell injection 위험 → env var + 형식 검증.
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT }}
+          # SSH host fingerprint 검증 — 미설정 시 InsecureIgnoreHostKey() default → MITM 위험.
+          # secret 등록 방법은 스펙 §3.3 참조 (ssh-keyscan + ssh-keygen -lf).
+          fingerprint: ${{ secrets.DEPLOY_SSH_FINGERPRINT }}
+          envs: RELEASE_TAG,DEPLOY_PATH
+          # 30분 timeout (npm ci + build + pm2 restart 충분)
+          command_timeout: 30m
+          script: |
+            set -euo pipefail
+            # 태그 형식 검증 (semver: vMAJOR.MINOR.PATCH[-suffix])
+            if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+              echo "ERROR: Invalid tag format: $RELEASE_TAG" >&2
+              exit 1
+            fi
+            cd "$DEPLOY_PATH"
+            ./deploy/deploy.sh "$RELEASE_TAG"
+
+      # 배포 결과 텔레그램 알림 — myfinance-bot 인프라 재활용. raw curl 로 third-party action 의존 X.
+      # 토큰은 GitHub Actions가 자동 마스킹. 성공/실패 모두 알림 (무알림이 더 위험).
+      - name: Notify Telegram (success)
+        if: success()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "${TELEGRAM_BOT_TOKEN:-}" || -z "${TELEGRAM_CHAT_ID:-}" ]]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID secret 미설정 — 알림 skip"
+            exit 0
+          fi
+          # printf로 \n literal newline 처리 — multi-line YAML block scalar 들여쓰기 깨짐 회피.
+          text=$(printf '✅ <b>myFinance Deploy %s</b> 성공\n서버: production\n워크플로우: %s' "$RELEASE_TAG" "$RUN_URL")
+          curl -sS -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "parse_mode=HTML" \
+            --data-urlencode "text=$text" \
+            -o /dev/null
+
+      - name: Notify Telegram (failure)
+        if: failure()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [[ -z "${TELEGRAM_BOT_TOKEN:-}" || -z "${TELEGRAM_CHAT_ID:-}" ]]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID secret 미설정 — 알림 skip"
+            exit 0
+          fi
+          text=$(printf '❌ <b>myFinance Deploy %s</b> 실패\n워크플로우 로그: %s' "${RELEASE_TAG:-unknown}" "$RUN_URL")
+          curl -sS -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "parse_mode=HTML" \
+            --data-urlencode "text=$text" \
+            -o /dev/null

--- a/docs/specs/366-deploy-automation.md
+++ b/docs/specs/366-deploy-automation.md
@@ -1,0 +1,86 @@
+# 운영 배포 자동화 — GitHub Actions
+
+- **작성일**: 2026-06-30
+- **타입**: enhancement / 운영 (P2)
+- **참조**: `fomalhaut84/myFitness#137` deploy.yml (같은 서버, 동일 패턴 이식)
+
+## 1. 배경
+
+현재 매 릴리즈마다 사용자가 직접:
+```bash
+ssh server
+cd /home/nasty68/myFinance
+./deploy/deploy.sh <tag>
+pm2 restart myfinance myfinance-bot
+```
+
+수동 진행 → 누락 위험 + 시간 소비. myFitness 에서 같은 문제로 자동화 했고 (#137, v2.2.12 부터 적용), 동일 서버라 동일 패턴 이식 가능.
+
+## 2. 요구사항
+
+- [ ] **F1**: `release.published` 이벤트 자동 트리거. prerelease/draft 제외.
+- [ ] **F2**: `workflow_dispatch` 수동 트리거 (tag 입력) — 운영자가 재실행 가능.
+- [ ] **F3**: 운영 서버 SSH → `./deploy/deploy.sh <tag>` 실행.
+- [ ] **F4**: SSH host fingerprint 검증 (MITM 방지). 누락 시 배포 중단 (preflight).
+- [ ] **F5**: tag 형식 검증 (`v\d+\.\d+\.\d+(-suffix)?`) — shell injection 차단.
+- [ ] **F6**: 동시 배포 차단 (`concurrency: deploy-production`).
+- [ ] **F7**: 배포 결과 텔레그램 알림 (성공/실패).
+
+## 3. 기술 설계
+
+### 3.1 `.github/workflows/deploy.yml` 신규
+
+myFitness #137 와 100% 동일 구조 (workflow 이름/도메인 라벨만 수정).
+
+핵심 단계:
+1. **Preflight**: `DEPLOY_SSH_FINGERPRINT` secret 존재 확인 (없으면 fail).
+2. **Deploy via SSH** (`appleboy/ssh-action@v1.2.2`):
+   - `host`, `username`, `key`, `port`, `fingerprint` secret 사용.
+   - 30분 timeout.
+   - 운영 서버 script: tag 형식 검증 → `cd $DEPLOY_PATH && ./deploy/deploy.sh $RELEASE_TAG`.
+3. **Telegram 알림** (성공/실패 각각 step): raw curl, 토큰/chat_id secret.
+
+### 3.2 GitHub Secrets (사용자 등록 필요)
+
+운영 환경 정보. myFitness 와 동일 서버라면 같은 값 재사용 가능:
+
+| Secret | 설명 | 예시 |
+|---|---|---|
+| `DEPLOY_SSH_HOST` | 서버 IP/도메인 | `xxx.xxx.xxx.xxx` |
+| `DEPLOY_SSH_USER` | SSH 계정 | `nasty68` |
+| `DEPLOY_SSH_KEY` | private key (PEM) | `-----BEGIN OPENSSH PRIVATE KEY-----\n...` |
+| `DEPLOY_SSH_PORT` | SSH 포트 | `22` |
+| `DEPLOY_SSH_FINGERPRINT` | host fingerprint | `SHA256:...` |
+| `DEPLOY_PATH` | 서버의 myFinance 경로 | `/home/nasty68/myFinance` |
+| `TELEGRAM_BOT_TOKEN` | 봇 토큰 (알림용, 운영봇 재사용 가능) | `0123456789:AAA...` |
+| `TELEGRAM_CHAT_ID` | 알림 chat ID | `123456789` |
+
+### 3.3 host fingerprint 추출
+
+```bash
+# 운영 서버 OR 로컬 사용자 머신에서 (이미 known_hosts 에 있다면 사용 가능)
+ssh-keyscan -p <port> <host> > /tmp/host.pub
+ssh-keygen -lf /tmp/host.pub
+# → "SHA256:..." 부분만 secret 으로 등록
+```
+
+### 3.4 운영 서버 배포 흐름 (변경 없음)
+
+`./deploy/deploy.sh <tag>` 그대로 동작. tag 인자 받아서 checkout/pull/build/PM2 restart. 이미 호환.
+
+## 4. 검증
+
+- yml 문법: GitHub Actions 가 push 시점에 검증
+- 첫 배포: v0.8.3 또는 next release 시점에 실제 동작 확인
+- workflow_dispatch 수동 재실행으로 시험 (v0.8.2 재배포 등)
+
+## 5. 위험도
+
+- **낮음**: 워크플로우 파일 1개만 추가, 기존 배포 절차 (deploy.sh) 변경 없음
+- 처음 실행 시 secret 누락이면 preflight 에서 fail (서버 영향 없음)
+
+## 6. 사용자 액션 (머지 후)
+
+1. GitHub repo Settings → Secrets and variables → Actions 에 위 8개 secret 등록
+2. (선택) v0.8.3 release 만들어서 자동 트리거 확인. 또는 Actions UI 에서 workflow_dispatch 로 v0.8.2 재실행
+3. 텔레그램에 ✅/❌ 알림 도착 확인


### PR DESCRIPTION
## 요약

매 릴리즈 시 운영 서버에 ssh 들어가서 deploy.sh 수동 실행하는 부담 제거. `myFitness#137` 동일 패턴 이식.

## 변경

- `.github/workflows/deploy.yml` 신규
- `docs/specs/366-deploy-automation.md` 신규

## 동작

| 트리거 | 결과 |
|---|---|
| GitHub Release publish (정식, prerelease/draft 제외) | 자동 SSH 배포 |
| Actions UI "Run workflow" (tag 입력) | 수동 재실행 |

흐름:
1. Preflight: `DEPLOY_SSH_FINGERPRINT` 검증 (MITM 차단)
2. `appleboy/ssh-action` 으로 운영 서버 SSH
3. 운영 서버: tag 형식 검증 → `./deploy/deploy.sh <tag>` 실행
4. 텔레그램 알림 (성공/실패 each step)

## 보안 가드

- `DEPLOY_SSH_FINGERPRINT` 누락 시 InsecureIgnoreHostKey 회피 → preflight fail
- tag 형식 regex 검증 → shell injection 차단
- `concurrency: deploy-production` → 동시 빌드 방지
- 토큰/key 모두 GitHub Secrets, 자동 마스킹

## 머지 후 사용자 액션 (꼭 필요)

GitHub repo Settings → Secrets and variables → Actions 에 **8개 secret 등록**:

| Secret | 비고 |
|---|---|
| `DEPLOY_SSH_HOST` | 서버 IP/도메인 |
| `DEPLOY_SSH_USER` | 보통 `nasty68` |
| `DEPLOY_SSH_KEY` | private key (PEM) |
| `DEPLOY_SSH_PORT` | 보통 `22` |
| `DEPLOY_SSH_FINGERPRINT` | `ssh-keyscan -p <port> <host> \| ssh-keygen -lf -` 의 `SHA256:...` 부분 |
| `DEPLOY_PATH` | `/home/nasty68/myFinance` |
| `TELEGRAM_BOT_TOKEN` | myfinance-bot 토큰 재사용 가능 |
| `TELEGRAM_CHAT_ID` | 알림 받을 chat ID |

myFitness 와 같은 서버라면 SSH 관련 4개 (HOST/USER/KEY/PORT/FINGERPRINT) + DEPLOY_PATH 만 myFinance 경로로 바꿔 재사용. Telegram 은 봇 토큰만 다름.

## 검증

- YAML 문법 ✅ (`yaml.safe_load`)
- lint / typecheck / 167 tests / build 모두 통과 (워크플로우 추가만, 코드 변경 없음)
- 첫 실제 동작 검증: v0.8.3 release 시 자동 트리거 확인, 또는 workflow_dispatch 로 v0.8.2 재실행

## 위험도

낮음. `deploy.sh` 자체는 변경 없음, 워크플로우 파일만 추가. secret 누락이면 preflight 에서 fail (서버 영향 없음).

Closes #366