### PR TITLE
[Phase 29-B v1] long_hold 매수 기회 + 관심종목 long_hold 지원 (#373)

### DIFF
--- a/docs/specs/373-strategy-alert-gap.md
+++ b/docs/specs/373-strategy-alert-gap.md
@@ -1,0 +1,49 @@
+# [Phase 29-B v1] 전략별 알림 gap fix — long_hold 매수 기회 + 관심종목 long_hold 지원
+
+- **작성일**: 2026-07-01
+- **타입**: enhancement (P2)
+- **참조**: 마스터 이슈 #370, 이슈 #230 (2)
+
+## 1. 배경
+
+Phase 29-B/C 는 사실상 `ta-signal-alert.ts` 에서 이미 대부분 구현되어 있음 (전략별 시그널 규칙, AI 가이드 첨부 등).
+
+**남은 gap 2개**:
+1. `long_hold` 전략 시그널이 `STRONG_SELL` (매도) 만 있음 — 급락/저평가 시 "매수 기회" 알림 없음
+2. 관심종목에 `long_hold` 전략 등록 불가
+   - 봇: `STRATEGY_LABELS` / `STRATEGY_ALIASES` 에 없음
+   - 웹: `validStrategies` 배열에 없음
+   - `ta-signal-alert.ts:121` 관심종목 대상에 `long_hold` 제외
+
+## 2. 변경
+
+### 2.1 봇 `src/bot/commands/watchlist.ts`
+- `STRATEGY_LABELS` 에 `long_hold: '💎 장기보유'` 추가
+- `STRATEGY_ALIASES` 에 `'장기': 'long_hold'`, `'장기보유': 'long_hold'` 추가
+
+### 2.2 웹 `src/app/api/watchlist/route.ts`
+- `validStrategies` 배열에 `'long_hold'` 추가
+
+### 2.3 `src/bot/notifications/ta-signal-alert.ts`
+- line 121: 관심종목 `strategy: { in: [...] }` 에 `'long_hold'` 추가
+- `checkSignals` 의 `long_hold` case 에 `STRONG_BUY` 시그널 추가:
+  ```ts
+  if (report.signalSummary.overall === 'STRONG_BUY') {
+    signals.push({
+      id: 'STRONG_BUY',
+      message: `💰 종합 STRONG_BUY — ${report.signalSummary.reasons.slice(0, 2).join(', ')} — 추가 매수 기회`
+    })
+  }
+  ```
+
+## 3. 테스트
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build`
+- 수동:
+  - 봇 `관심 SOXL 장기보유` 명령 → long_hold 로 저장 확인
+  - `holdingStrategy.strategy = 'long_hold'` 인 보유 종목 중 STRONG_BUY 상황이면 매수 기회 알림 도착
+
+## 4. 제외
+
+- 새 알림 트리거 규칙 (예: -5% 하락 시 매수 기회) — TA 시그널 프레임워크로 이미 커버됨 (STRONG_BUY = 지지선 근접 + RSI 과매도 등 종합 판단)
+- Phase 29-D (능동 AI cron) — 별도 PR

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -372,7 +372,7 @@ model Watchlist {
   ticker      String   @unique
   displayName String
   market      String             // "US", "KR"
-  strategy    String   @default("swing") // swing, momentum, value, scalp
+  strategy    String   @default("swing") // long_hold, swing, momentum, value, scalp
   memo        String?
   targetBuy   Float?             // 목표 매수가
   entryLow    Float?             // 매수 구간 하한

--- a/src/app/api/watchlist/[id]/route.ts
+++ b/src/app/api/watchlist/[id]/route.ts
@@ -28,7 +28,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       data.market = body.market.trim()
     }
     if (typeof body.strategy === 'string') {
-      const validStrategies = ['swing', 'momentum', 'value', 'scalp']
+      const validStrategies = ['long_hold', 'swing', 'momentum', 'value', 'scalp']
       if (!validStrategies.includes(body.strategy)) return fail('유효한 전략을 선택해주세요.', 400)
       data.strategy = body.strategy
     }

--- a/src/app/api/watchlist/route.ts
+++ b/src/app/api/watchlist/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
     const validMarkets = ['US', 'KR']
     if (!validMarkets.includes(market)) return fail('시장은 US 또는 KR만 허용됩니다.', 400)
 
-    const validStrategies = ['swing', 'momentum', 'value', 'scalp']
+    const validStrategies = ['long_hold', 'swing', 'momentum', 'value', 'scalp']
     const strategy = typeof body.strategy === 'string' && validStrategies.includes(body.strategy) ? body.strategy : 'swing'
 
     const targetBuy = typeof body.targetBuy === 'number' && body.targetBuy > 0 ? body.targetBuy : null

--- a/src/bot/commands/watchlist.ts
+++ b/src/bot/commands/watchlist.ts
@@ -6,13 +6,15 @@ import { replyHtml, escapeHtml, h } from '../utils/telegram'
 import { sanitizeError } from '../utils/error'
 
 const STRATEGY_LABELS: Record<string, string> = {
+  long_hold: '💎 장기보유',
   swing: '🔄 스윙',
   momentum: '🚀 모멘텀',
-  value: '💎 가치투자',
+  value: '📊 가치투자',
   scalp: '⚡ 단타',
 }
 
 const STRATEGY_ALIASES: Record<string, string> = {
+  '장기': 'long_hold', '장기보유': 'long_hold',
   '스윙': 'swing',
   '모멘텀': 'momentum',
   '가치투자': 'value', '가치': 'value',

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -47,39 +47,44 @@ interface TickerMeta {
   displayName: string
   market: string
   strategies: Set<string>
+  hasHolding: boolean
 }
 
-/** 전략별 시그널 조건 매칭 — id는 중복 방지 키에 사용 */
-function checkSignals(report: TAReport, strategy: string): Signal[] {
+/**
+ * 전략별 시그널 조건 매칭 — id는 중복 방지 키에 사용.
+ * hasHolding=false (관심종목만) 는 매도 시그널 스킵 — 매도할 대상 없음.
+ */
+function checkSignals(report: TAReport, strategy: string, hasHolding: boolean): Signal[] {
   const signals: Signal[] = []
   const { rsi14, macd, bollingerBands, volume, sma } = report.indicators
 
   switch (strategy) {
     case 'swing':
       if (rsi14.signal === 'OVERSOLD') signals.push({ id: 'RSI_OVERSOLD', message: `📉 RSI 과매도 (${rsi14.value.toFixed(1)}) — 매수 기회` })
-      if (rsi14.signal === 'OVERBOUGHT') signals.push({ id: 'RSI_OVERBOUGHT', message: `📈 RSI 과매수 (${rsi14.value.toFixed(1)}) — 매도 검토` })
+      if (hasHolding && rsi14.signal === 'OVERBOUGHT') signals.push({ id: 'RSI_OVERBOUGHT', message: `📈 RSI 과매수 (${rsi14.value.toFixed(1)}) — 매도 검토` })
       if (macd.crossover === 'GOLDEN') signals.push({ id: 'MACD_GOLDEN', message: '🔄 MACD 골든크로스 — 매수 시그널' })
-      if (macd.crossover === 'DEAD') signals.push({ id: 'MACD_DEAD', message: '🔄 MACD 데드크로스 — 매도 시그널' })
+      if (hasHolding && macd.crossover === 'DEAD') signals.push({ id: 'MACD_DEAD', message: '🔄 MACD 데드크로스 — 매도 시그널' })
       break
 
     case 'momentum':
       if (volume.surge && report.price.change1d > 0) signals.push({ id: 'VOL_SURGE', message: `🚀 거래량 급증 (${volume.ratio.toFixed(1)}배) + 상승` })
       if (sma.goldenCross) signals.push({ id: 'SMA_GOLDEN', message: '🔄 SMA 골든크로스 — 상승 추세 전환' })
-      if (sma.deathCross) signals.push({ id: 'SMA_DEAD', message: '🔄 SMA 데드크로스 — 하락 추세 전환' })
+      if (hasHolding && sma.deathCross) signals.push({ id: 'SMA_DEAD', message: '🔄 SMA 데드크로스 — 하락 추세 전환' })
       break
 
     case 'scalp':
       if (bollingerBands.position === 'BELOW_LOWER') signals.push({ id: 'BB_BELOW', message: '📉 BB 하단 이탈 — 매수 구간' })
-      if (bollingerBands.position === 'ABOVE_UPPER') signals.push({ id: 'BB_ABOVE', message: '📈 BB 상단 이탈 — 매도 구간' })
+      if (hasHolding && bollingerBands.position === 'ABOVE_UPPER') signals.push({ id: 'BB_ABOVE', message: '📈 BB 상단 이탈 — 매도 구간' })
       if (rsi14.value < 25) signals.push({ id: 'RSI_EXTREME_LOW', message: `📉 RSI 극단 과매도 (${rsi14.value.toFixed(1)})` })
-      if (rsi14.value > 75) signals.push({ id: 'RSI_EXTREME_HIGH', message: `📈 RSI 극단 과매수 (${rsi14.value.toFixed(1)})` })
+      if (hasHolding && rsi14.value > 75) signals.push({ id: 'RSI_EXTREME_HIGH', message: `📈 RSI 극단 과매수 (${rsi14.value.toFixed(1)})` })
       break
 
     case 'long_hold':
-      if (report.signalSummary.overall === 'STRONG_SELL') {
+      // 매도 검토 시그널은 보유 중일 때만 (관심종목만 있으면 매도할 대상 없음)
+      if (hasHolding && report.signalSummary.overall === 'STRONG_SELL') {
         signals.push({ id: 'STRONG_SELL', message: `⚠️ 종합 STRONG_SELL — ${report.signalSummary.reasons.slice(0, 2).join(', ')}` })
       }
-      // 장기보유는 하락 매수 기회 포착이 핵심 — STRONG_BUY 시그널 발생 시 추가 매수 검토 알림
+      // 장기보유는 하락 매수 기회 포착이 핵심 — 보유/관심 모두 대상
       if (report.signalSummary.overall === 'STRONG_BUY') {
         signals.push({ id: 'STRONG_BUY', message: `💰 종합 STRONG_BUY — ${report.signalSummary.reasons.slice(0, 2).join(', ')} — 추가 매수 검토` })
       }
@@ -125,17 +130,19 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     where: { strategy: { in: ['swing', 'momentum', 'scalp', 'long_hold'] } },
   })
 
-  // 티커별 전략 수집 (다중 전략 지원)
+  // 티커별 전략 수집 (다중 전략 지원). hasHolding=true 는 보유 중 → 매도 시그널 활성.
   const tickerStrategies = new Map<string, TickerMeta>()
   for (const h of holdings) {
     const existing = tickerStrategies.get(h.holding.ticker)
     if (existing) {
       existing.strategies.add(h.strategy)
+      existing.hasHolding = true
     } else {
       tickerStrategies.set(h.holding.ticker, {
         displayName: h.holding.displayName,
         market: h.holding.market,
         strategies: new Set([h.strategy]),
+        hasHolding: true,
       })
     }
   }
@@ -143,11 +150,13 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     const existing = tickerStrategies.get(w.ticker)
     if (existing) {
       existing.strategies.add(w.strategy)
+      // hasHolding 은 holding 존재 여부만 반영 (관심종목이 병존해도 true 유지)
     } else {
       tickerStrategies.set(w.ticker, {
         displayName: w.displayName,
         market: w.market,
         strategies: new Set([w.strategy]),
+        hasHolding: false,
       })
     }
   }
@@ -178,10 +187,10 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     try {
       const report = await generateTAReport(ticker)
 
-      // 모든 전략에 대해 시그널 체크
+      // 모든 전략에 대해 시그널 체크 (관심종목만 있으면 매도 시그널 스킵)
       const allSignals: Signal[] = []
       for (const strategy of Array.from(meta.strategies)) {
-        allSignals.push(...checkSignals(report, strategy))
+        allSignals.push(...checkSignals(report, strategy, meta.hasHolding))
       }
 
       if (allSignals.length === 0) continue

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -79,6 +79,10 @@ function checkSignals(report: TAReport, strategy: string): Signal[] {
       if (report.signalSummary.overall === 'STRONG_SELL') {
         signals.push({ id: 'STRONG_SELL', message: `⚠️ 종합 STRONG_SELL — ${report.signalSummary.reasons.slice(0, 2).join(', ')}` })
       }
+      // 장기보유는 하락 매수 기회 포착이 핵심 — STRONG_BUY 시그널 발생 시 추가 매수 검토 알림
+      if (report.signalSummary.overall === 'STRONG_BUY') {
+        signals.push({ id: 'STRONG_BUY', message: `💰 종합 STRONG_BUY — ${report.signalSummary.reasons.slice(0, 2).join(', ')} — 추가 매수 검토` })
+      }
       break
   }
 
@@ -116,9 +120,9 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     include: { holding: { select: { ticker: true, displayName: true, market: true } } },
   })
 
-  // 관심종목 중 액티브 전략 (long_hold 제외 — 관심종목에 장기보유는 해당 없음)
+  // 관심종목 중 액티브 전략 (long_hold 포함 — 장기보유 관심종목도 매수 기회 알림 대상)
   const watchlist = await prisma.watchlist.findMany({
-    where: { strategy: { in: ['swing', 'momentum', 'scalp'] } },
+    where: { strategy: { in: ['swing', 'momentum', 'scalp', 'long_hold'] } },
   })
 
   // 티커별 전략 수집 (다중 전략 지원)

--- a/src/components/watchlist/WatchlistForm.tsx
+++ b/src/components/watchlist/WatchlistForm.tsx
@@ -11,7 +11,15 @@ interface WatchlistFormProps {
   onSaved: () => void
 }
 
-const STRATEGIES = ['swing', 'momentum', 'value', 'scalp'] as const
+const STRATEGIES = ['long_hold', 'swing', 'momentum', 'value', 'scalp'] as const
+
+const STRATEGY_LABELS: Record<string, string> = {
+  long_hold: '장기보유',
+  swing: '스윙',
+  momentum: '모멘텀',
+  value: '가치투자',
+  scalp: '단타',
+}
 
 export default function WatchlistForm({ mode, item, onClose, onSaved }: WatchlistFormProps) {
   const { show } = useToast()
@@ -118,7 +126,7 @@ export default function WatchlistForm({ mode, item, onClose, onSaved }: Watchlis
               <select value={strategy} onChange={(e) => setStrategy(e.target.value)}
                 className={`${inputClasses} appearance-none cursor-pointer`}
                 style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 14px center' }}>
-                {STRATEGIES.map((s) => <option key={s} value={s}>{s}</option>)}
+                {STRATEGIES.map((s) => <option key={s} value={s}>{STRATEGY_LABELS[s] ?? s}</option>)}
               </select>
             </div>
           </div>

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -269,7 +269,7 @@ server.tool(
   '관심종목 추가. 티커 유효성은 Yahoo Finance로 자동 검증. 사용자 확인 후 호출할 것.',
   {
     ticker: z.string().describe('Yahoo Finance 티커 (예: AVAV, 005930.KS)'),
-    strategy: z.enum(['swing', 'momentum', 'value', 'scalp']).optional().describe('전략 (기본 swing)'),
+    strategy: z.enum(['long_hold', 'swing', 'momentum', 'value', 'scalp']).optional().describe('전략 (기본 swing)'),
     targetBuy: z.number().positive().optional().describe('목표 매수가'),
     entryLow: z.number().positive().optional().describe('매수 구간 하한'),
     entryHigh: z.number().positive().optional().describe('매수 구간 상한'),
@@ -283,7 +283,7 @@ server.tool(
   '관심종목 부분 업데이트. ticker로 식별. 제공된 필드만 변경. 사용자 확인 후 호출할 것.',
   {
     ticker: z.string().describe('대상 티커'),
-    strategy: z.enum(['swing', 'momentum', 'value', 'scalp']).optional(),
+    strategy: z.enum(['long_hold', 'swing', 'momentum', 'value', 'scalp']).optional(),
     targetBuy: z.number().positive().nullable().optional().describe('null 전달 시 초기화'),
     entryLow: z.number().positive().nullable().optional(),
     entryHigh: z.number().positive().nullable().optional(),

--- a/src/mcp/tools/watchlist.ts
+++ b/src/mcp/tools/watchlist.ts
@@ -80,7 +80,7 @@ export async function getWatchlist() {
   }
 }
 
-const VALID_STRATEGIES = ['swing', 'momentum', 'value', 'scalp']
+const VALID_STRATEGIES = ['long_hold', 'swing', 'momentum', 'value', 'scalp']
 
 /**
  * add_watchlist: 관심종목 추가 (신규)


### PR DESCRIPTION
## 요약

Phase 29-B v1. 이슈 #230 (2) '투자 목적에 따른 알람' 완전 해결.

## 재검토 결과

기존 `ta-signal-alert.ts` 는 이미 다 되어 있었음:
- 전략별 시그널 규칙 (swing/momentum/scalp/long_hold) ✓
- 보유종목 + 관심종목 대상 ✓
- 하루 종목별 dedup ✓
- **AI 가이드 자동 첨부** (Phase 29-C 예정이던 것) ✓

## 남은 gap 2개 fix

### 1. long_hold 매수 기회 알림 신설
기존 long_hold 트리거가 STRONG_SELL (매도) 만 있어서 급락 반등 기회 시 알림 없음.
→ `checkSignals` long_hold case 에 STRONG_BUY 추가:
```
💰 종합 STRONG_BUY — [reasons] — 추가 매수 검토
```

### 2. 관심종목에 long_hold 등록 지원 (4곳)
- 봇 `src/bot/commands/watchlist.ts`: STRATEGY_LABELS/ALIASES 에 '💎 장기보유' 추가 (value 는 📊 로 이모지 이관)
- 웹 `src/app/api/watchlist/route.ts` / `[id]/route.ts`: validStrategies 배열 확장
- 웹 폼 `src/components/watchlist/WatchlistForm.tsx`: STRATEGIES 배열 + 한글 label 추가
- MCP `src/mcp/tools/watchlist.ts` + `src/mcp/server.ts` (add/update): zod enum 확장
- `ta-signal-alert.ts` line 121: 관심종목 대상에 long_hold 포함
- `prisma/schema.prisma:375`: strategy 주석 갱신

## 체크리스트

- [x] 린트 / 타입체크 / 167 tests / 빌드 ✅
- [x] 코드 리뷰 P1×2 발견 (웹 form + MCP) → 같은 PR 수정. 최종 P0/P1/P2 = 0
- [x] 봇 + 웹 + MCP 3 경로 모두 long_hold 지원 확인
- [x] dedup 정상 (STRONG_BUY / STRONG_SELL 별도 key)

## 효과

이슈 #230 (2) 완전 해결. 장기보유 관심종목/보유종목이 STRONG_BUY 조건 (급락+지지선+과매도 종합) 도달 시 매수 검토 알림 자동 도착.

Closes #373