### PR TITLE
[fix] deploy.yml Codex 리뷰 P2×2 반영 (DEPLOY_PATH + telegram fail)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,13 +94,20 @@ jobs:
           fi
           # printf로 \n literal newline 처리 — multi-line YAML block scalar 들여쓰기 깨짐 회피.
           text=$(printf '✅ <b>myFinance Deploy %s</b> 성공\n서버: production\n워크플로우: %s' "$RELEASE_TAG" "$RUN_URL")
-          # --fail-with-body: HTTP 4xx/5xx 시 curl exit non-zero + body 출력.
-          # Telegram bad token/chat_id/parse 오류/rate limit 등 swallow 차단 → step fail 로 알림 누락 가시화.
-          curl -sS --fail-with-body -X POST \
+          # 성공 응답 body (sent message + chat metadata) 는 chat 정보 노출 위험 → /tmp 로 격리.
+          # 실패 (HTTP 4xx/5xx) 시에만 body 출력 + step fail (--fail-with-body).
+          body=$(mktemp)
+          if ! curl -sS --fail-with-body -o "$body" -X POST \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
             --data-urlencode "parse_mode=HTML" \
-            --data-urlencode "text=$text"
+            --data-urlencode "text=$text"; then
+            echo "::error::Telegram sendMessage failed"
+            cat "$body" >&2
+            rm -f "$body"
+            exit 1
+          fi
+          rm -f "$body"
 
       - name: Notify Telegram (failure)
         if: failure()
@@ -115,9 +122,16 @@ jobs:
             exit 0
           fi
           text=$(printf '❌ <b>myFinance Deploy %s</b> 실패\n워크플로우 로그: %s' "${RELEASE_TAG:-unknown}" "$RUN_URL")
-          # --fail-with-body: 실패 알림 자체가 또 실패해도 가시화 (잡음 알림은 swallow 보다 낫다).
-          curl -sS --fail-with-body -X POST \
+          # 실패 알림 자체가 또 실패해도 가시화. 성공 body 는 chat 정보 노출 위험 → /tmp 격리.
+          body=$(mktemp)
+          if ! curl -sS --fail-with-body -o "$body" -X POST \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
             --data-urlencode "parse_mode=HTML" \
-            --data-urlencode "text=$text"
+            --data-urlencode "text=$text"; then
+            echo "::error::Telegram failure notification itself failed"
+            cat "$body" >&2
+            rm -f "$body"
+            exit 1
+          fi
+          rm -f "$body"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,12 +94,13 @@ jobs:
           fi
           # printf로 \n literal newline 처리 — multi-line YAML block scalar 들여쓰기 깨짐 회피.
           text=$(printf '✅ <b>myFinance Deploy %s</b> 성공\n서버: production\n워크플로우: %s' "$RELEASE_TAG" "$RUN_URL")
-          curl -sS -X POST \
+          # --fail-with-body: HTTP 4xx/5xx 시 curl exit non-zero + body 출력.
+          # Telegram bad token/chat_id/parse 오류/rate limit 등 swallow 차단 → step fail 로 알림 누락 가시화.
+          curl -sS --fail-with-body -X POST \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
             --data-urlencode "parse_mode=HTML" \
-            --data-urlencode "text=$text" \
-            -o /dev/null
+            --data-urlencode "text=$text"
 
       - name: Notify Telegram (failure)
         if: failure()
@@ -114,9 +115,9 @@ jobs:
             exit 0
           fi
           text=$(printf '❌ <b>myFinance Deploy %s</b> 실패\n워크플로우 로그: %s' "${RELEASE_TAG:-unknown}" "$RUN_URL")
-          curl -sS -X POST \
+          # --fail-with-body: 실패 알림 자체가 또 실패해도 가시화 (잡음 알림은 swallow 보다 낫다).
+          curl -sS --fail-with-body -X POST \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
             --data-urlencode "parse_mode=HTML" \
-            --data-urlencode "text=$text" \
-            -o /dev/null
+            --data-urlencode "text=$text"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -4,10 +4,16 @@
 # 예시: ./deploy/deploy.sh main
 #       ./deploy/deploy.sh v0.1.0
 #       ./deploy/deploy.sh dev
+#
+# 호출 시 cwd 자동 처리:
+# - cwd 가 myFinance 루트면 그대로 (deploy.sh 가 직접 호출됨)
+# - 그 외엔 스크립트 위치 기준 상위 디렉토리 (CI workflow 에서 임의 cwd 호출 호환)
 set -e
 
 TARGET="${1:-main}"
-cd /home/nasty68/myFinance
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+cd "$REPO_ROOT"
 
 echo "=== 1. Fetch latest ==="
 git fetch origin --tags

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -4,7 +4,7 @@ module.exports = {
       name: 'myfinance',
       script: 'node_modules/.bin/next',
       args: 'start -p 4100',
-      cwd: '/home/nasty68/myFinance',
+      cwd: __dirname,
       env: {
         NODE_ENV: 'production',
         PORT: 4100,
@@ -18,7 +18,7 @@ module.exports = {
     {
       name: 'myfinance-bot',
       script: 'dist/bot/standalone.cjs',
-      cwd: '/home/nasty68/myFinance',
+      cwd: __dirname,
       env: {
         NODE_ENV: 'production',
       },


### PR DESCRIPTION
## 요약

PR #368 의 Codex 리뷰 P2 두 건. **PR #368 이 머지되기 전에 먼저 dev 에 들어가야** 자동 배포 첫 동작 시 정상 작동.

## 변경

### P2-1: `DEPLOY_PATH` 무효 fix
`deploy/deploy.sh` 가 hardcoded `cd /home/nasty68/myFinance` → workflow 의 `cd "$DEPLOY_PATH"` 가 사실상 무효.

수정: `deploy.sh` 가 자기 스크립트 위치 기준 (`BASH_SOURCE/..`) repo root 자동 resolve.
- 임의 cwd 호출 호환 (CI 에서 `cd $DEPLOY_PATH && ./deploy/deploy.sh ...`)
- 향후 같은 서버에 다른 경로 배포 옵션도 secret 만 바꾸면 됨

### P2-2: 텔레그램 알림 swallow fix
`curl -sS` 는 HTTP 4xx/5xx 도 exit 0 → bad token / chat_id 오류 / rate limit 발생 시 step 은 green 인데 알림은 안 옴.

수정: `--fail-with-body` 추가. step fail 로 알림 누락 가시화.

## 머지 후

PR #368 (dev → main) 머지 → workflow_dispatch 로 v0.8.2 검증.