### PR TITLE
[Phase 31-A] 커스텀 전략 v2 조건 확장 (시간/요일/보유) (#397)

### DIFF
--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -134,6 +134,14 @@ async function runScan(chatIds: number[]): Promise<void> {
   })
   const priceMap = new Map(prices.map((p) => [p.ticker, p]))
 
+  // 보유 티커 조회 — holding_status 조건 평가용 (Phase 31-A v2).
+  // shares > 0 만 홀딩으로 간주. 여러 계좌에서 같은 티커 보유해도 Set 이므로 중복 무관.
+  const holdingRows = await prisma.holding.findMany({
+    where: { shares: { gt: 0 } },
+    select: { ticker: true },
+  })
+  const holdings = new Set(holdingRows.map((h) => h.ticker))
+
   // TA 필요한 ticker 만 리포트 생성 (병렬 + 실패 허용)
   const taByTicker = new Map<string, TAReport | null>()
 
@@ -186,6 +194,7 @@ async function runScan(chatIds: number[]): Promise<void> {
       conds,
       s.logic === 'OR' ? 'OR' : 'AND',
       snapshot,
+      { now, holdings, strategyTicker: s.ticker },
     )
 
     if (!satisfied) continue

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateStrategy,
   requiresTA,
   type MarketSnapshot,
+  type EvaluationContext,
 } from '../evaluator'
 import type { Condition } from '../types'
 import type { TAReport } from '@/lib/ta/types'
@@ -12,6 +13,19 @@ function makeSnapshot(overrides?: Partial<MarketSnapshot>): MarketSnapshot {
   return {
     price: { price: 100, changePercent: 1.5 },
     ta: null,
+    ...overrides,
+  }
+}
+
+/**
+ * 기본 context — 2026-01-05 (월) 10:00 UTC = 2026-01-05 19:00 KST.
+ * 개별 테스트가 필요 시 오버라이드.
+ */
+function makeContext(overrides: Partial<EvaluationContext> = {}): EvaluationContext {
+  return {
+    now: new Date('2026-01-05T10:00:00Z'),
+    holdings: new Set<string>(),
+    strategyTicker: 'TEST',
     ...overrides,
   }
 }
@@ -49,15 +63,17 @@ function makeTAReport(overrides: Partial<TAReport> = {}): TAReport {
   return { ...base, ...overrides }
 }
 
