### PR TITLE
[Phase 31-E] 모바일 더보기 → nav-config 자동 파생 리팩터 (#392)

### DIFF
--- a/docs/specs/395-milestone-13-master.md
+++ b/docs/specs/395-milestone-13-master.md
@@ -1,0 +1,112 @@
+# 13차 마일스톤 — 설정 UX 통합 + 전략 조건 확장 (마스터)
+
+- **작성일**: 2026-07-02
+- **타입**: 마일스톤 (마스터 스펙, sub-phase 로 분할 진행)
+- **참조**: 12차 마스터 #385, `memory/project_next_milestone_13.md`, 이슈 #392 (기존 리팩터 예약)
+
+## 1. 배경
+
+12차까지 커스텀 전략 + 능동 AI 인프라가 안착. 실사용 관점의 다음 병목:
+
+1. **알림 설정이 flat 나열** — active_review / custom_strategy_alerts / ta_ai_guide 등 카테고리 없이 나열. 사용자가 무슨 기능이 어떤 스위치인지 파악 어려움.
+2. **모바일 nav drift 재발 우려** — 오늘 fix (#391) 는 다시 하드코딩 갱신. 근본 리팩터 필요 (#392).
+3. **커스텀 전략 조건 제약** — 6개 타입만 지원, 시간 필터 없음, 보유 상태 무관.
+
+3축 병렬 진행하여 사용자 편의성 완성 + 유지보수 부담 격리.
+
+## 2. 목표
+
+12차 종료 시:
+- ✅ nav-config 이 사이드바 + 모바일 더보기의 단일 소스 (drift 방지)
+- ✅ `/settings` 페이지가 카테고리별로 알림/설정 그루핑 → 신규 키 추가 시 코드 한 곳만 수정
+- ✅ 커스텀 전략 조건에 시간 필터 (`time_window` / `weekday`) + 보유 필터 (`holding_status`) 추가
+
+## 3. Sub-Phase 분할
+
+### Phase 31-E: nav-config 자동 파생 리팩터 (기존 #392 재활용)
+
+**목적**: `BottomTab.MORE_ITEMS` 하드코딩 제거 → `nav-config.ts` 단일 소스.
+
+- [ ] `NavItem` 에 `hiddenOnMobile?: boolean` 추가
+- [ ] `BottomTab.tsx` 에서 `NAV_GROUPS` 를 flat 하여 파생 (FIXED_MOBILE_HREFS 제외)
+- [ ] 순서는 사이드바와 자동 일치
+- [ ] 유닛 테스트: nav-config 변경 → BottomTab 반영
+
+**노력**: S (1-2일)
+**완료 조건**: 신규 페이지 추가 시 nav-config 만 갱신하면 모바일 자동 반영
+
+### Phase 31-B: AlertConfig 통합 설정 UI
+
+**목적**: 늘어난 알림/설정 키를 카테고리별로 그루핑해 사용자 파악/제어 편의 확보.
+
+**현재 키 (예)**:
+- 주가 관련: `price_drop_pct`, `price_surge_pct`, `fx_change_krw`
+- TA 관련: `ta_check_interval_min`, `ta_ai_guide`
+- 능동 AI: `active_review`
+- 커스텀 전략: `custom_strategy_alerts`
+- 일반: `daily_summary_hour` 등
+
+**설계**:
+- AlertConfig 키에 카테고리 정보 첨부 (metadata table 또는 코드 상수 매핑)
+- `/settings` 페이지를 아코디언/섹션으로 재구성
+- 각 섹션: 카테고리명 + 설명 + 관련 키 목록 + 관련 페이지 링크
+
+**API/DB**:
+- 스키마 변경 최소화 — `AlertConfig` 에 `category` 컬럼 신설 (기존 row 는 마이그레이션 스크립트로 채움)
+- 또는 서버 코드 상수 매핑 유지 (스키마 변경 없이)
+
+**노력**: 중 (API 1-2개, 컴포넌트 재구성, 디자인 단계 필요)
+
+### Phase 31-A: 커스텀 전략 조건 확장 v2
+
+**목적**: 파워 유저 요구 대비 + 잘못된 시간대 발동 방지.
+
+**신규 조건 타입**:
+- `time_window` — HH:MM~HH:MM 필터 (KST 기준). 예: "09:00~09:30" (KR 개장 30분)
+- `weekday` — 요일 집합 (예: `[MON, TUE, WED, THU, FRI]` — 주말 제외)
+- `holding_status` — `HELD` / `NOT_HELD` (해당 티커 보유 여부)
+
+**Evaluator 확장**:
+- `time_window`: 현재 KST 시각 vs 범위 (자정 경계 처리)
+- `weekday`: 현재 KST 요일 vs 집합
+- `holding_status`: Holdings DB 조회 후 매칭
+
+**Parser 확장**:
+- 자연어 예: "SOXL 40달러 이하 시 알림, 단 월-금 09:30-16:00 미국장 시간 내에만"
+- LLM 프롬프트에 신규 타입 추가
+
+**호환성**:
+- 기존 저장된 조건은 그대로 유효 (신규 타입 addition)
+- 웹/봇 표시는 새 조건 타입도 `conditionToString` 확장
+
+**노력**: 중 (types.ts + parser + evaluator + 테스트)
+
+## 4. 진행 순서
+
+1. **31-E** 먼저 — 리팩터 격리, 리스크 낮음
+2. **31-B** — 설정 UI 재구성, 디자인 단계 포함
+3. **31-A** — 조건 확장, 테스트 부담 큼
+
+## 5. 성공 지표
+
+- 신규 페이지 등록 시 nav-config 한 곳만 수정으로 모바일까지 반영
+- 사용자가 알림 카테고리별로 on/off 파악 가능 (스크린샷)
+- 커스텀 전략에 시간/요일/보유 조건 등록 가능 → 원하지 않는 시간대 알림 억제
+
+## 6. 제외 사항
+
+- 커스텀 전략 v3 (뉴스/어닝/크로스-티커) — 별도 마일스톤
+- 알림 로그/히스토리 페이지 — 별도 이슈
+- 자동 매매 — 마일스톤 후보 아님 (책임 이슈)
+
+## 7. 위험
+
+- **31-B**: 설정 페이지 리팩터 시 기존 URL/앵커 깨질 수 있음. 앵커 유지 검토.
+- **31-A**: LLM 파싱 프롬프트가 복잡해질수록 파싱 실패율 상승 가능. 예시 다수 포함 + fallback 안내.
+- **31-E**: 파생 로직 버그 시 전체 nav 사라짐. 유닛 테스트 필수 + 배포 후 즉시 확인.
+
+## 8. 참고
+
+- `.claude/rules/api-routes.md` — envelope 규칙
+- `src/lib/custom-strategy/` — types / parser / evaluator (11-12차 산출물)
+- `docs/specs/392-mobile-nav-refactor.md` — 31-E 상세 스펙 (기존)

--- a/docs/specs/396-alert-config-ui.md
+++ b/docs/specs/396-alert-config-ui.md
@@ -1,0 +1,105 @@
+# Phase 31-B — AlertConfig 통합 설정 UI
+
+- **작성일**: 2026-07-02
+- **참조**: [395-milestone-13-master.md](./395-milestone-13-master.md)
+- **선행 이슈**: 31-E (#392) 후에 진행 (컴포넌트 위치가 nav-config 리팩터 여파 받음)
+
+## 1. 목적
+
+늘어난 AlertConfig 키를 카테고리별로 그루핑해 `/settings` 페이지에서 파악/제어 편의 확보.
+
+## 2. 현재 상태
+
+`AlertConfig` 테이블 (`prisma/schema.prisma`):
+```
+model AlertConfig {
+  key    String @id
+  value  String
+  label  String?
+}
+```
+
+`/settings` 페이지는 이 row 들을 flat 하게 나열 — 카테고리 구분 없음.
+
+**현재 등록된 키** (배포 자동 upsert 기준):
+- **가격/환율 알림**: `price_drop_pct`, `price_surge_pct`, `fx_change_krw`
+- **TA 관련**: `ta_check_interval_min`, `ta_ai_guide`
+- **능동 AI**: `active_review`
+- **커스텀 전략**: `custom_strategy_alerts`
+- **일반**: `daily_summary_hour`, `whooing_url` 등
+
+## 3. 요구사항
+
+- [ ] AlertConfig 에 `category` 필드 추가 (스키마 + migration)
+- [ ] `ensure*Setting` 함수들이 upsert 시 category 도 지정
+- [ ] `/api/alerts/config` 응답에 category 포함
+- [ ] `/settings` 페이지에서 카테고리별 아코디언 (기본 접힘 or 펼침 결정)
+- [ ] 각 섹션에 설명 + 관련 페이지 링크 (예: "커스텀 전략" 섹션 → `/strategies` 링크)
+- [ ] 기존 URL/앵커 유지 (예: `/settings#alerts`)
+- [ ] 신규 키 추가 시 category 만 지정하면 자동으로 해당 섹션에 나타남
+
+## 4. 기술 설계
+
+### DB migration
+```prisma
+model AlertConfig {
+  key      String  @id
+  value    String
+  label    String?
+  category String  @default("general")  // 'price' | 'ta' | 'ai' | 'strategy' | 'general'
+  order    Int     @default(0)          // 섹션 내 정렬
+}
+```
+
+Migration: 기존 row 들을 초기 카테고리 매핑 (스크립트로 upsert).
+
+### 카테고리 상수
+```ts
+// src/lib/alert-config/categories.ts
+export const CATEGORIES = [
+  { key: 'price', label: '가격 / 환율 알림', description: '급등락 임계값', pageLink: null },
+  { key: 'ta', label: '기술적 분석 알림', description: 'TA 시그널 + AI 가이드', pageLink: '/strategies' },
+  { key: 'ai', label: '능동 AI 리뷰', description: '클로징/주간 리뷰', pageLink: null },
+  { key: 'strategy', label: '커스텀 전략', description: '자연어 조건 감시', pageLink: '/strategies' },
+  { key: 'general', label: '일반', description: '기타 알림/설정', pageLink: null },
+]
+```
+
+### `/settings` UI 구조
+- 상단: 페이지 제목 + 총 활성 키 요약
+- 카테고리 섹션 반복:
+  - 섹션 헤더 (label + 관련 페이지 링크)
+  - 소속 키 리스트 (label + value 편집 + Save 버튼)
+- 접힘/펼침: 로컬 저장 (localStorage) 로 상태 유지
+
+### API 변경
+- `GET /api/alerts/config` → 응답에 category 필드 추가 (envelope 유지)
+- `PUT /api/alerts/config` → 기존과 동일 (key + value 만 업데이트)
+- `POST /api/alerts/config/reseed` (선택) — 카테고리 매핑 다시 채우기 (운영자용)
+
+## 5. 디자인 단계
+
+`frontend-design` 스킬로 프로토타입:
+- 카테고리 섹션 아코디언 레이아웃
+- 각 키의 편집 UI (숫자 slider / toggle / dropdown / text)
+- 관련 페이지 링크 배지
+- 다크 테마 + 반응형
+
+승인 후 `docs/designs/396-alert-config-ui/` 저장.
+
+## 6. 테스트 계획
+
+- [ ] 유닛: 카테고리별 그루핑 로직
+- [ ] 유닛: 기존 값 유지 + 신규 category 필드 upsert
+- [ ] API: envelope + category 필드 포함
+- [ ] 통합: 각 ensure*Setting 이 정확한 category 로 upsert
+- [ ] lint / typecheck / test / build
+
+## 7. 제외
+
+- 알림 로그/히스토리 페이지 (별도 이슈)
+- 카테고리 관리 UI (사용자가 카테고리 추가/삭제) — v2 후보
+
+## 8. 완료 시
+
+`/settings` 페이지가 카테고리별로 정리되어 신규 키 추가 시 코드 한 곳만 갱신하면 UI 자동 반영.

--- a/docs/specs/397-custom-strategy-v2.md
+++ b/docs/specs/397-custom-strategy-v2.md
@@ -1,0 +1,142 @@
+# Phase 31-A — 커스텀 전략 조건 확장 v2 (시간/보유 필터)
+
+- **작성일**: 2026-07-02
+- **참조**: [395-milestone-13-master.md](./395-milestone-13-master.md), [380-custom-strategy.md](./380-custom-strategy.md) (v1)
+- **선행 이슈**: 없음 (기존 v1 인프라 위에 addition)
+
+## 1. 목적
+
+파워 유저 관점의 잘못된 시간대 발동 방지 + 보유 여부 기반 조건 추가.
+
+## 2. 요구사항
+
+### 신규 조건 타입
+
+- [ ] `time_window`
+  - `value`: `HH:MM~HH:MM` 문자열 (KST 기준)
+  - `operator`: `is`
+  - 의미: 현재 KST 시각이 범위 내이면 true
+  - 자정 경계: `23:00~02:00` 같은 wraparound 지원
+
+- [ ] `weekday`
+  - `value`: 대문자 요일 코드 배열 (예: `["MON","TUE","WED","THU","FRI"]`)
+  - `operator`: `is`
+  - 의미: 현재 KST 요일이 배열에 포함되면 true
+  - 유효값: `MON` / `TUE` / `WED` / `THU` / `FRI` / `SAT` / `SUN`
+
+- [ ] `holding_status`
+  - `value`: `HELD` / `NOT_HELD`
+  - `operator`: `is`
+  - 의미: strategy.ticker 를 Holdings 테이블에 보유 중이면 `HELD` 매칭
+  - 데이터: `Holding.shares > 0` 기준
+
+### Types 확장
+
+`src/lib/custom-strategy/types.ts`:
+```ts
+export type ConditionType =
+  | 'price' | 'rsi' | 'macd_signal' | 'sma_cross' | 'bb_position' | 'change_pct'
+  | 'time_window' | 'weekday' | 'holding_status'  // v2 추가
+
+export const ALLOWED_STRING_VALUES = {
+  macd_signal: ['GOLDEN', 'DEAD'] as const,
+  sma_cross: ['GOLDEN', 'DEAD'] as const,
+  bb_position: ['BELOW_LOWER', 'ABOVE_UPPER'] as const,
+  holding_status: ['HELD', 'NOT_HELD'] as const,  // 신규
+} as const
+
+export const VALID_WEEKDAYS = new Set(['MON','TUE','WED','THU','FRI','SAT','SUN'])
+```
+
+- validateCondition 에 3 신규 케이스 추가:
+  - `time_window`: `HH:MM~HH:MM` regex 매칭
+  - `weekday`: 배열 + 각 요소가 VALID_WEEKDAYS 에 속함
+  - `holding_status`: ALLOWED_STRING_VALUES 참조
+
+### Evaluator 확장
+
+`src/lib/custom-strategy/evaluator.ts`:
+
+```ts
+export interface EvaluationContext {
+  now: Date            // KST 로 변환된 시각 접근용
+  holdings: Set<string> // 보유 티커 set (호출자가 조회 후 주입)
+}
+
+export function evaluateCondition(
+  cond: Condition,
+  snapshot: MarketSnapshot,
+  context: EvaluationContext,
+): boolean
+```
+
+**주의**: 기존 호출자 (custom-strategy-alert.ts) 는 context 를 준비해 넘겨야 함.
+- Holdings 조회: `prisma.holding.findMany({ where: { shares: { gt: 0 } }, select: { ticker: true }})` 1회
+- KST now: `new Date(Date.now() + 9*60*60*1000)` (기존 패턴 재활용)
+
+`requiresTA` 는 v2 조건 타입 무시 (TA 필요 없음).
+
+### Parser 프롬프트 갱신
+
+`src/lib/custom-strategy/parser.ts` 프롬프트 헤더에 신규 타입 안내:
+
+```
+지원 조건 타입 (v2 추가):
+- time_window ("HH:MM~HH:MM" KST, is 전용)
+- weekday (요일 배열 ["MON","FRI"] 등, is 전용)
+- holding_status ("HELD" | "NOT_HELD", is 전용)
+
+## 사용 예 (v2)
+- "SOXL 40달러 이하 + 미국장 시간에만 알림" →
+  {"conditions": [
+    {"type":"price","operator":"<=","value":40},
+    {"type":"time_window","operator":"is","value":"22:30~05:00"}
+  ]}
+- "NVDA MACD 골든크로스 + 평일에만" →
+  {"conditions": [
+    {"type":"macd_signal","operator":"is","value":"GOLDEN"},
+    {"type":"weekday","operator":"is","value":["MON","TUE","WED","THU","FRI"]}
+  ]}
+- "TSLA 볼밴 하단 + 보유 중일 때만" →
+  {"conditions":[
+    {"type":"bb_position","operator":"is","value":"BELOW_LOWER"},
+    {"type":"holding_status","operator":"is","value":"HELD"}
+  ]}
+```
+
+### 표시 (conditionToString 확장)
+
+- `time_window is 22:30~05:00`
+- `weekday is [MON,TUE,WED,THU,FRI]`
+- `holding_status is HELD`
+
+## 3. 파일 변경
+
+- `src/lib/custom-strategy/types.ts` — 3 신규 타입 + validation
+- `src/lib/custom-strategy/evaluator.ts` — EvaluationContext + 3 신규 케이스
+- `src/lib/custom-strategy/parser.ts` — 프롬프트 예시 확장
+- `src/bot/notifications/custom-strategy-alert.ts` — holdings 조회 + context 전달
+- 유닛 테스트 (types / evaluator) 확장
+
+## 4. 호환성
+
+- 기존 저장된 조건 (v1) 은 그대로 유효 — 신규 타입 addition
+- Migration 불필요 (JSON 저장이라 스키마 변경 없음)
+
+## 5. 테스트 계획
+
+- [ ] `validateCondition` — 3 신규 타입 각각 valid/invalid 케이스
+- [ ] `evaluateCondition` — time_window (KST, wraparound), weekday (경계), holding_status (Set 매칭)
+- [ ] 통합: 기존 v1 조건과 v2 조건 혼합 시 AND/OR 정상 동작
+- [ ] Parser (통합, mock 없이): 예시 3개 파싱 성공 확인 (선택, AI 호출 비용)
+
+## 6. 제외 (v3 후보)
+
+- `earnings_calendar` — 어닝 발표일 근접 필터
+- `news_mention` — 뉴스 언급 조건
+- `cross_ticker` — 다른 티커 시세 조건 참조
+- 신규 action (v1/v2 는 알림만)
+
+## 7. 완료 시
+
+커스텀 전략에 시간/요일/보유 필터 적용 가능 → 잘못된 시간대 알림 억제.

--- a/src/components/layout/BottomTab.tsx
+++ b/src/components/layout/BottomTab.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import ThemeToggle from '@/components/theme/ThemeToggle'
+import { deriveMobileMoreItems, MOBILE_FIXED_HREFS } from './nav-config'
 
 interface BottomTabProps {
   accounts: { id: string; name: string }[]
@@ -15,28 +16,11 @@ const colorMap: Record<string, string> = {
   '다솜': 'text-dasom',
 }
 
-// 순서: nav-config.ts 사이드바 그루핑 순 (포트폴리오 → 가계부 → 분석 → AI & 전략).
-// 유지 보수 시 nav-config.ts 와 함께 갱신 (drift 방지는 #391 후속 리팩터에서).
-const MORE_ITEMS = [
-  { href: '/rsu', icon: '🏢', label: 'RSU' },
-  { href: '/stock-options', icon: '📊', label: '스톡옵션' },
-  { href: '/vesting', icon: '📅', label: '베스팅 캘린더' },
-  { href: '/dividends', icon: '💰', label: '배당금' },
-  { href: '/deposits', icon: '🎁', label: '입금/증여' },
-  { href: '/watchlist', icon: '👀', label: '관심종목' },
-  { href: '/categories', icon: '🏷️', label: '카테고리' },
-  { href: '/budgets', icon: '📋', label: '예산' },
-  { href: '/recurring', icon: '🔄', label: '반복 거래' },
-  { href: '/tax', icon: '🧾', label: '세금' },
-  { href: '/simulator', icon: '🔮', label: '시뮬레이터' },
-  { href: '/performance', icon: '📈', label: '수익률 분석' },
-  { href: '/ai', icon: '🤖', label: 'AI 분석' },
-  { href: '/strategies', icon: '🧠', label: '커스텀 전략' },
-  { href: '/networth', icon: '💰', label: '순자산' },
-  { href: '/assets', icon: '🏦', label: '자산 관리' },
-  { href: '/reports', icon: '📋', label: '리포트' },
-  { href: '/backtest', icon: '🧪', label: '백테스팅' },
-]
+/**
+ * 모바일 하단 더보기 항목 — nav-config.ts 사이드바에서 자동 파생.
+ * 신규 페이지 추가 시 nav-config.ts 만 갱신하면 모바일도 자동 반영 (#392).
+ */
+const MORE_ITEMS = deriveMobileMoreItems()
 
 export default function BottomTab({ accounts }: BottomTabProps) {
   const pathname = usePathname()
@@ -44,11 +28,10 @@ export default function BottomTab({ accounts }: BottomTabProps) {
 
   if (pathname.startsWith('/auth') || pathname === '/offline') return null
 
-  const FIXED_TAB_PATHS = ['/', '/trades', '/expenses']
   const isMoreActive = (
     MORE_ITEMS.some((item) => pathname.startsWith(item.href))
     || accounts.some((a) => pathname === `/accounts/${a.id}`)
-  ) && !FIXED_TAB_PATHS.some((p) => p === '/' ? pathname === '/' : pathname.startsWith(p))
+  ) && !MOBILE_FIXED_HREFS.some((p) => p === '/' ? pathname === '/' : pathname.startsWith(p))
 
   return (
     <>

--- a/src/components/layout/__tests__/nav-config.test.ts
+++ b/src/components/layout/__tests__/nav-config.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NAV_GROUPS,
+  MOBILE_FIXED_HREFS,
+  deriveMobileMoreItems,
+  isPathActive,
+  findActiveGroup,
+  type NavGroup,
+} from '../nav-config'
+
+describe('deriveMobileMoreItems (실제 NAV_GROUPS)', () => {
+  const items = deriveMobileMoreItems()
+
+  it('MOBILE_FIXED_HREFS 항목은 제외 (/, /trades, /expenses)', () => {
+    for (const fixed of MOBILE_FIXED_HREFS) {
+      expect(items.some((i) => i.href === fixed)).toBe(false)
+    }
+  })
+
+  it('hiddenOnMobile 항목은 제외 (/settings)', () => {
+    expect(items.some((i) => i.href === '/settings')).toBe(false)
+  })
+
+  it('사이드바에 있는 신규 페이지들이 모바일 더보기에 포함됨 (#391 회귀 방지)', () => {
+    const hrefs = items.map((i) => i.href)
+    for (const href of ['/strategies', '/watchlist', '/vesting', '/budgets', '/recurring', '/assets']) {
+      expect(hrefs).toContain(href)
+    }
+  })
+
+  it('중복 항목 없음', () => {
+    const hrefs = items.map((i) => i.href)
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+})
+
+describe('deriveMobileMoreItems (합성 NAV_GROUPS)', () => {
+  const fixture: NavGroup[] = [
+    {
+      title: 'A',
+      items: [
+        { href: '/', icon: '🏠', label: 'Home' },
+        { href: '/x', icon: '🔴', label: 'X' },
+        { href: '/y', icon: '🔵', label: 'Y', hiddenOnMobile: true },
+      ],
+    },
+    {
+      title: 'B',
+      items: [
+        { href: '/z', icon: '🟢', label: 'Z' },
+      ],
+    },
+  ]
+
+  it('사이드바 순서 유지', () => {
+    const result = deriveMobileMoreItems(fixture, ['/'])
+    expect(result.map((i) => i.href)).toEqual(['/x', '/z'])
+  })
+
+  it('fixedHrefs 로 지정한 경로 제외', () => {
+    const result = deriveMobileMoreItems(fixture, ['/x'])
+    expect(result.map((i) => i.href)).toEqual(['/', '/z'])
+  })
+
+  it('빈 그룹 → 빈 배열', () => {
+    expect(deriveMobileMoreItems([], [])).toEqual([])
+  })
+})
+
+describe('isPathActive', () => {
+  it('/ 는 정확히 매칭', () => {
+    expect(isPathActive('/', '/')).toBe(true)
+    expect(isPathActive('/foo', '/')).toBe(false)
+  })
+
+  it('정확 매치 + startsWith', () => {
+    expect(isPathActive('/trades', '/trades')).toBe(true)
+    expect(isPathActive('/trades/new', '/trades')).toBe(true)
+    expect(isPathActive('/tradings', '/trades')).toBe(false)
+  })
+})
+
+describe('findActiveGroup', () => {
+  it('실제 NAV_GROUPS 에서 /strategies 는 AI & 전략 그룹', () => {
+    expect(findActiveGroup('/strategies')).toBe('AI & 전략')
+  })
+
+  it('/expenses 는 가계부 그룹', () => {
+    expect(findActiveGroup('/expenses')).toBe('가계부')
+  })
+
+  it('매칭 없으면 null', () => {
+    expect(findActiveGroup('/no-such-page')).toBe(null)
+  })
+})
+
+describe('NAV_GROUPS 정합성', () => {
+  it('모든 그룹 아이템의 href 가 유일', () => {
+    const all = NAV_GROUPS.flatMap((g) => g.items.map((i) => i.href))
+    expect(new Set(all).size).toBe(all.length)
+  })
+
+  it('MOBILE_FIXED_HREFS 는 실제 NAV_GROUPS 에 존재', () => {
+    const allHrefs = new Set(NAV_GROUPS.flatMap((g) => g.items.map((i) => i.href)))
+    for (const fixed of MOBILE_FIXED_HREFS) {
+      expect(allHrefs.has(fixed)).toBe(true)
+    }
+  })
+})

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -2,6 +2,8 @@ export interface NavItem {
   href: string
   icon: string
   label: string
+  /** true 시 모바일 하단 더보기에서 제외 (기본: 포함) */
+  hiddenOnMobile?: boolean
 }
 
 export interface NavGroup {
@@ -47,17 +49,42 @@ export const NAV_GROUPS: NavGroup[] = [
       { href: '/strategies', icon: '🧠', label: '커스텀 전략' },
       { href: '/networth', icon: '💰', label: '순자산' },
       { href: '/assets', icon: '🏦', label: '자산 관리' },
-      { href: '/reports', icon: '📋', label: '분기 리포트' },
+      { href: '/reports', icon: '📋', label: '리포트' },
       { href: '/backtest', icon: '🧪', label: '백테스팅' },
     ],
   },
   {
     title: '설정',
     items: [
-      { href: '/settings', icon: '⚙️', label: '설정' },
+      { href: '/settings', icon: '⚙️', label: '설정', hiddenOnMobile: true },
     ],
   },
 ]
+
+/**
+ * 모바일 하단 탭에서 고정으로 노출되는 경로 —
+ * BottomTab.tsx 의 3개 고정 탭 (대시보드/거래/가계부) 과 동기화 유지.
+ */
+export const MOBILE_FIXED_HREFS: readonly string[] = ['/', '/trades', '/expenses']
+
+/**
+ * 모바일 하단 더보기 아이템 목록을 NAV_GROUPS 에서 파생.
+ *
+ * - 사이드바 순서 그대로 flat
+ * - hiddenOnMobile=true 제외
+ * - MOBILE_FIXED_HREFS 는 이미 고정 탭에 있으므로 더보기에서 제외
+ *
+ * 파생으로 유지해 nav-config 만 갱신하면 모바일도 자동 반영 (#391/#392).
+ */
+export function deriveMobileMoreItems(
+  groups: NavGroup[] = NAV_GROUPS,
+  fixedHrefs: readonly string[] = MOBILE_FIXED_HREFS,
+): NavItem[] {
+  const fixed = new Set(fixedHrefs)
+  return groups
+    .flatMap((g) => g.items)
+    .filter((item) => !item.hiddenOnMobile && !fixed.has(item.href))
+}
 
 export function isPathActive(pathname: string, href: string): boolean {
   if (href === '/') return pathname === '/'


### PR DESCRIPTION
## Summary
BottomTab.MORE_ITEMS 하드코딩을 제거하고 NAV_GROUPS 에서 파생. #391 drift 원천 차단.

### 변경
- \`NavItem.hiddenOnMobile\` 필드 추가 (기본 false)
- \`MOBILE_FIXED_HREFS\` 상수 (/, /trades, /expenses)
- \`deriveMobileMoreItems()\` 순수 함수 — 사이드바 순 flat + hiddenOnMobile/fixed 제외
- \`/settings\` 는 \`hiddenOnMobile: true\` 로 기존 동작 보존
- BottomTab.tsx: MORE_ITEMS 하드코딩 제거, isMoreActive 도 상수 공유

### 회귀 방지
유닛 테스트 14 케이스 — 특히 #391 에서 누락됐던 6개 경로 (/strategies, /watchlist, /vesting, /budgets, /recurring, /assets) 가 파생 결과에 반드시 포함되는지 검증.

### 동봉
13차 마일스톤 스펙:
- \`docs/specs/395-milestone-13-master.md\` (마스터)
- \`docs/specs/396-alert-config-ui.md\` (31-B)
- \`docs/specs/397-custom-strategy-v2.md\` (31-A)

## Test plan
- [x] lint / typecheck / test (222, +14) / build 통과
- [x] 자체 코드 리뷰
- [ ] 배포 후 모바일 더보기 시각 확인 (사이드바 순서 일치)

Closes #392

Parent: #395