### PR TITLE
[Phase 31-B] AlertConfig 통합 UI — 카테고리 그루핑 (#396)

### DIFF
--- a/docs/designs/396-alert-config-ui/design-notes.md
+++ b/docs/designs/396-alert-config-ui/design-notes.md
@@ -1,0 +1,58 @@
+# AlertConfig 통합 설정 UI 디자인 노트
+
+## 목적
+`/settings` 페이지의 알림 탭을 카테고리별로 그루핑해 사용자가 무슨 기능이 어떤 스위치인지 빠르게 파악.
+
+## 카테고리 매핑 (초안)
+| 카테고리 | 색상 (icon) | 키 | 관련 페이지 |
+|---|---|---|---|
+| 가격/환율 | `--sejin` 📉 | price_drop_pct, price_surge_pct, fx_change_krw | - |
+| 가계부 | `--dasom` 💸 | budget_warn_pct | `/budgets` |
+| 스케줄 | `--sodam` 🕰️ | daily_summary_hour, monthly_report_day | - |
+| AI & 전략 | `--amber` 🧠 | ta_check_interval_min, ta_ai_guide, active_review, custom_strategy_alerts | `/strategies` |
+
+## 레이아웃
+1. **기존 탭 유지** (계좌 / 알림 / 근로소득 / 후잉 연동)
+2. **알림 탭 진입 시**:
+   - Summary strip: 전체 / 활성 / 비활성 / 카테고리 (4 카드)
+   - 카테고리 섹션 반복 (모두 기본 펼침)
+
+## 섹션 구조
+- 헤더: icon (원형 배경) + 카테고리명 + 설명 + 키 개수 + 관련 페이지 링크 + ▾ 토글
+- 바디: 키 행 반복
+  - 행 좌: label + code (모노스페이스) + description (선택)
+  - 행 우: 값 배지 (숫자+단위) 또는 toggle 스위치 + 수정 버튼
+
+## 입력 타입 매핑
+- **on/off 문자열** (ta_ai_guide, active_review, custom_strategy_alerts) → toggle 스위치
+- **숫자 %** (price_drop_pct, price_surge_pct, budget_warn_pct) → number input + `%` 단위
+- **정수** (fx_change_krw 원, ta_check_interval_min 분, daily_summary_hour 시, monthly_report_day 일) → number input + 단위
+
+## 인터랙션
+- 섹션 헤더 클릭: 접힘/펼침 (로컬 저장 선택)
+- 수정 버튼: 인라인 편집 → 저장/취소
+- toggle: 즉시 PUT (낙관적 UI + 실패 롤백)
+
+## 반응형
+- 데스크톱: max-w-4xl, 여유롭게
+- 모바일: summary strip 2x2, 섹션은 동일
+
+## 색상 근거
+- 가격/환율은 `--sejin` (녹색 = 시세 관련, 세진 컬러 재사용)
+- 가계부는 `--dasom` (주황 = 지출 신중)
+- 스케줄은 `--sodam` (파랑 = 시간/체계)
+- AI & 전략은 `--amber` (황금색 = 지능/자동)
+
+## 접근성
+- 각 toggle 에 `role="switch"` + `aria-checked`
+- 색상만이 아니라 텍스트 상태 표기 (예: 값 배지 자체)
+- 키보드로 편집 가능 (Tab 순서, Enter 저장, Esc 취소)
+
+## 확장성
+- 신규 키 추가 시 서버 코드 상수 매핑에 카테고리 지정만 하면 UI 자동 반영
+- 카테고리 자체를 추가하려면 CATEGORIES 배열 갱신 + section 렌더링 자동 확장
+
+## 마이그레이션
+- AlertConfig 스키마에 `category` 컬럼 추가 vs 서버 코드 상수 매핑 유지 → **후자 (스키마 변경 최소화)**
+- 이유: category 는 개발자가 정의, 사용자 수정 불필요. 코드 상수 map (`ALERT_KEY_CATEGORY` 등) 으로 관리하는 편이 안전.
+- 알 수 없는 키는 "일반" 카테고리로 자동 분류 (fallback).

--- a/docs/designs/396-alert-config-ui/prototype.html
+++ b/docs/designs/396-alert-config-ui/prototype.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>알림 설정 · myFinance</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+<style>
+  :root {
+    --bg: #07080c;
+    --bg-raised: #0d0e14;
+    --card: rgba(255, 255, 255, 0.025);
+    --border: rgba(255, 255, 255, 0.06);
+    --border-hover: rgba(255, 255, 255, 0.12);
+    --dim: #6e6e82;
+    --sub: #9494a8;
+    --text: #c8c8d4;
+    --bright: #eeeef2;
+    --sejin: #34d399;
+    --sodam: #60a5fa;
+    --dasom: #fb923c;
+    --amber: #fbbf24;
+    --red: #ef4444;
+    --surface-dim: rgba(255, 255, 255, 0.04);
+    --surface: rgba(255, 255, 255, 0.06);
+    --surface-hover: rgba(255, 255, 255, 0.1);
+  }
+  html.light {
+    --bg: #f5f5f7;
+    --bg-raised: #ffffff;
+    --card: rgba(0, 0, 0, 0.02);
+    --border: rgba(0, 0, 0, 0.08);
+    --border-hover: rgba(0, 0, 0, 0.15);
+    --dim: #9ca3af;
+    --sub: #6b7280;
+    --text: #374151;
+    --bright: #111827;
+    --sejin: #059669;
+    --sodam: #2563eb;
+    --dasom: #ea580c;
+    --amber: #b45309;
+    --red: #dc2626;
+    --surface-dim: rgba(0, 0, 0, 0.05);
+    --surface: rgba(0, 0, 0, 0.07);
+    --surface-hover: rgba(0, 0, 0, 0.09);
+  }
+  body { background: var(--bg); color: var(--text); font-family: 'Pretendard', -apple-system, system-ui, sans-serif; }
+  .bg-bg-raised { background: var(--bg-raised); }
+  .bg-card { background: var(--card); }
+  .bg-surface-dim { background: var(--surface-dim); }
+  .bg-surface { background: var(--surface); }
+  .text-bright { color: var(--bright); }
+  .text-sub { color: var(--sub); }
+  .text-dim { color: var(--dim); }
+  .text-app { color: var(--text); }
+  .text-sejin { color: var(--sejin); }
+  .text-sodam { color: var(--sodam); }
+  .text-dasom { color: var(--dasom); }
+  .text-amber { color: var(--amber); }
+  .text-red { color: var(--red); }
+
+  .section-card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
+  .section-header { display: flex; align-items: center; gap: 12px; padding: 16px 20px; background: var(--surface-dim); border-bottom: 1px solid var(--border); cursor: pointer; user-select: none; transition: background 0.15s; }
+  .section-header:hover { background: var(--surface); }
+  .section-icon { width: 36px; height: 36px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 18px; flex-shrink: 0; }
+  .section-icon.price { background: color-mix(in srgb, var(--sejin) 15%, transparent); color: var(--sejin); }
+  .section-icon.expense { background: color-mix(in srgb, var(--dasom) 15%, transparent); color: var(--dasom); }
+  .section-icon.schedule { background: color-mix(in srgb, var(--sodam) 15%, transparent); color: var(--sodam); }
+  .section-icon.ai { background: color-mix(in srgb, var(--amber) 15%, transparent); color: var(--amber); }
+  .chevron { transition: transform 0.2s ease; color: var(--sub); }
+  .section-header[data-open="false"] .chevron { transform: rotate(-90deg); }
+
+  .key-row { display: flex; align-items: center; gap: 16px; padding: 14px 20px; border-bottom: 1px solid var(--border); }
+  .key-row:last-child { border-bottom: none; }
+  .key-row:hover { background: var(--surface-dim); }
+  .key-info { flex: 1; min-width: 0; }
+  .key-label { font-size: 13px; font-weight: 600; color: var(--bright); }
+  .key-code { font-size: 11px; color: var(--dim); font-family: 'JetBrains Mono', ui-monospace, monospace; }
+  .key-desc { font-size: 11px; color: var(--sub); margin-top: 2px; }
+
+  .value-badge { font-size: 15px; font-weight: 700; color: var(--bright); font-variant-numeric: tabular-nums; }
+  .unit { font-size: 11px; color: var(--sub); margin-left: 2px; }
+
+  .toggle { position: relative; width: 40px; height: 22px; background: var(--surface); border-radius: 999px; cursor: pointer; transition: background 0.2s; border: 1px solid var(--border); }
+  .toggle::after { content: ""; position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; background: var(--sub); border-radius: 50%; transition: all 0.2s; }
+  .toggle.on { background: color-mix(in srgb, var(--sejin) 30%, transparent); border-color: color-mix(in srgb, var(--sejin) 40%, transparent); }
+  .toggle.on::after { left: 20px; background: var(--sejin); }
+
+  .btn { padding: 6px 12px; border-radius: 6px; font-size: 12px; font-weight: 600; transition: all 0.15s; border: 1px solid transparent; }
+  .btn-secondary { background: var(--surface-dim); color: var(--sub); border-color: var(--border); }
+  .btn-secondary:hover { background: var(--surface); color: var(--bright); }
+  .btn-primary { background: var(--bright); color: var(--bg); }
+  .btn-primary:hover { transform: translateY(-1px); }
+  .input { background: var(--surface-dim); border: 1px solid var(--border); border-radius: 6px; color: var(--bright); padding: 6px 10px; font-size: 13px; font-weight: 600; width: 80px; text-align: right; font-variant-numeric: tabular-nums; }
+  .input:focus { outline: none; border-color: var(--sejin); }
+
+  .link-badge { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 999px; background: var(--surface); color: var(--sub); font-size: 10px; font-weight: 600; border: 1px solid var(--border); text-decoration: none; }
+  .link-badge:hover { color: var(--bright); background: var(--surface-hover); }
+
+  .tab { padding: 10px; border-radius: 8px; text-align: center; font-size: 13px; font-weight: 600; transition: all 0.15s; color: var(--sub); }
+  .tab.active { background: var(--surface); color: var(--bright); }
+  .tab:hover:not(.active) { color: var(--text); }
+
+  .summary-strip { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-bottom: 20px; }
+  @media (min-width: 768px) { .summary-strip { grid-template-columns: repeat(4, 1fr); } }
+  .summary-card { padding: 14px 16px; background: var(--card); border: 1px solid var(--border); border-radius: 12px; }
+  .summary-num { font-size: 22px; font-weight: 800; color: var(--bright); }
+  .summary-label { font-size: 11px; color: var(--sub); margin-top: 2px; letter-spacing: 0.2px; }
+</style>
+</head>
+<body>
+
+<!-- Header -->
+<header class="sticky top-0 z-20 bg-bg-raised border-b border-border">
+  <div class="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+    <div class="flex items-center gap-3">
+      <div class="w-8 h-8 rounded-lg bg-sodam/20 flex items-center justify-center text-sodam text-lg">⚙️</div>
+      <div>
+        <h1 class="text-bright font-bold text-lg">설정</h1>
+        <p class="text-sub text-xs">계정, 알림, 근로소득, 외부 연동 관리</p>
+      </div>
+    </div>
+    <button class="btn btn-secondary" onclick="toggleTheme()">🌙</button>
+  </div>
+</header>
+
+<main class="max-w-4xl mx-auto px-6 py-6 space-y-6">
+
+  <!-- Top tab (기존 유지) -->
+  <div class="grid grid-cols-4 gap-1 bg-card border border-border rounded-[10px] p-1">
+    <div class="tab">계좌</div>
+    <div class="tab active">알림</div>
+    <div class="tab">근로소득</div>
+    <div class="tab">후잉 연동</div>
+  </div>
+
+  <!-- Summary strip -->
+  <div class="summary-strip">
+    <div class="summary-card">
+      <div class="summary-num">10</div>
+      <div class="summary-label">전체 알림 설정</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-num text-sejin">3</div>
+      <div class="summary-label">활성 (on)</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-num text-dim">0</div>
+      <div class="summary-label">비활성 (off)</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-num text-sodam">4</div>
+      <div class="summary-label">카테고리</div>
+    </div>
+  </div>
+
+  <!-- Section 1: 가격/환율 -->
+  <section class="section-card">
+    <div class="section-header" data-open="true" onclick="toggleSection(this)">
+      <div class="section-icon price">📉</div>
+      <div class="flex-1">
+        <div class="text-bright font-bold text-sm">가격 / 환율 알림</div>
+        <div class="text-sub text-xs mt-0.5">종목 급등락 및 원/달러 환율 변동 임계값 <span class="text-dim">· 3개 키</span></div>
+      </div>
+      <span class="chevron">▾</span>
+    </div>
+    <div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">급락 알림 (%)</div>
+          <div class="key-code">price_drop_pct</div>
+          <div class="key-desc">일일 변동률이 이 값 이하이면 텔레그램 급락 알림</div>
+        </div>
+        <span class="value-badge">-5<span class="unit">%</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">급등 알림 (%)</div>
+          <div class="key-code">price_surge_pct</div>
+          <div class="key-desc">일일 변동률이 이 값 이상이면 텔레그램 급등 알림</div>
+        </div>
+        <span class="value-badge">5<span class="unit">%</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">환율 변동 알림 (원)</div>
+          <div class="key-code">fx_change_krw</div>
+          <div class="key-desc">원/달러 하루 변동폭이 이 값 이상이면 알림</div>
+        </div>
+        <span class="value-badge">50<span class="unit">원</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: 가계부 -->
+  <section class="section-card">
+    <div class="section-header" data-open="true" onclick="toggleSection(this)">
+      <div class="section-icon expense">💸</div>
+      <div class="flex-1">
+        <div class="text-bright font-bold text-sm">
+          가계부
+          <a class="link-badge ml-2" href="/budgets">예산 페이지 →</a>
+        </div>
+        <div class="text-sub text-xs mt-0.5">예산 초과 경고 임계값 <span class="text-dim">· 1개 키</span></div>
+      </div>
+      <span class="chevron">▾</span>
+    </div>
+    <div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">예산 경고 (%)</div>
+          <div class="key-code">budget_warn_pct</div>
+          <div class="key-desc">카테고리별 월 예산 사용률이 이 값을 초과하면 경고</div>
+        </div>
+        <span class="value-badge">80<span class="unit">%</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 3: 스케줄 -->
+  <section class="section-card">
+    <div class="section-header" data-open="true" onclick="toggleSection(this)">
+      <div class="section-icon schedule">🕰️</div>
+      <div class="flex-1">
+        <div class="text-bright font-bold text-sm">발송 스케줄</div>
+        <div class="text-sub text-xs mt-0.5">자동 발송 시각/주기 <span class="text-dim">· 2개 키</span></div>
+      </div>
+      <span class="chevron">▾</span>
+    </div>
+    <div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">일일 요약 시각</div>
+          <div class="key-code">daily_summary_hour</div>
+          <div class="key-desc">매일 이 시각(KST)에 포트폴리오 요약 발송 (0~23)</div>
+        </div>
+        <span class="value-badge">8<span class="unit">시</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">월간 리포트 발송일</div>
+          <div class="key-code">monthly_report_day</div>
+          <div class="key-desc">매월 이 날짜(KST 자정)에 월간 리포트 발송 (1~28)</div>
+        </div>
+        <span class="value-badge">1<span class="unit">일</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 4: AI & 전략 -->
+  <section class="section-card">
+    <div class="section-header" data-open="true" onclick="toggleSection(this)">
+      <div class="section-icon ai">🧠</div>
+      <div class="flex-1">
+        <div class="text-bright font-bold text-sm">
+          AI & 전략 알림
+          <a class="link-badge ml-2" href="/strategies">전략 페이지 →</a>
+        </div>
+        <div class="text-sub text-xs mt-0.5">기술적 분석 · 능동 AI 리뷰 · 커스텀 전략 <span class="text-dim">· 4개 키</span></div>
+      </div>
+      <span class="chevron">▾</span>
+    </div>
+    <div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">TA 모니터링 주기 (분)</div>
+          <div class="key-code">ta_check_interval_min</div>
+          <div class="key-desc">TA 시그널 스캔 최소 간격 (기본 10분)</div>
+        </div>
+        <span class="value-badge">10<span class="unit">분</span></span>
+        <button class="btn btn-secondary">수정</button>
+      </div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">TA 시그널 AI 가이드</div>
+          <div class="key-code">ta_ai_guide</div>
+          <div class="key-desc">TA 시그널 알림에 AI 짧은 조언 첨부 (티커별 6h 쿨다운)</div>
+        </div>
+        <div class="toggle on"></div>
+      </div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">능동 AI 리뷰</div>
+          <div class="key-code">active_review</div>
+          <div class="key-desc">KR 15:40 / US 07:15 클로징 리뷰 + 주간 리뷰 자동 발송</div>
+        </div>
+        <div class="toggle on"></div>
+      </div>
+      <div class="key-row">
+        <div class="key-info">
+          <div class="key-label">커스텀 전략 알림</div>
+          <div class="key-code">custom_strategy_alerts</div>
+          <div class="key-desc">/strategies 등록 조건 발동 시 텔레그램 알림</div>
+        </div>
+        <div class="toggle on"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Disclaimer -->
+  <p class="text-center text-dim text-xs pt-4">알림 임계값 변경은 다음 주기부터 반영됩니다.</p>
+</main>
+
+<script>
+  function toggleTheme() { document.documentElement.classList.toggle('light') }
+  function toggleSection(el) {
+    const isOpen = el.dataset.open === 'true'
+    el.dataset.open = isOpen ? 'false' : 'true'
+    const body = el.nextElementSibling
+    body.style.display = isOpen ? 'none' : ''
+  }
+</script>
+
+</body>
+</html>

--- a/src/app/api/alerts/config/route.ts
+++ b/src/app/api/alerts/config/route.ts
@@ -1,18 +1,30 @@
 import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { ok, fail } from '@/lib/api-response'
+import {
+  categoryOf,
+  inputTypeOf,
+  ALERT_KEY_DESCRIPTION,
+} from '@/lib/alert-config/categories'
 
 export const dynamic = 'force-dynamic'
 
 /**
- * GET /api/alerts/config — 전체 알림 설정 조회
+ * GET /api/alerts/config — 전체 알림 설정 조회.
+ * 응답에 category / inputType / description 을 첨부 (Phase 31-B).
  */
 export async function GET() {
   try {
     const configs = await prisma.alertConfig.findMany({
       orderBy: { key: 'asc' },
     })
-    return ok(configs)
+    const enriched = configs.map((c) => ({
+      ...c,
+      category: categoryOf(c.key),
+      inputType: inputTypeOf(c.key, c.value),
+      description: ALERT_KEY_DESCRIPTION[c.key] ?? null,
+    }))
+    return ok(enriched)
   } catch (error) {
     console.error('GET /api/alerts/config error:', error)
     return fail('알림 설정을 불러올 수 없습니다.', 500)

--- a/src/components/settings/AlertConfigEditor.tsx
+++ b/src/components/settings/AlertConfigEditor.tsx
@@ -29,6 +29,7 @@ const UNIT_BY_TYPE: Record<AlertInputType, string> = {
   day: '일',
   minutes: '분',
   integer: '',
+  text: '',
 }
 
 /** 카테고리 색상 → tailwind 유틸 클래스 매핑 */
@@ -169,11 +170,13 @@ export default function AlertConfigEditor() {
       )
     }
 
+    const isText = c.inputType === 'text'
+
     if (editingKey === c.key) {
       return (
         <div className="flex items-center gap-2">
           <input
-            type="number"
+            type={isText ? 'text' : 'number'}
             value={editValue}
             onChange={(e) => setEditValue(e.target.value)}
             onKeyDown={(e) => {
@@ -181,9 +184,13 @@ export default function AlertConfigEditor() {
               if (e.key === 'Escape') cancelEdit()
             }}
             autoFocus
-            className="bg-surface-dim border border-border rounded-md px-2.5 py-1.5 text-[13px] font-semibold text-bright w-20 text-right tabular-nums focus:outline-none focus:border-sejin"
+            className={`bg-surface-dim border border-border rounded-md px-2.5 py-1.5 text-[13px] font-semibold text-bright focus:outline-none focus:border-sejin ${
+              isText ? 'w-56' : 'w-20 text-right tabular-nums'
+            }`}
           />
-          <span className="text-[11px] text-sub">{UNIT_BY_TYPE[c.inputType]}</span>
+          {UNIT_BY_TYPE[c.inputType] && (
+            <span className="text-[11px] text-sub">{UNIT_BY_TYPE[c.inputType]}</span>
+          )}
           <button
             onClick={() => commitEdit(c)}
             disabled={savingKey === c.key}
@@ -202,16 +209,19 @@ export default function AlertConfigEditor() {
     }
 
     return (
-      <div className="flex items-center gap-3">
-        <span className="text-[15px] font-bold text-bright tabular-nums">
-          {c.value}
+      <div className="flex items-center gap-3 min-w-0">
+        <span
+          className={`text-[15px] font-bold text-bright ${isText ? 'truncate max-w-[280px]' : 'tabular-nums'}`}
+          title={isText ? c.value : undefined}
+        >
+          {c.value || <span className="text-dim">(비어 있음)</span>}
           {UNIT_BY_TYPE[c.inputType] && (
             <span className="text-[11px] text-sub ml-0.5">{UNIT_BY_TYPE[c.inputType]}</span>
           )}
         </span>
         <button
           onClick={() => startEdit(c)}
-          className="text-[12px] font-semibold text-sub bg-surface-dim border border-border rounded-md px-3 py-1.5 hover:bg-surface hover:text-bright transition-all"
+          className="text-[12px] font-semibold text-sub bg-surface-dim border border-border rounded-md px-3 py-1.5 hover:bg-surface hover:text-bright transition-all flex-shrink-0"
         >
           수정
         </button>

--- a/src/components/settings/AlertConfigEditor.tsx
+++ b/src/components/settings/AlertConfigEditor.tsx
@@ -1,93 +1,318 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  ALERT_CATEGORIES,
+  groupByCategory,
+  type AlertCategory,
+  type AlertCategoryKey,
+  type AlertInputType,
+} from '@/lib/alert-config/categories'
+import { useToast } from '@/components/ui/Toast'
 
 interface AlertConfig {
-  id: string
   key: string
   value: string
   label: string
+  category: AlertCategoryKey
+  inputType: AlertInputType
+  description: string | null
+}
+
+/** 값 + 단위 표시 (숫자형) */
+const UNIT_BY_TYPE: Record<AlertInputType, string> = {
+  toggle: '',
+  percent: '%',
+  currency_krw: '원',
+  hour: '시',
+  day: '일',
+  minutes: '분',
+  integer: '',
+}
+
+/** 카테고리 색상 → tailwind 유틸 클래스 매핑 */
+const COLOR_CLASS: Record<AlertCategory['color'], { icon: string; text: string }> = {
+  sejin: { icon: 'bg-sejin/15 text-sejin', text: 'text-sejin' },
+  sodam: { icon: 'bg-sodam/15 text-sodam', text: 'text-sodam' },
+  dasom: { icon: 'bg-dasom/15 text-dasom', text: 'text-dasom' },
+  amber: { icon: 'bg-amber-500/15 text-amber-400', text: 'text-amber-400' },
+  sub: { icon: 'bg-surface text-sub', text: 'text-sub' },
 }
 
 export default function AlertConfigEditor() {
+  const { show } = useToast()
   const [configs, setConfigs] = useState<AlertConfig[]>([])
+  const [loading, setLoading] = useState(true)
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
-  const [saving, setSaving] = useState(false)
+  const [savingKey, setSavingKey] = useState<string | null>(null)
+  const [openCategories, setOpenCategories] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(ALERT_CATEGORIES.map((c) => [c.key, true])),
+  )
 
-  useEffect(() => {
-    fetch('/api/alerts/config')
-      .then((res) => res.ok ? res.json() : null)
-      .then((json) => { if (Array.isArray(json?.data)) setConfigs(json.data) })
-      .catch(() => {})
-  }, [])
-
-  const startEdit = (config: AlertConfig) => {
-    setEditingKey(config.key)
-    setEditValue(config.value)
+  const fetchConfigs = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/alerts/config')
+      const json = await res.json()
+      if (!res.ok) {
+        show({ variant: 'error', title: json?.error ?? '알림 설정 조회에 실패했습니다.' })
+        return
+      }
+      setConfigs(Array.isArray(json.data) ? json.data : [])
+    } catch (e) {
+      console.error('[alerts/config] 조회 실패:', e)
+      show({ variant: 'error', title: '알림 설정 조회 중 오류가 발생했습니다.' })
+    } finally {
+      setLoading(false)
+    }
   }
 
-  const handleSave = async (key: string) => {
-    if (!editValue.trim()) return
-    setSaving(true)
+  useEffect(() => {
+    fetchConfigs()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const grouped = useMemo(() => groupByCategory(configs), [configs])
+
+  const activeToggleCount = useMemo(
+    () => configs.filter((c) => c.inputType === 'toggle' && c.value.toLowerCase() === 'on').length,
+    [configs],
+  )
+  const inactiveToggleCount = useMemo(
+    () => configs.filter((c) => c.inputType === 'toggle' && c.value.toLowerCase() === 'off').length,
+    [configs],
+  )
+
+  const saveConfig = async (key: string, value: string) => {
+    setSavingKey(key)
+    // Optimistic
+    const prev = configs.find((c) => c.key === key)?.value
+    setConfigs((cs) => cs.map((c) => (c.key === key ? { ...c, value } : c)))
     try {
       const res = await fetch('/api/alerts/config', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key, value: editValue.trim() }),
+        body: JSON.stringify({ key, value }),
       })
-      if (res.ok) {
-        setConfigs((prev) => prev.map((c) => c.key === key ? { ...c, value: editValue.trim() } : c))
-        setEditingKey(null)
+      const json = await res.json()
+      if (!res.ok) {
+        // Rollback
+        if (prev !== undefined) {
+          setConfigs((cs) => cs.map((c) => (c.key === key ? { ...c, value: prev } : c)))
+        }
+        show({ variant: 'error', title: json?.error ?? '설정 저장에 실패했습니다.' })
+        return
       }
+      show({ variant: 'success', title: '저장 완료' })
+    } catch (e) {
+      if (prev !== undefined) {
+        setConfigs((cs) => cs.map((c) => (c.key === key ? { ...c, value: prev } : c)))
+      }
+      console.error('[alerts/config] 저장 실패:', e)
+      show({ variant: 'error', title: '저장 요청 중 오류가 발생했습니다.' })
     } finally {
-      setSaving(false)
+      setSavingKey(null)
     }
   }
 
-  const inputClasses = 'bg-surface-dim border border-border rounded-lg px-3 py-2 text-[13px] text-bright font-medium focus:outline-none focus:bg-surface focus:border-border-hover transition-colors'
+  const handleToggle = (c: AlertConfig) => {
+    const next = c.value.toLowerCase() === 'on' ? 'off' : 'on'
+    saveConfig(c.key, next)
+  }
+
+  const startEdit = (c: AlertConfig) => {
+    setEditingKey(c.key)
+    setEditValue(c.value)
+  }
+
+  const commitEdit = async (c: AlertConfig) => {
+    const trimmed = editValue.trim()
+    if (!trimmed) {
+      show({ variant: 'error', title: '값을 입력해주세요.' })
+      return
+    }
+    await saveConfig(c.key, trimmed)
+    setEditingKey(null)
+  }
+
+  const cancelEdit = () => {
+    setEditingKey(null)
+    setEditValue('')
+  }
+
+  const toggleSection = (catKey: AlertCategoryKey) => {
+    setOpenCategories((s) => ({ ...s, [catKey]: !s[catKey] }))
+  }
+
+  const renderValueControl = (c: AlertConfig) => {
+    if (c.inputType === 'toggle') {
+      const isOn = c.value.toLowerCase() === 'on'
+      return (
+        <button
+          onClick={() => handleToggle(c)}
+          disabled={savingKey === c.key}
+          role="switch"
+          aria-checked={isOn}
+          aria-label={isOn ? '비활성화' : '활성화'}
+          className={`relative w-10 h-[22px] rounded-full border transition-colors flex-shrink-0 disabled:opacity-50 ${
+            isOn ? 'bg-sejin/30 border-sejin/40' : 'bg-surface border-border'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 w-4 h-4 rounded-full transition-all ${
+              isOn ? 'left-[20px] bg-sejin' : 'left-0.5 bg-sub'
+            }`}
+          />
+        </button>
+      )
+    }
+
+    if (editingKey === c.key) {
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitEdit(c)
+              if (e.key === 'Escape') cancelEdit()
+            }}
+            autoFocus
+            className="bg-surface-dim border border-border rounded-md px-2.5 py-1.5 text-[13px] font-semibold text-bright w-20 text-right tabular-nums focus:outline-none focus:border-sejin"
+          />
+          <span className="text-[11px] text-sub">{UNIT_BY_TYPE[c.inputType]}</span>
+          <button
+            onClick={() => commitEdit(c)}
+            disabled={savingKey === c.key}
+            className="text-[11px] font-bold text-sodam bg-sodam/15 border border-sodam/25 rounded-md px-2.5 py-1 disabled:opacity-40"
+          >
+            저장
+          </button>
+          <button
+            onClick={cancelEdit}
+            className="text-[11px] font-semibold text-sub border border-border rounded-md px-2.5 py-1 hover:text-bright hover:bg-surface"
+          >
+            취소
+          </button>
+        </div>
+      )
+    }
+
+    return (
+      <div className="flex items-center gap-3">
+        <span className="text-[15px] font-bold text-bright tabular-nums">
+          {c.value}
+          {UNIT_BY_TYPE[c.inputType] && (
+            <span className="text-[11px] text-sub ml-0.5">{UNIT_BY_TYPE[c.inputType]}</span>
+          )}
+        </span>
+        <button
+          onClick={() => startEdit(c)}
+          className="text-[12px] font-semibold text-sub bg-surface-dim border border-border rounded-md px-3 py-1.5 hover:bg-surface hover:text-bright transition-all"
+        >
+          수정
+        </button>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-[14px] border border-border bg-card p-8 text-center text-[13px] text-sub">
+        불러오는 중…
+      </div>
+    )
+  }
+
+  const toggleTotal = activeToggleCount + inactiveToggleCount
 
   return (
-    <div className="flex flex-col gap-2">
-      {configs.map((config) => (
-        <div key={config.key} className="rounded-[14px] border border-border bg-card px-5 py-3.5 flex items-center justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <div className="text-[13px] font-medium text-bright">{config.label}</div>
-            <div className="text-[11px] text-dim">{config.key}</div>
+    <div className="space-y-6">
+      {/* Summary strip */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-[22px] font-extrabold text-bright tabular-nums">{configs.length}</div>
+          <div className="text-[11px] text-sub mt-0.5">전체 알림 설정</div>
+        </div>
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-[22px] font-extrabold text-sejin tabular-nums">{activeToggleCount}</div>
+          <div className="text-[11px] text-sub mt-0.5">활성 (on)</div>
+        </div>
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className={`text-[22px] font-extrabold tabular-nums ${inactiveToggleCount > 0 ? 'text-dim' : 'text-dim'}`}>
+            {inactiveToggleCount}
           </div>
-          {editingKey === config.key ? (
-            <div className="flex items-center gap-2">
-              <input
-                className={`w-24 ${inputClasses}`}
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                autoFocus
-              />
-              <button onClick={() => handleSave(config.key)} disabled={saving}
-                className="text-[11px] font-bold text-sodam bg-sodam/15 border border-sodam/25 rounded-md px-2.5 py-1 disabled:opacity-40">
-                저장
-              </button>
-              <button onClick={() => setEditingKey(null)}
-                className="text-[11px] font-semibold text-sub border border-border rounded-md px-2.5 py-1">
-                취소
-              </button>
-            </div>
-          ) : (
-            <div className="flex items-center gap-3">
-              <span className="text-[15px] font-bold text-bright tabular-nums">{config.value}</span>
-              <button onClick={() => startEdit(config)}
-                className="text-[12px] font-semibold text-sub bg-surface-dim border border-border rounded-md px-3 py-1.5 hover:bg-surface hover:text-bright transition-all">
-                수정
-              </button>
-            </div>
-          )}
+          <div className="text-[11px] text-sub mt-0.5">비활성 (off) / 전체 {toggleTotal}</div>
         </div>
-      ))}
-      {configs.length === 0 && (
-        <div className="rounded-[14px] border border-border bg-card p-8 text-center text-[13px] text-sub">
-          알림 설정이 없습니다.
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-[22px] font-extrabold text-sodam tabular-nums">{grouped.length}</div>
+          <div className="text-[11px] text-sub mt-0.5">카테고리</div>
         </div>
-      )}
+      </div>
+
+      {/* Category sections */}
+      {grouped.map(({ category, items }) => {
+        const colors = COLOR_CLASS[category.color]
+        const isOpen = openCategories[category.key] ?? true
+        return (
+          <section key={category.key} className="rounded-[14px] border border-border bg-card overflow-hidden">
+            <button
+              type="button"
+              onClick={() => toggleSection(category.key)}
+              className="w-full flex items-center gap-3 px-5 py-4 bg-surface-dim hover:bg-surface transition-colors border-b border-border text-left"
+              aria-expanded={isOpen}
+            >
+              <div className={`w-9 h-9 rounded-xl flex items-center justify-center text-lg flex-shrink-0 ${colors.icon}`}>
+                {category.icon}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-bright font-bold text-sm flex items-center gap-2 flex-wrap">
+                  {category.label}
+                  {category.pageLink && (
+                    <Link
+                      href={category.pageLink.href}
+                      onClick={(e) => e.stopPropagation()}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold border border-border bg-surface text-sub hover:text-bright hover:bg-surface-hover"
+                    >
+                      {category.pageLink.label} →
+                    </Link>
+                  )}
+                </div>
+                <div className="text-sub text-xs mt-0.5">
+                  {category.description} <span className="text-dim">· {items.length}개 키</span>
+                </div>
+              </div>
+              <span className={`text-sub transition-transform ${isOpen ? '' : '-rotate-90'}`}>▾</span>
+            </button>
+            {isOpen && (
+              <div>
+                {items.map((c) => (
+                  <div
+                    key={c.key}
+                    className="flex items-center gap-4 px-5 py-3.5 border-b border-border last:border-b-0 hover:bg-surface-dim transition-colors"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[13px] font-semibold text-bright">{c.label}</div>
+                      <div className="text-[11px] text-dim font-mono">{c.key}</div>
+                      {c.description && (
+                        <div className="text-[11px] text-sub mt-1">{c.description}</div>
+                      )}
+                    </div>
+                    {renderValueControl(c)}
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )
+      })}
+
+      <p className="text-center text-dim text-xs pt-2">
+        알림 임계값 변경은 다음 스캔 주기부터 반영됩니다.
+      </p>
     </div>
   )
 }

--- a/src/components/settings/AlertConfigEditor.tsx
+++ b/src/components/settings/AlertConfigEditor.tsx
@@ -257,36 +257,36 @@ export default function AlertConfigEditor() {
       {grouped.map(({ category, items }) => {
         const colors = COLOR_CLASS[category.color]
         const isOpen = openCategories[category.key] ?? true
+        // Header 는 toggle 버튼 + 옵션 Link 를 flex 로 분리 — <a> in <button> nesting 회피 (invalid HTML).
         return (
           <section key={category.key} className="rounded-[14px] border border-border bg-card overflow-hidden">
-            <button
-              type="button"
-              onClick={() => toggleSection(category.key)}
-              className="w-full flex items-center gap-3 px-5 py-4 bg-surface-dim hover:bg-surface transition-colors border-b border-border text-left"
-              aria-expanded={isOpen}
-            >
-              <div className={`w-9 h-9 rounded-xl flex items-center justify-center text-lg flex-shrink-0 ${colors.icon}`}>
-                {category.icon}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-bright font-bold text-sm flex items-center gap-2 flex-wrap">
-                  {category.label}
-                  {category.pageLink && (
-                    <Link
-                      href={category.pageLink.href}
-                      onClick={(e) => e.stopPropagation()}
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold border border-border bg-surface text-sub hover:text-bright hover:bg-surface-hover"
-                    >
-                      {category.pageLink.label} →
-                    </Link>
-                  )}
+            <div className="flex items-stretch bg-surface-dim border-b border-border">
+              <button
+                type="button"
+                onClick={() => toggleSection(category.key)}
+                className="flex-1 flex items-center gap-3 px-5 py-4 hover:bg-surface transition-colors text-left"
+                aria-expanded={isOpen}
+              >
+                <div className={`w-9 h-9 rounded-xl flex items-center justify-center text-lg flex-shrink-0 ${colors.icon}`}>
+                  {category.icon}
                 </div>
-                <div className="text-sub text-xs mt-0.5">
-                  {category.description} <span className="text-dim">· {items.length}개 키</span>
+                <div className="flex-1 min-w-0">
+                  <div className="text-bright font-bold text-sm">{category.label}</div>
+                  <div className="text-sub text-xs mt-0.5">
+                    {category.description} <span className="text-dim">· {items.length}개 키</span>
+                  </div>
                 </div>
-              </div>
-              <span className={`text-sub transition-transform ${isOpen ? '' : '-rotate-90'}`}>▾</span>
-            </button>
+                <span className={`text-sub transition-transform ${isOpen ? '' : '-rotate-90'}`}>▾</span>
+              </button>
+              {category.pageLink && (
+                <Link
+                  href={category.pageLink.href}
+                  className="flex items-center gap-1 px-4 border-l border-border text-[11px] font-semibold text-sub hover:text-bright hover:bg-surface transition-colors whitespace-nowrap"
+                >
+                  {category.pageLink.label} →
+                </Link>
+              )}
+            </div>
             {isOpen && (
               <div>
                 {items.map((c) => (

--- a/src/lib/alert-config/__tests__/categories.test.ts
+++ b/src/lib/alert-config/__tests__/categories.test.ts
@@ -35,6 +35,17 @@ describe('inputTypeOf', () => {
 
   it('매핑 없고 숫자 값이면 integer', () => {
     expect(inputTypeOf('random_key_y', '123')).toBe('integer')
+    expect(inputTypeOf('random_key_y', '-5')).toBe('integer')
+    expect(inputTypeOf('random_key_y', '3.14')).toBe('integer')
+  })
+
+  it('매핑 없고 비숫자 문자열은 text (URL/토큰 값 보존)', () => {
+    // codex P2 회귀 방지 — integer 로 판정하면 <input type="number"> 가 값을 blank 처리
+    expect(inputTypeOf('whooing_url', 'https://example.com/webhook')).toBe('text')
+    expect(inputTypeOf('some_token', 'abc-def-123')).toBe('text')
+    expect(inputTypeOf('random_key', 'hello world')).toBe('text')
+    expect(inputTypeOf('empty_key', '')).toBe('text')
+    expect(inputTypeOf('space_key', '   ')).toBe('text')
   })
 })
 

--- a/src/lib/alert-config/__tests__/categories.test.ts
+++ b/src/lib/alert-config/__tests__/categories.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALERT_CATEGORIES,
+  ALERT_KEY_CATEGORY,
+  categoryOf,
+  inputTypeOf,
+  groupByCategory,
+} from '../categories'
+
+describe('categoryOf', () => {
+  it('알려진 키는 매핑된 카테고리 반환', () => {
+    expect(categoryOf('price_drop_pct')).toBe('price')
+    expect(categoryOf('active_review')).toBe('ai')
+    expect(categoryOf('budget_warn_pct')).toBe('expense')
+    expect(categoryOf('daily_summary_hour')).toBe('schedule')
+  })
+
+  it('알려지지 않은 키는 general fallback', () => {
+    expect(categoryOf('unknown_key_xyz')).toBe('general')
+    expect(categoryOf('')).toBe('general')
+  })
+})
+
+describe('inputTypeOf', () => {
+  it('매핑 있으면 override 우선', () => {
+    expect(inputTypeOf('ta_ai_guide', 'off')).toBe('toggle')
+    expect(inputTypeOf('price_drop_pct', '-5')).toBe('percent')
+    expect(inputTypeOf('daily_summary_hour', '8')).toBe('hour')
+  })
+
+  it('매핑 없고 값이 on/off 이면 toggle 자동 판정', () => {
+    expect(inputTypeOf('random_key_x', 'on')).toBe('toggle')
+    expect(inputTypeOf('random_key_x', 'OFF')).toBe('toggle')
+  })
+
+  it('매핑 없고 숫자 값이면 integer', () => {
+    expect(inputTypeOf('random_key_y', '123')).toBe('integer')
+  })
+})
+
+describe('groupByCategory', () => {
+  const items = [
+    { key: 'price_drop_pct', value: '-5' },
+    { key: 'active_review', value: 'on' },
+    { key: 'custom_strategy_alerts', value: 'on' },
+    { key: 'budget_warn_pct', value: '80' },
+    { key: 'unknown_key', value: 'x' },
+  ]
+
+  it('카테고리별로 묶고 사이드바 순서 유지', () => {
+    const groups = groupByCategory(items)
+    const keys = groups.map((g) => g.category.key)
+    // ALERT_CATEGORIES 순서: price → expense → schedule → ai → general
+    expect(keys).toEqual(['price', 'expense', 'ai', 'general'])
+  })
+
+  it('각 그룹 내 아이템 정합성', () => {
+    const groups = groupByCategory(items)
+    const aiGroup = groups.find((g) => g.category.key === 'ai')!
+    expect(aiGroup.items.map((i) => i.key).sort()).toEqual(['active_review', 'custom_strategy_alerts'])
+  })
+
+  it('빈 카테고리는 결과에서 제외', () => {
+    const groups = groupByCategory([{ key: 'active_review', value: 'on' }])
+    expect(groups.length).toBe(1)
+    expect(groups[0].category.key).toBe('ai')
+  })
+
+  it('빈 입력 → 빈 배열', () => {
+    expect(groupByCategory([])).toEqual([])
+  })
+})
+
+describe('ALERT_KEY_CATEGORY 완전성', () => {
+  it('실제 사용 중인 10개 키가 모두 매핑됨', () => {
+    const knownKeys = [
+      'price_drop_pct',
+      'price_surge_pct',
+      'fx_change_krw',
+      'budget_warn_pct',
+      'daily_summary_hour',
+      'monthly_report_day',
+      'ta_check_interval_min',
+      'ta_ai_guide',
+      'active_review',
+      'custom_strategy_alerts',
+    ]
+    for (const key of knownKeys) {
+      expect(ALERT_KEY_CATEGORY[key]).toBeDefined()
+    }
+  })
+})
+
+describe('ALERT_CATEGORIES 정합성', () => {
+  it('key 는 유일하며 general 이 포함', () => {
+    const catKeys = ALERT_CATEGORIES.map((c) => c.key)
+    expect(new Set(catKeys).size).toBe(catKeys.length)
+    expect(catKeys).toContain('general')
+  })
+})

--- a/src/lib/alert-config/categories.ts
+++ b/src/lib/alert-config/categories.ts
@@ -75,7 +75,7 @@ export const ALERT_KEY_CATEGORY: Record<string, AlertCategoryKey> = {
   custom_strategy_alerts: 'ai',
 }
 
-export type AlertInputType = 'toggle' | 'percent' | 'currency_krw' | 'hour' | 'day' | 'minutes' | 'integer'
+export type AlertInputType = 'toggle' | 'percent' | 'currency_krw' | 'hour' | 'day' | 'minutes' | 'integer' | 'text'
 
 /** 키별 입력 타입 오버라이드 (없으면 값 형태 추론) */
 export const ALERT_KEY_INPUT_TYPE: Record<string, AlertInputType> = {
@@ -110,13 +110,26 @@ export function categoryOf(key: string): AlertCategoryKey {
   return ALERT_KEY_CATEGORY[key] ?? 'general'
 }
 
-/** 값이 on/off 문자열이면 toggle 로 판정 (매핑 우선) */
+/**
+ * 값 형태로 입력 타입 추론 (매핑 우선).
+ *
+ * fallback 순서:
+ *   1. `ALERT_KEY_INPUT_TYPE` 오버라이드
+ *   2. on/off → toggle
+ *   3. 유한 숫자 → integer
+ *   4. 그 외 → text (URL/토큰 등 문자열 값 보존)
+ *
+ * `integer` fallback 이 넓으면 `<input type="number">` 가 문자열 값을
+ * blank 처리 → 데이터 손실 (#396 codex P2 회귀 방지).
+ */
 export function inputTypeOf(key: string, value: string): AlertInputType {
   const overridden = ALERT_KEY_INPUT_TYPE[key]
   if (overridden) return overridden
   const lower = value.toLowerCase()
   if (lower === 'on' || lower === 'off') return 'toggle'
-  return 'integer'
+  const trimmed = value.trim()
+  if (trimmed !== '' && Number.isFinite(Number(trimmed))) return 'integer'
+  return 'text'
 }
 
 /** 카테고리별 그루핑 헬퍼 */

--- a/src/lib/alert-config/categories.ts
+++ b/src/lib/alert-config/categories.ts
@@ -1,0 +1,135 @@
+/**
+ * AlertConfig 카테고리 매핑 (Phase 31-B).
+ *
+ * DB 스키마 변경 없이 서버 코드 상수로 category 를 부여.
+ * `ALERT_KEY_CATEGORY` 에 없는 키는 자동으로 `general` 로 분류 (fallback).
+ *
+ * 신규 알림 키 추가 시:
+ *   1. `ensure*Setting` upsert 호출
+ *   2. 여기 매핑에 category 추가
+ *   3. 필요 시 `INPUT_TYPE` 오버라이드 (기본은 문자열 인식으로 자동 판정)
+ */
+
+export type AlertCategoryKey = 'price' | 'expense' | 'schedule' | 'ai' | 'general'
+
+export interface AlertCategory {
+  key: AlertCategoryKey
+  label: string
+  description: string
+  icon: string
+  color: 'sejin' | 'sodam' | 'dasom' | 'amber' | 'sub'
+  pageLink?: { href: string; label: string }
+}
+
+export const ALERT_CATEGORIES: AlertCategory[] = [
+  {
+    key: 'price',
+    label: '가격 / 환율 알림',
+    description: '종목 급등락 및 원/달러 환율 변동 임계값',
+    icon: '📉',
+    color: 'sejin',
+  },
+  {
+    key: 'expense',
+    label: '가계부',
+    description: '예산 초과 경고 임계값',
+    icon: '💸',
+    color: 'dasom',
+    pageLink: { href: '/budgets', label: '예산 페이지' },
+  },
+  {
+    key: 'schedule',
+    label: '발송 스케줄',
+    description: '자동 발송 시각 / 주기',
+    icon: '🕰️',
+    color: 'sodam',
+  },
+  {
+    key: 'ai',
+    label: 'AI & 전략 알림',
+    description: '기술적 분석 · 능동 AI 리뷰 · 커스텀 전략',
+    icon: '🧠',
+    color: 'amber',
+    pageLink: { href: '/strategies', label: '전략 페이지' },
+  },
+  {
+    key: 'general',
+    label: '기타',
+    description: '분류되지 않은 알림/설정',
+    icon: '⚙️',
+    color: 'sub',
+  },
+]
+
+/** 알려진 키의 카테고리. 여기에 없는 키는 `general` 로 fallback. */
+export const ALERT_KEY_CATEGORY: Record<string, AlertCategoryKey> = {
+  price_drop_pct: 'price',
+  price_surge_pct: 'price',
+  fx_change_krw: 'price',
+  budget_warn_pct: 'expense',
+  daily_summary_hour: 'schedule',
+  monthly_report_day: 'schedule',
+  ta_check_interval_min: 'ai',
+  ta_ai_guide: 'ai',
+  active_review: 'ai',
+  custom_strategy_alerts: 'ai',
+}
+
+export type AlertInputType = 'toggle' | 'percent' | 'currency_krw' | 'hour' | 'day' | 'minutes' | 'integer'
+
+/** 키별 입력 타입 오버라이드 (없으면 값 형태 추론) */
+export const ALERT_KEY_INPUT_TYPE: Record<string, AlertInputType> = {
+  price_drop_pct: 'percent',
+  price_surge_pct: 'percent',
+  budget_warn_pct: 'percent',
+  fx_change_krw: 'currency_krw',
+  daily_summary_hour: 'hour',
+  monthly_report_day: 'day',
+  ta_check_interval_min: 'minutes',
+  ta_ai_guide: 'toggle',
+  active_review: 'toggle',
+  custom_strategy_alerts: 'toggle',
+}
+
+/** 키별 사용자 향 설명 (label 은 DB label, 이건 부가 설명) */
+export const ALERT_KEY_DESCRIPTION: Record<string, string> = {
+  price_drop_pct: '일일 변동률이 이 값 이하이면 텔레그램 급락 알림',
+  price_surge_pct: '일일 변동률이 이 값 이상이면 텔레그램 급등 알림',
+  fx_change_krw: '원/달러 하루 변동폭이 이 값 이상이면 알림',
+  budget_warn_pct: '카테고리별 월 예산 사용률이 이 값을 초과하면 경고',
+  daily_summary_hour: '매일 이 시각 (KST) 에 포트폴리오 요약 발송',
+  monthly_report_day: '매월 이 날짜에 월간 리포트 발송',
+  ta_check_interval_min: 'TA 시그널 스캔 최소 간격',
+  ta_ai_guide: 'TA 시그널 알림에 AI 짧은 조언 첨부 (티커별 6h 쿨다운)',
+  active_review: 'KR 15:40 / US 07:15 클로징 리뷰 + 주간 리뷰 자동 발송',
+  custom_strategy_alerts: '/strategies 에 등록한 조건 발동 시 텔레그램 알림',
+}
+
+/** 카테고리 조회 — 알려지지 않은 키는 general */
+export function categoryOf(key: string): AlertCategoryKey {
+  return ALERT_KEY_CATEGORY[key] ?? 'general'
+}
+
+/** 값이 on/off 문자열이면 toggle 로 판정 (매핑 우선) */
+export function inputTypeOf(key: string, value: string): AlertInputType {
+  const overridden = ALERT_KEY_INPUT_TYPE[key]
+  if (overridden) return overridden
+  const lower = value.toLowerCase()
+  if (lower === 'on' || lower === 'off') return 'toggle'
+  return 'integer'
+}
+
+/** 카테고리별 그루핑 헬퍼 */
+export function groupByCategory<T extends { key: string }>(
+  items: T[],
+): Array<{ category: AlertCategory; items: T[] }> {
+  const buckets = new Map<AlertCategoryKey, T[]>()
+  for (const item of items) {
+    const cat = categoryOf(item.key)
+    if (!buckets.has(cat)) buckets.set(cat, [])
+    buckets.get(cat)!.push(item)
+  }
+  return ALERT_CATEGORIES
+    .map((category) => ({ category, items: buckets.get(category.key) ?? [] }))
+    .filter((b) => b.items.length > 0)
+}


### PR DESCRIPTION
## Summary
10개 알림 설정 키를 카테고리별로 그루핑해 파악/제어 편의 확보.

### 카테고리 (서버 코드 상수 매핑, DB 스키마 변경 없음)
- 📉 가격/환율 (\`--sejin\`) — 3키
- 💸 가계부 (\`--dasom\`) — 1키 + \`/budgets\` 링크
- 🕰️ 스케줄 (\`--sodam\`) — 2키
- 🧠 AI & 전략 (amber) — 4키 + \`/strategies\` 링크
- (fallback) 기타 — 알려지지 않은 키 자동 분류

### 신규 기능
- Summary strip: 전체 / 활성 (on) / 비활성 (off) / 카테고리 카운트
- 카테고리별 접힘/펼침 (기본 펼침)
- toggle 스위치: 즉시 PUT + 낙관적 UI + 실패 롤백
- 숫자형: 인라인 편집 (Enter 저장, Esc 취소, 단위 자동 표시)
- 관련 페이지 배지 링크

### API 확장
\`GET /api/alerts/config\` 응답에 \`category / inputType / description\` 첨부. 기존 \`PUT\` 은 그대로.

## Test plan
- [x] lint / typecheck / test (233, +11) / build 통과
- [x] 자체 코드 리뷰
- [ ] 실서비스 배포 후 카테고리별 렌더링 + toggle 즉시 반영 확인

## 디자인
\`docs/designs/396-alert-config-ui/prototype.html\`, \`design-notes.md\`

Closes #396

Parent: #395