-describe('evaluateCondition', () => {
+describe('evaluateCondition — v1', () => {
+  const ctx = makeContext()
+
   it('price < value satisfied', () => {
     const cond: Condition = { type: 'price', operator: '<', value: 200 }
-    expect(evaluateCondition(cond, makeSnapshot())).toBe(true)
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
   })
 
   it('price > value not satisfied when equal', () => {
     const cond: Condition = { type: 'price', operator: '>', value: 100 }
-    expect(evaluateCondition(cond, makeSnapshot())).toBe(false)
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
   })
 
   it('rsi <= value with TA report', () => {
@@ -68,12 +84,12 @@ describe('evaluateCondition', () => {
         rsi14: { value: 28, signal: 'OVERSOLD' },
       },
     })
-    expect(evaluateCondition(cond, makeSnapshot({ ta }))).toBe(true)
+    expect(evaluateCondition(cond, makeSnapshot({ ta }), ctx)).toBe(true)
   })
 
   it('rsi missing TA → false', () => {
     const cond: Condition = { type: 'rsi', operator: '<=', value: 30 }
-    expect(evaluateCondition(cond, makeSnapshot({ ta: null }))).toBe(false)
+    expect(evaluateCondition(cond, makeSnapshot({ ta: null }), ctx)).toBe(false)
   })
 
   it('macd_signal is GOLDEN', () => {
@@ -85,7 +101,7 @@ describe('evaluateCondition', () => {
         macd: { ...baseInd.macd, crossover: 'GOLDEN' },
       },
     })
-    expect(evaluateCondition(cond, makeSnapshot({ ta }))).toBe(true)
+    expect(evaluateCondition(cond, makeSnapshot({ ta }), ctx)).toBe(true)
   })
 
   it('sma_cross is GOLDEN — golden true', () => {
@@ -97,7 +113,7 @@ describe('evaluateCondition', () => {
         sma: { ...baseInd.sma, goldenCross: true },
       },
     })
-    expect(evaluateCondition(cond, makeSnapshot({ ta }))).toBe(true)
+    expect(evaluateCondition(cond, makeSnapshot({ ta }), ctx)).toBe(true)
   })
 
   it('bb_position is BELOW_LOWER', () => {
@@ -109,7 +125,7 @@ describe('evaluateCondition', () => {
         bollingerBands: { ...baseInd.bollingerBands, position: 'BELOW_LOWER' },
       },
     })
-    expect(evaluateCondition(cond, makeSnapshot({ ta }))).toBe(true)
+    expect(evaluateCondition(cond, makeSnapshot({ ta }), ctx)).toBe(true)
   })
 
   it('change_pct 5d 사용 → TA.change5d', () => {
@@ -117,7 +133,7 @@ describe('evaluateCondition', () => {
     const ta = makeTAReport({
       price: { ...makeTAReport().price, change5d: -12 },
     })
-    expect(evaluateCondition(cond, makeSnapshot({ ta }))).toBe(true)
+    expect(evaluateCondition(cond, makeSnapshot({ ta }), ctx)).toBe(true)
   })
 
   it('change_pct 1d fallback → priceCache.changePercent', () => {
@@ -125,30 +141,147 @@ describe('evaluateCondition', () => {
     const snap = makeSnapshot({
       price: { price: 100, changePercent: -6 },
     })
-    expect(evaluateCondition(cond, snap)).toBe(true)
+    expect(evaluateCondition(cond, snap, ctx)).toBe(true)
+  })
+})
+
+describe('evaluateCondition — v2 time_window', () => {
+  it('KST 정상 범위 내 (09:00~15:30, KST 12:00)', () => {
+    // 2026-01-05 03:00 UTC = 12:00 KST
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '09:00~15:30' }
+    const ctx = makeContext({ now: new Date('2026-01-05T03:00:00Z') })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('KST 정상 범위 밖 (09:00~15:30, KST 16:00)', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '09:00~15:30' }
+    const ctx = makeContext({ now: new Date('2026-01-05T07:00:00Z') }) // 16:00 KST
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('KST 정상 범위 경계 시작은 포함 (09:00~15:30, KST 09:00)', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '09:00~15:30' }
+    const ctx = makeContext({ now: new Date('2026-01-05T00:00:00Z') }) // 09:00 KST
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('KST 정상 범위 경계 끝은 제외 [half-open, 15:30 KST → false]', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '09:00~15:30' }
+    const ctx = makeContext({ now: new Date('2026-01-05T06:30:00Z') }) // 15:30 KST
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('KST wraparound 범위 (23:00~02:00, KST 00:30)', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '23:00~02:00' }
+    const ctx = makeContext({ now: new Date('2026-01-05T15:30:00Z') }) // 00:30 KST
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('KST wraparound 범위 밖 (23:00~02:00, KST 10:00)', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '23:00~02:00' }
+    const ctx = makeContext({ now: new Date('2026-01-05T01:00:00Z') }) // 10:00 KST
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('start == end → 항상 false (0-duration 방어)', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: '09:00~09:00' }
+    const ctx = makeContext({ now: new Date('2026-01-05T00:00:00Z') })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('잘못된 포맷 → false', () => {
+    const cond: Condition = { type: 'time_window', operator: 'is', value: 'noon' }
+    expect(evaluateCondition(cond, makeSnapshot(), makeContext())).toBe(false)
+  })
+})
+
+describe('evaluateCondition — v2 weekday', () => {
+  it('KST 월요일 매칭 (2026-01-05 은 월요일)', () => {
+    // 2026-01-05 UTC = 2026-01-05 KST (동일 date), 요일=MON
+    const cond: Condition = { type: 'weekday', operator: 'is', value: ['MON', 'TUE', 'WED', 'THU', 'FRI'] }
+    const ctx = makeContext({ now: new Date('2026-01-05T03:00:00Z') })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('KST 토요일 매칭 X (2026-01-05 월요일 리스트에 SAT 없음)', () => {
+    const cond: Condition = { type: 'weekday', operator: 'is', value: ['SAT', 'SUN'] }
+    const ctx = makeContext({ now: new Date('2026-01-05T03:00:00Z') })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('KST 요일 boundary — UTC 자정 근처의 KST 는 다음날', () => {
+    // 2026-01-04 20:00 UTC = 2026-01-05 05:00 KST → MON
+    const cond: Condition = { type: 'weekday', operator: 'is', value: ['MON'] }
+    const ctx = makeContext({ now: new Date('2026-01-04T20:00:00Z') })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('KST 요일 boundary — UTC 오후 → KST 다음날 새벽 → 요일 SUN 매칭', () => {
+    // 2026-01-03 22:00 UTC = 2026-01-04 07:00 KST → SUN (2026-01-04 은 일요일)
+    const cond: Condition = { type: 'weekday', operator: 'is', value: ['SUN'] }
+    const ctx = makeContext({ now: new Date('2026-01-03T22:00:00Z') })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+})
+
+describe('evaluateCondition — v2 holding_status', () => {
+  it('HELD — 보유 중 매칭', () => {
+    const cond: Condition = { type: 'holding_status', operator: 'is', value: 'HELD' }
+    const ctx = makeContext({ holdings: new Set(['SOXL']), strategyTicker: 'SOXL' })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('HELD — 미보유 시 false', () => {
+    const cond: Condition = { type: 'holding_status', operator: 'is', value: 'HELD' }
+    const ctx = makeContext({ holdings: new Set(['NVDA']), strategyTicker: 'SOXL' })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('NOT_HELD — 미보유 매칭', () => {
+    const cond: Condition = { type: 'holding_status', operator: 'is', value: 'NOT_HELD' }
+    const ctx = makeContext({ holdings: new Set(['NVDA']), strategyTicker: 'SOXL' })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('NOT_HELD — 보유 중 시 false', () => {
+    const cond: Condition = { type: 'holding_status', operator: 'is', value: 'NOT_HELD' }
+    const ctx = makeContext({ holdings: new Set(['SOXL']), strategyTicker: 'SOXL' })
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
   })
 })
 
 describe('evaluateStrategy', () => {
   const c1: Condition = { type: 'price', operator: '<=', value: 200 }
   const c2: Condition = { type: 'price', operator: '>=', value: 50 }
+  const ctx = makeContext()
 
   it('AND — 모두 만족', () => {
-    const res = evaluateStrategy([c1, c2], 'AND', makeSnapshot())
+    const res = evaluateStrategy([c1, c2], 'AND', makeSnapshot(), ctx)
     expect(res.satisfied).toBe(true)
     expect(res.perCondition).toHaveLength(2)
   })
 
   it('AND — 하나만 만족 → false', () => {
     const bad: Condition = { type: 'price', operator: '<', value: 50 }
-    const res = evaluateStrategy([c1, bad], 'AND', makeSnapshot())
+    const res = evaluateStrategy([c1, bad], 'AND', makeSnapshot(), ctx)
     expect(res.satisfied).toBe(false)
   })
 
   it('OR — 하나만 만족해도 true', () => {
     const bad: Condition = { type: 'price', operator: '<', value: 50 }
-    const res = evaluateStrategy([c1, bad], 'OR', makeSnapshot())
+    const res = evaluateStrategy([c1, bad], 'OR', makeSnapshot(), ctx)
     expect(res.satisfied).toBe(true)
+  })
+
+  it('v1 + v2 조건 혼합 (price + time_window 평일 장시간만)', () => {
+    const price: Condition = { type: 'price', operator: '<=', value: 200 }
+    const window: Condition = { type: 'time_window', operator: 'is', value: '09:00~15:30' }
+    // KST 12:00 (2026-01-05 03:00 UTC)
+    const c = makeContext({ now: new Date('2026-01-05T03:00:00Z') })
+    expect(evaluateStrategy([price, window], 'AND', makeSnapshot(), c).satisfied).toBe(true)
+    // 장 종료 후: KST 16:00 (07:00 UTC)
+    const c2 = makeContext({ now: new Date('2026-01-05T07:00:00Z') })
+    expect(evaluateStrategy([price, window], 'AND', makeSnapshot(), c2).satisfied).toBe(false)
   })
 })
 
@@ -167,5 +300,11 @@ describe('requiresTA', () => {
 
   it('rsi → true', () => {
     expect(requiresTA([{ type: 'rsi', operator: '<=', value: 30 }])).toBe(true)
+  })
+
+  it('v2 조건들 (time_window / weekday / holding_status) → TA 불필요', () => {
+    expect(requiresTA([{ type: 'time_window', operator: 'is', value: '09:00~15:30' }])).toBe(false)
+    expect(requiresTA([{ type: 'weekday', operator: 'is', value: ['MON'] }])).toBe(false)
+    expect(requiresTA([{ type: 'holding_status', operator: 'is', value: 'HELD' }])).toBe(false)
   })
 })

--- a/src/lib/custom-strategy/__tests__/types.test.ts
+++ b/src/lib/custom-strategy/__tests__/types.test.ts
@@ -63,6 +63,62 @@ describe('validateCondition', () => {
   it('NaN value → 무효', () => {
     expect(validateCondition({ type: 'price', operator: '<', value: NaN })).toBe(false)
   })
+
+  // ── v2 (Phase 31-A) —
+  describe('time_window (v2)', () => {
+    it('유효한 HH:MM~HH:MM', () => {
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '09:00~15:30' })).toBe(true)
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '23:00~02:00' })).toBe(true)
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '00:00~23:59' })).toBe(true)
+    })
+    it('range 밖 시각 → 무효', () => {
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '24:00~05:00' })).toBe(false)
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '09:60~10:00' })).toBe(false)
+    })
+    it('잘못된 포맷 → 무효', () => {
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '9:00~15:00' })).toBe(false)
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '09:00-15:00' })).toBe(false)
+      expect(validateCondition({ type: 'time_window', operator: 'is', value: '오전 9시' })).toBe(false)
+    })
+    it('operator 가 is 아니면 무효', () => {
+      expect(validateCondition({ type: 'time_window', operator: '<', value: '09:00~15:00' })).toBe(false)
+    })
+  })
+
+  describe('weekday (v2)', () => {
+    it('유효한 요일 배열', () => {
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: ['MON', 'TUE', 'WED', 'THU', 'FRI'] })).toBe(true)
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: ['SAT'] })).toBe(true)
+    })
+    it('빈 배열 → 무효 (의미 없음)', () => {
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: [] })).toBe(false)
+    })
+    it('알 수 없는 요일 코드 → 무효', () => {
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: ['MON', 'MONDAY'] })).toBe(false)
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: ['mon'] })).toBe(false)
+    })
+    it('중복 요일 → 무효 (정규화 요구)', () => {
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: ['MON', 'MON'] })).toBe(false)
+    })
+    it('문자열/숫자 값 → 무효', () => {
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: 'MON' })).toBe(false)
+      expect(validateCondition({ type: 'weekday', operator: 'is', value: 1 })).toBe(false)
+    })
+  })
+
+  describe('holding_status (v2)', () => {
+    it('HELD / NOT_HELD 유효', () => {
+      expect(validateCondition({ type: 'holding_status', operator: 'is', value: 'HELD' })).toBe(true)
+      expect(validateCondition({ type: 'holding_status', operator: 'is', value: 'NOT_HELD' })).toBe(true)
+    })
+    it('기타 값 → 무효', () => {
+      expect(validateCondition({ type: 'holding_status', operator: 'is', value: 'held' })).toBe(false)
+      expect(validateCondition({ type: 'holding_status', operator: 'is', value: 'OWNED' })).toBe(false)
+    })
+    it('operator 가 is 아니면 무효', () => {
+      expect(validateCondition({ type: 'holding_status', operator: '<', value: 'HELD' })).toBe(false)
+    })
+  })
 })
 
 describe('validateParsedStrategy', () => {
@@ -126,5 +182,23 @@ describe('conditionToString', () => {
     expect(
       conditionToString({ type: 'change_pct', operator: '<', value: -5, timeframe: '5d' }),
     ).toBe('change_pct(5d) < -5')
+  })
+
+  it('weekday 는 배열을 [MON,FRI] 형태로 표시', () => {
+    expect(
+      conditionToString({ type: 'weekday', operator: 'is', value: ['MON', 'FRI'] }),
+    ).toBe('weekday is [MON,FRI]')
+  })
+
+  it('time_window 문자열 그대로', () => {
+    expect(
+      conditionToString({ type: 'time_window', operator: 'is', value: '09:00~15:30' }),
+    ).toBe('time_window is 09:00~15:30')
+  })
+
+  it('holding_status', () => {
+    expect(
+      conditionToString({ type: 'holding_status', operator: 'is', value: 'HELD' }),
+    ).toBe('holding_status is HELD')
   })
 })

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -1,14 +1,19 @@
 /**
  * Custom strategy condition evaluator — 순수 코드 평가 (매번 AI 호출 X).
  *
+ * v1 (Phase 29-E): price/rsi/macd_signal/sma_cross/bb_position/change_pct
+ * v2 (Phase 31-A): time_window/weekday/holding_status
+ *
  * 입력:
  *   - Condition[]: 사용자 정의 조건 (parser 로 자연어 파싱된 결과)
  *   - MarketSnapshot: priceCache + (필요 시) TAReport
+ *   - EvaluationContext: 시각 + 보유 티커 (v2 조건 대비)
  *
  * 출력: 각 조건 만족 여부 boolean[] → logic (AND/OR) 결합 → 최종 만족 여부
  */
 
-import type { Condition } from './types'
+import type { Condition, WeekdayCode } from './types'
+import { TIME_WINDOW_RE } from './types'
 import type { TAReport } from '@/lib/ta/types'
 
 export interface PriceSnapshot {
@@ -21,6 +26,19 @@ export interface MarketSnapshot {
   ta: TAReport | null
 }
 
+/**
+ * v2 조건 평가에 필요한 런타임 컨텍스트.
+ * 호출자 (custom-strategy-alert.ts) 가 준비해서 주입.
+ */
+export interface EvaluationContext {
+  /** 평가 시각 (UTC Date). KST 변환은 evaluator 내부에서 처리 */
+  now: Date
+  /** 사용자가 실제 보유 중인 티커 (shares > 0). holding_status 판정용 */
+  holdings: Set<string>
+  /** 평가 대상 티커 — holding_status 판정용 (Strategy.ticker 주입) */
+  strategyTicker: string
+}
+
 /** 지원 조건 타입 중 TA 필요 여부 판단 — 평가 전에 TAReport fetch 여부 결정 */
 export function requiresTA(conditions: Condition[]): boolean {
   return conditions.some((c) =>
@@ -29,6 +47,7 @@ export function requiresTA(conditions: Condition[]): boolean {
     c.type === 'sma_cross' ||
     c.type === 'bb_position' ||
     (c.type === 'change_pct' && c.timeframe !== '1d') // 1d 는 priceCache 로 충분
+    // v2 (time_window/weekday/holding_status) 는 TA 불필요
   )
 }
 
@@ -43,8 +62,40 @@ function compareNumeric(actual: number, op: string, expected: number): boolean {
   }
 }
 
-/** 단일 Condition 평가. 데이터 부족 시 false (안전 default). */
-export function evaluateCondition(cond: Condition, snapshot: MarketSnapshot): boolean {
+/** UTC Date → KST 시각 (분 단위 0~1439) */
+function kstMinutes(now: Date): number {
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
+  return kst.getUTCHours() * 60 + kst.getUTCMinutes()
+}
+
+/** UTC Date → KST 요일 코드 */
+function kstWeekday(now: Date): WeekdayCode {
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
+  const dow = kst.getUTCDay() // 0=Sun, 1=Mon, ...
+  const codes: WeekdayCode[] = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+  return codes[dow]
+}
+
+/** "HH:MM~HH:MM" 파싱 → 분 단위 [start, end]. wraparound (end < start) 도 허용. */
+function parseTimeWindow(value: string): { start: number; end: number } | null {
+  const m = value.match(TIME_WINDOW_RE)
+  if (!m) return null
+  const [, sh, sm, eh, em] = m
+  return {
+    start: parseInt(sh, 10) * 60 + parseInt(sm, 10),
+    end: parseInt(eh, 10) * 60 + parseInt(em, 10),
+  }
+}
+
+/**
+ * 단일 Condition 평가. 데이터 부족 시 false (안전 default).
+ * context 는 v2 조건 (time_window/weekday/holding_status) 평가용.
+ */
+export function evaluateCondition(
+  cond: Condition,
+  snapshot: MarketSnapshot,
+  context: EvaluationContext,
+): boolean {
   switch (cond.type) {
     case 'price': {
       const price = snapshot.price?.price
@@ -86,6 +137,32 @@ export function evaluateCondition(cond: Condition, snapshot: MarketSnapshot): bo
       if (pct == null) return false
       return compareNumeric(pct, cond.operator, cond.value)
     }
+    // ── v2 —
+    case 'time_window': {
+      if (cond.operator !== 'is' || typeof cond.value !== 'string') return false
+      const parsed = parseTimeWindow(cond.value)
+      if (!parsed) return false
+      const nowMin = kstMinutes(context.now)
+      const { start, end } = parsed
+      // start == end 는 순간만 true — 실무상 무의미. 사용자 편의로 항상 false 로 처리.
+      if (start === end) return false
+      // wraparound (예: 23:00~02:00): start ~ 24:00 또는 00:00 ~ end
+      if (start > end) return nowMin >= start || nowMin < end
+      // 정상 (예: 09:00~15:30): [start, end)
+      return nowMin >= start && nowMin < end
+    }
+    case 'weekday': {
+      if (cond.operator !== 'is' || !Array.isArray(cond.value)) return false
+      const today = kstWeekday(context.now)
+      return (cond.value as WeekdayCode[]).includes(today)
+    }
+    case 'holding_status': {
+      if (cond.operator !== 'is' || typeof cond.value !== 'string') return false
+      const isHeld = context.holdings.has(context.strategyTicker)
+      if (cond.value === 'HELD') return isHeld
+      if (cond.value === 'NOT_HELD') return !isHeld
+      return false
+    }
     default:
       return false
   }
@@ -100,10 +177,11 @@ export function evaluateStrategy(
   conditions: Condition[],
   logic: 'AND' | 'OR',
   snapshot: MarketSnapshot,
+  context: EvaluationContext,
 ): EvaluationResult {
   const perCondition = conditions.map((c) => ({
     condition: c,
-    result: evaluateCondition(c, snapshot),
+    result: evaluateCondition(c, snapshot, context),
   }))
   const results = perCondition.map((p) => p.result)
   const satisfied = logic === 'AND' ? results.every(Boolean) : results.some(Boolean)

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -13,7 +13,7 @@ import { validateParsedStrategy, type ParsedStrategy } from './types'
 const PROMPT_HEADER = `
 사용자 입력을 아래 JSON schema 로 정확히 파싱해줘. 오직 JSON 오브젝트만 출력 — 다른 설명/코드블록 없이.
 
-## 지원 조건 타입
+## 지원 조건 타입 (v1)
 - price (숫자, ticker 현재가)
 - rsi (숫자, RSI14 값)
 - macd_signal (문자열, "GOLDEN" 또는 "DEAD")
@@ -21,9 +21,14 @@ const PROMPT_HEADER = `
 - bb_position (문자열, "BELOW_LOWER" 또는 "ABOVE_UPPER")
 - change_pct (숫자, timeframe 필수 — "1d" | "5d" | "20d")
 
+## 지원 조건 타입 (v2 — 시간/보유 필터)
+- time_window (문자열 "HH:MM~HH:MM", KST 24h. 자정 wraparound 허용 — 예 "23:00~02:00")
+- weekday (배열, 요일 코드 ["MON","TUE","WED","THU","FRI","SAT","SUN"] 중 부분집합)
+- holding_status (문자열, "HELD" 또는 "NOT_HELD" — 사용자가 해당 ticker 보유 여부)
+
 ## 연산자
 - 숫자 타입: < <= > >= ==
-- 문자열 타입: is (전용)
+- 문자열/배열 타입: is (전용)
 
 ## logic (AND | OR)
 ## frequency (once | daily | always)
@@ -40,10 +45,28 @@ const PROMPT_HEADER = `
   "frequency": "daily"
 }
 
+## v2 예시
+- "SOXL 40달러 이하 시 알림, 단 미국장 시간대 (KST 22:30~05:00) 에만" →
+  {"conditions": [
+    {"type":"price","operator":"<=","value":40},
+    {"type":"time_window","operator":"is","value":"22:30~05:00"}
+  ], "logic":"AND"}
+- "NVDA MACD 골든크로스 시 알림 (평일만)" →
+  {"conditions": [
+    {"type":"macd_signal","operator":"is","value":"GOLDEN"},
+    {"type":"weekday","operator":"is","value":["MON","TUE","WED","THU","FRI"]}
+  ], "logic":"AND"}
+- "TSLA 볼밴 하단 이탈 시 알림 (보유 중일 때만)" →
+  {"conditions": [
+    {"type":"bb_position","operator":"is","value":"BELOW_LOWER"},
+    {"type":"holding_status","operator":"is","value":"HELD"}
+  ], "logic":"AND"}
+
 ## 규칙
 - 지원 타입 외 조건 요구되면 { "error": "지원 안함: ..." } 로만 응답
-- 뉴스/펀더멘털/시간 조건은 미지원
+- 뉴스/펀더멘털/어닝/크로스-티커 조건은 미지원 (지원 타입 외 로 처리)
 - ticker 알 수 없으면 { "error": "ticker 를 명확히 지정해주세요" }
+- 사용자가 시간대를 "미국장" / "한국장" 등으로 지칭하면 KST 로 환산 (미국장 = 대략 22:30~05:00 KST DST 무관 단순화, 한국장 = 09:00~15:30)
 
 ## 사용자 입력
 `

--- a/src/lib/custom-strategy/types.ts
+++ b/src/lib/custom-strategy/types.ts
@@ -1,27 +1,36 @@
 /**
  * Phase 29-E — 커스텀 전략 조건 스펙.
+ * Phase 31-A (v2) — 시간/요일/보유 필터 추가.
  *
  * 사용자 자연어 → AI 파싱 → Condition[] JSON 으로 CustomStrategy.conditions 저장.
  * cron 이 evaluator 로 순수 코드 평가 (매번 AI 호출 X).
  */
 
 export type ConditionType =
-  | 'price'         // 현재가
-  | 'rsi'           // RSI14 값
-  | 'macd_signal'   // MACD crossover
-  | 'sma_cross'     // SMA golden/dead cross
-  | 'bb_position'   // Bollinger Bands position
-  | 'change_pct'    // 기간 변동 %
+  | 'price'           // 현재가
+  | 'rsi'             // RSI14 값
+  | 'macd_signal'     // MACD crossover
+  | 'sma_cross'       // SMA golden/dead cross
+  | 'bb_position'     // Bollinger Bands position
+  | 'change_pct'      // 기간 변동 %
+  // v2 additions —
+  | 'time_window'     // KST 시각 범위 필터 (HH:MM~HH:MM)
+  | 'weekday'         // KST 요일 필터 (MON/TUE/…)
+  | 'holding_status'  // 사용자 보유 여부
 
 export type Operator = '<' | '<=' | '>' | '>=' | '==' | 'is'
 
 /** timeframe 지원 조건 타입 (change_pct 전용) */
 export type Timeframe = '1d' | '5d' | '20d'
 
+/** 요일 코드 (KST 기준) */
+export type WeekdayCode = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN'
+
 export interface Condition {
   type: ConditionType
   operator: Operator
-  value: number | string
+  /** number (수치 조건) | string (단일 상태) | WeekdayCode[] (weekday 배열) */
+  value: number | string | WeekdayCode[]
   timeframe?: Timeframe
 }
 
@@ -37,15 +46,22 @@ export interface ParsedStrategy {
   frequency: Frequency
 }
 
-/** 지원 문자열 값 (macd_signal, sma_cross, bb_position 등) */
+/** 지원 문자열 값 (macd_signal, sma_cross, bb_position, holding_status) */
 export const ALLOWED_STRING_VALUES = {
   macd_signal: ['GOLDEN', 'DEAD'] as const,
   sma_cross: ['GOLDEN', 'DEAD'] as const,
   bb_position: ['BELOW_LOWER', 'ABOVE_UPPER'] as const,
+  holding_status: ['HELD', 'NOT_HELD'] as const,
 } as const
 
+export const VALID_WEEKDAYS: readonly WeekdayCode[] = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+const VALID_WEEKDAYS_SET = new Set<WeekdayCode>(VALID_WEEKDAYS)
+
+/** HH:MM~HH:MM 포맷 (00~23:00~59). 자정 wraparound 는 evaluator 가 판정. */
+export const TIME_WINDOW_RE = /^([01]\d|2[0-3]):([0-5]\d)~([01]\d|2[0-3]):([0-5]\d)$/
+
 const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct'])
-const STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position'])
+const SINGLE_STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position', 'holding_status'])
 const NUMERIC_OPS = new Set<Operator>(['<', '<=', '>', '>=', '=='])
 const IS_OP: Operator = 'is'
 
@@ -54,6 +70,7 @@ const VALID_FREQUENCY = new Set<Frequency>(['once', 'daily', 'always'])
 const VALID_TIMEFRAMES = new Set<Timeframe>(['1d', '5d', '20d'])
 const VALID_TYPES = new Set<ConditionType>([
   'price', 'rsi', 'macd_signal', 'sma_cross', 'bb_position', 'change_pct',
+  'time_window', 'weekday', 'holding_status',
 ])
 
 /** Condition 유효성 검증 — evaluator 진입 전 방어 */
@@ -74,11 +91,31 @@ export function validateCondition(c: unknown): c is Condition {
     return true
   }
 
-  if (STRING_TYPES.has(type)) {
+  if (SINGLE_STRING_TYPES.has(type)) {
     if (cond.operator !== IS_OP) return false
     if (typeof cond.value !== 'string') return false
     const allowed = ALLOWED_STRING_VALUES[type as keyof typeof ALLOWED_STRING_VALUES] as readonly string[]
     return allowed.includes(cond.value)
+  }
+
+  if (type === 'time_window') {
+    if (cond.operator !== IS_OP) return false
+    if (typeof cond.value !== 'string') return false
+    return TIME_WINDOW_RE.test(cond.value)
+  }
+
+  if (type === 'weekday') {
+    if (cond.operator !== IS_OP) return false
+    if (!Array.isArray(cond.value) || cond.value.length === 0) return false
+    // 중복 허용하지 않음 → 집합 크기 == 배열 길이. 모두 유효한 코드여야.
+    const seen = new Set<string>()
+    for (const v of cond.value) {
+      if (typeof v !== 'string') return false
+      if (!VALID_WEEKDAYS_SET.has(v as WeekdayCode)) return false
+      if (seen.has(v)) return false
+      seen.add(v)
+    }
+    return true
   }
 
   return false
@@ -97,5 +134,8 @@ export function validateParsedStrategy(p: unknown): p is ParsedStrategy {
 
 export function conditionToString(c: Condition): string {
   const timeframe = c.timeframe ? `(${c.timeframe})` : ''
+  if (c.type === 'weekday' && Array.isArray(c.value)) {
+    return `weekday ${c.operator} [${c.value.join(',')}]`
+  }
   return `${c.type}${timeframe} ${c.operator} ${c.value}`
 }


### PR DESCRIPTION
## Summary
커스텀 전략 조건 프레임워크에 시간·요일·보유 필터 3종 추가.

### 신규 조건 타입
- \`time_window\` — KST 시각 범위 필터 (\`HH:MM~HH:MM\`, 자정 wraparound 허용)
- \`weekday\` — KST 요일 배열 필터 (\`["MON","TUE",...]\`)
- \`holding_status\` — 사용자 보유 여부 (\`HELD\` / \`NOT_HELD\`)

### 자연어 예시 (파서 프롬프트 반영)
- "SOXL 40달러 이하 시 알림, 단 미국장 시간대 (KST 22:30~05:00) 에만"
- "NVDA MACD 골든크로스 시 알림 (평일만)"
- "TSLA 볼밴 하단 이탈 시 알림 (보유 중일 때만)"

### 호환성
기존 저장된 v1 조건은 그대로 유효 — v2 는 순수 addition (validateCondition 기존 케이스 무변경).

### 인프라
- \`EvaluationContext { now, holdings, strategyTicker }\` 신규 — 알림 스캔 시 \`prisma.holding.findMany({shares: {gt: 0}})\` 로 holdings Set 1회 조회 후 주입
- KST 변환 (kstMinutes / kstWeekday), wraparound (start > end 시 [start,24) ∪ [0,end)), start == end → false (0-duration 방어)

## 사전 리뷰
\`pr-review-toolkit:code-reviewer\` 에이전트 결과: **P0/P1/P2: 0건 통과** (workflow 룰 8-1).

## Test plan
- [x] lint / typecheck / test (267, +33) / build 통과
- [x] 사전 에이전트 리뷰 통과 (P0/P1/P2: 0)
- [ ] 실서비스 배포 후 봇 \`/커스텀전략등록 SOXL 40달러 이하, 미국장 시간에만\` e2e

Closes #397

Parent: #395