### PR TITLE
feat(alert): AlertHistory 모델 + 발동 hook (Phase 33-A, #416)

### DIFF
--- a/docs/specs/416-alert-history.md
+++ b/docs/specs/416-alert-history.md
@@ -1,0 +1,99 @@
+# [Phase 33-A] AlertHistory 모델 + 발동 hook
+
+- **이슈**: #416
+- **마스터**: #414
+- **작성일**: 2026-07-08
+
+## 목표
+
+모든 알림 발동을 DB 에 저장 → 33-B 이력 페이지 + 사후 진단 (예: 재현 이슈) 데이터 소스.
+
+## 스키마
+
+```prisma
+model AlertHistory {
+  id             String   @id @default(cuid())
+  firedAt        DateTime @default(now())
+  kind           String   // surge / drop / fx / target_hit / stop_loss / watch_buy / watch_zone / ta_signal / custom_strategy
+  ticker         String?  // null 허용 (환율 등)
+  price          Float?
+  changePercent  Float?
+  message        String   // 발송 본문 (per-event HTML)
+  deliveryStatus String   // 'sent' | 'partial' | 'failed'
+  recipientCount Int      @default(0)
+  errorMessage   String?
+
+  @@index([firedAt])
+  @@index([kind, firedAt])
+  @@index([ticker, firedAt])
+}
+```
+
+- **1 행 = 1 이벤트** (한 번의 텔레그램 발송에 여러 이벤트가 들어가면 여러 행 저장)
+- `deliveryStatus` 는 배치 발송 결과 요약 (chatIds 전원 성공 = sent, 일부 = partial, 전원 실패 = failed)
+- `errorMessage` 는 실패 시 마지막 예외 (진단용)
+
+## Helper — `src/bot/notifications/alert-history.ts`
+
+- `type AlertKind = ...`
+- `type DeliveryStatus = 'sent' | 'partial' | 'failed'`
+- `computeDeliveryStatus(successCount, total)` — pure
+- `recordAlertHistory(events, deliveryStatus, recipientCount, errorMessage?)` — Prisma createMany. 실패는 로그만.
+
+## Hook 지점
+
+기존 알림 스캐너 3곳 각각 이벤트 수집 후 저장:
+
+### `price-alert.ts`
+- 급등 → `surge`
+- 급락 → `drop`
+- 환율 → `fx`
+- 보유종목 목표가 도달 → `target_hit`
+- 보유종목 손절가 도달 → `stop_loss`
+- 관심종목 목표매수가 → `watch_buy`
+- 관심종목 매수구간 진입 → `watch_zone`
+
+문자열 `alerts.push(...)` 대신 구조체 `events.push({ kind, ticker, price, changePercent, message })` 로 변경. 배치 발송 후 `recordAlertHistory` 호출.
+
+### `ta-signal-alert.ts`
+- `ta_signal` — 한 티커의 여러 signal 을 하나의 event 로 통합 (`signals.join(', ')` 을 message 로)
+- 발송 성공 후 저장
+
+### `custom-strategy-alert.ts`
+- `custom_strategy` — 한 전략 발동 = 한 이벤트
+- 발송 성공 후 저장
+
+## MCP tool — `src/mcp/tools/alert-history.ts`
+
+```
+list_alert_history(kind?, ticker?, from?, to?, limit?)
+```
+
+- `kind`: 필터 (미지정 시 전체)
+- `ticker`: 필터
+- `from` / `to`: ISO 8601 문자열
+- `limit`: 기본 50, 최대 200
+- 결과: markdown 리스트 (시각 / 종류 / 종목 / 메시지 요약 / 배송 상태)
+
+`src/mcp/server.ts` 에 tool 등록.
+
+## 테스트
+
+- `alert-history.test.ts`:
+  - `computeDeliveryStatus` — total=0 → failed, 전원 성공 → sent, 전원 실패 → failed, 일부 성공 → partial
+  - `recordAlertHistory` — 빈 events 는 no-op
+- `price-alert-history-integration.test.ts` — pure 부분만 (event 수집 로직 refactor 후)
+- `mcp/tools/alert-history.test.ts` — 필터 조합 검증 (prisma mock)
+
+## 완료 조건
+
+- [ ] Prisma migration 생성 + 적용
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] MCP tool 텔레그램 AI 에서 호출 성공 (배포 후 검증)
+
+## 제외 사항
+
+- 33-B 이력 페이지 UI — 별도 이슈 (#417)
+- 알림 자체 로직 변경 — 순수 관측/저장만 추가
+- 33-D 이전 발동은 복원 불가 (마이그레이션 시점부터 축적)

--- a/prisma/migrations/20260708022825_add_alert_history/migration.sql
+++ b/prisma/migrations/20260708022825_add_alert_history/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "AlertHistory" (
+    "id" TEXT NOT NULL,
+    "firedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "kind" TEXT NOT NULL,
+    "ticker" TEXT,
+    "price" DOUBLE PRECISION,
+    "changePercent" DOUBLE PRECISION,
+    "message" TEXT NOT NULL,
+    "deliveryStatus" TEXT NOT NULL,
+    "recipientCount" INTEGER NOT NULL DEFAULT 0,
+    "errorMessage" TEXT,
+
+    CONSTRAINT "AlertHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AlertHistory_firedAt_idx" ON "AlertHistory"("firedAt");
+
+-- CreateIndex
+CREATE INDEX "AlertHistory_kind_firedAt_idx" ON "AlertHistory"("kind", "firedAt");
+
+-- CreateIndex
+CREATE INDEX "AlertHistory_ticker_firedAt_idx" ON "AlertHistory"("ticker", "firedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -327,6 +327,25 @@ model AlertConfig {
   updatedAt DateTime @updatedAt
 }
 
+// Phase 33-A (#416): 알림 발동 이력. 33-B 이력 페이지 + 사후 진단 데이터 소스.
+// 1 행 = 1 이벤트. 한 번의 텔레그램 배치 발송에 여러 알림이 포함되면 여러 행 저장.
+model AlertHistory {
+  id             String   @id @default(cuid())
+  firedAt        DateTime @default(now())
+  kind           String   // surge / drop / fx / target_hit / stop_loss / watch_buy / watch_zone / ta_signal / custom_strategy
+  ticker         String?  // 환율 등 티커 없는 알림은 null
+  price          Float?
+  changePercent  Float?
+  message        String   // per-event HTML 본문
+  deliveryStatus String   // 'sent' | 'partial' | 'failed'
+  recipientCount Int      @default(0)
+  errorMessage   String?
+
+  @@index([firedAt])
+  @@index([kind, firedAt])
+  @@index([ticker, firedAt])
+}
+
 model Asset {
   id           String    @id @default(cuid())
   name         String                         // "신한 적금", "전세 보증금"

--- a/src/bot/notifications/__tests__/alert-history.test.ts
+++ b/src/bot/notifications/__tests__/alert-history.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { computeDeliveryStatus, recordAlertHistory } from '../alert-history'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      createMany: vi.fn(),
+    },
+  },
+}))
+
+describe('computeDeliveryStatus', () => {
+  it('total <= 0 → failed (수신자 없는 이벤트는 실질 미발송)', () => {
+    expect(computeDeliveryStatus(0, 0)).toBe('failed')
+    expect(computeDeliveryStatus(0, -1)).toBe('failed')
+  })
+
+  it('전원 성공 → sent', () => {
+    expect(computeDeliveryStatus(3, 3)).toBe('sent')
+  })
+
+  it('전원 실패 → failed', () => {
+    expect(computeDeliveryStatus(0, 3)).toBe('failed')
+  })
+
+  it('일부 성공 → partial', () => {
+    expect(computeDeliveryStatus(1, 3)).toBe('partial')
+    expect(computeDeliveryStatus(2, 3)).toBe('partial')
+  })
+
+  it('successCount > total 도 sent (방어)', () => {
+    // 상위 로직이 잘못 세어도 최소 sent 판정 유지
+    expect(computeDeliveryStatus(5, 3)).toBe('sent')
+  })
+})
+
+describe('recordAlertHistory', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockReset()
+  })
+
+  it('빈 events 는 no-op (createMany 호출 없음)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    await recordAlertHistory([], 'sent', 0)
+    expect(prisma.alertHistory.createMany).not.toHaveBeenCalled()
+  })
+
+  it('event 들을 kind/ticker/message 그대로 매핑하여 createMany 호출', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 2 } as never)
+
+    await recordAlertHistory(
+      [
+        { kind: 'drop', ticker: 'AAPL', price: 150, changePercent: -6.2, message: '🔴 AAPL 급락' },
+        { kind: 'fx', ticker: 'USDKRW=X', price: 1330, message: '💱 환율 상승' },
+      ],
+      'sent',
+      2,
+    )
+
+    expect(prisma.alertHistory.createMany).toHaveBeenCalledTimes(1)
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data).toHaveLength(2)
+    expect(data[0]).toMatchObject({
+      kind: 'drop', ticker: 'AAPL', price: 150, changePercent: -6.2,
+      message: '🔴 AAPL 급락', deliveryStatus: 'sent', recipientCount: 2,
+    })
+    expect(data[1]).toMatchObject({
+      kind: 'fx', ticker: 'USDKRW=X', price: 1330,
+      message: '💱 환율 상승', deliveryStatus: 'sent', recipientCount: 2,
+    })
+  })
+
+  it('선택 필드 미지정 시 null 로 저장', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    await recordAlertHistory(
+      [{ kind: 'ta_signal', message: '📊 시그널' }],
+      'partial',
+      3,
+      '네트워크 오류',
+    )
+
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0]).toMatchObject({
+      kind: 'ta_signal', ticker: null, price: null, changePercent: null,
+      deliveryStatus: 'partial', recipientCount: 3, errorMessage: '네트워크 오류',
+    })
+  })
+
+  it('Prisma 실패는 삼키고 예외 전파 X (알림 흐름 유지)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockRejectedValueOnce(new Error('DB down'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      recordAlertHistory([{ kind: 'surge', message: 'x' }], 'sent', 1),
+    ).resolves.toBeUndefined()
+
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+})

--- a/src/bot/notifications/alert-history.ts
+++ b/src/bot/notifications/alert-history.ts
@@ -1,0 +1,73 @@
+/**
+ * Phase 33-A (#416) — 알림 발동 이력 저장.
+ *
+ * 각 알림 스캐너 (price-alert / ta-signal-alert / custom-strategy-alert) 에서
+ * 이벤트 수집 후 배치 발송 → 결과와 함께 이 헬퍼로 저장.
+ * 저장 실패는 로그만 (알림 자체 흐름에 영향 X).
+ */
+
+import { prisma } from '@/lib/prisma'
+
+export type AlertKind =
+  | 'surge'
+  | 'drop'
+  | 'fx'
+  | 'target_hit'
+  | 'stop_loss'
+  | 'watch_buy'
+  | 'watch_zone'
+  | 'ta_signal'
+  | 'custom_strategy'
+
+export type DeliveryStatus = 'sent' | 'partial' | 'failed'
+
+export interface AlertEventInput {
+  kind: AlertKind
+  ticker?: string | null
+  price?: number | null
+  changePercent?: number | null
+  message: string
+}
+
+/**
+ * 배치 발송 성공 카운트로부터 deliveryStatus 산출 (pure).
+ *   total=0  → failed (수신자 없는 이벤트는 실질 미발송)
+ *   all      → sent
+ *   none     → failed
+ *   partial  → partial
+ */
+export function computeDeliveryStatus(successCount: number, total: number): DeliveryStatus {
+  if (total <= 0) return 'failed'
+  if (successCount >= total) return 'sent'
+  if (successCount <= 0) return 'failed'
+  return 'partial'
+}
+
+/**
+ * events 를 AlertHistory 로 일괄 저장. 빈 배열이면 no-op.
+ * Prisma 실패는 삼키고 로그만 — 알림 흐름 유지 우선.
+ */
+export async function recordAlertHistory(
+  events: AlertEventInput[],
+  deliveryStatus: DeliveryStatus,
+  recipientCount: number,
+  errorMessage?: string,
+): Promise<void> {
+  if (events.length === 0) return
+  try {
+    await prisma.alertHistory.createMany({
+      data: events.map((e) => ({
+        kind: e.kind,
+        ticker: e.ticker ?? null,
+        price: e.price ?? null,
+        changePercent: e.changePercent ?? null,
+        message: e.message,
+        deliveryStatus,
+        recipientCount,
+        errorMessage: errorMessage ?? null,
+      })),
+    })
+  } catch (error) {
+    console.error('[alert-history] 저장 실패:', error)
+  }
+}

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -16,6 +16,11 @@ import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { generateTAReport } from '@/lib/ta/engine'
 import type { TAReport } from '@/lib/ta/types'
 import {
+  computeDeliveryStatus,
+  recordAlertHistory,
+  type AlertEventInput,
+} from './alert-history'
+import {
   evaluateStrategy,
   requiresTA,
   type MarketSnapshot,
@@ -168,6 +173,7 @@ async function runScan(chatIds: number[]): Promise<void> {
 
   const now = new Date()
   const alerts: string[] = []
+  const historyEvents: AlertEventInput[] = []
   const firedIds: string[] = []
   const disableIds: string[] = [] // frequency=once + 발동 → 자동 비활성화
 
@@ -210,11 +216,19 @@ async function runScan(chatIds: number[]): Promise<void> {
       ? `${priceRow.price.toLocaleString('ko-KR')} ${priceRow.currency}`
       : '(가격 미확인)'
 
-    alerts.push(
+    const alertBlock =
       `🎯 <b>${escapeHtml(s.name)}</b> (${escapeHtml(s.ticker)})\n` +
-        `현재가: ${escapeHtml(priceLabel)}\n` +
-        `${escapeHtml('조건 (' + s.logic + ') 만족:')}\n${escapeHtml(condLines)}`,
-    )
+      `현재가: ${escapeHtml(priceLabel)}\n` +
+      `${escapeHtml('조건 (' + s.logic + ') 만족:')}\n${escapeHtml(condLines)}`
+    alerts.push(alertBlock)
+
+    // 이력용 — HTML 태그 없이 이력 페이지에서 보기 편한 요약.
+    historyEvents.push({
+      kind: 'custom_strategy',
+      ticker: s.ticker,
+      price: priceRow?.price ?? null,
+      message: `${s.name} (${s.ticker}) — ${s.logic} 조건 만족`,
+    })
   }
 
   if (alerts.length === 0) return
@@ -222,14 +236,20 @@ async function runScan(chatIds: number[]): Promise<void> {
   // 최소 1개 chatId 에 발송 성공한 뒤에만 DB 상태 갱신 — 실패 시 다음 tick 에서 재시도.
   const message = `🧠 <b>커스텀 전략 발동</b> (${todayKST()})\n\n${alerts.join('\n\n')}`
   let sentCount = 0
+  let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
       await sendHtml(bot, chatId, message)
       sentCount++
     } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
       console.error(`[custom-strategy] 알림 발송 실패 (chatId: ${chatId}):`, error)
     }
   }
+
+  // Phase 33-A (#416): 발동 이력 저장 (발송 성공 여부와 무관 — 실패도 partial/failed 로 기록).
+  const status = computeDeliveryStatus(sentCount, chatIds.length)
+  await recordAlertHistory(historyEvents, status, chatIds.length, status === 'sent' ? undefined : lastError)
 
   if (sentCount === 0) {
     console.warn('[custom-strategy] 전체 chatId 발송 실패 — DB 상태 갱신 보류 (다음 tick 재시도)')

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -11,6 +11,11 @@ import { getBot } from '@/bot/index'
 import { formatPercent } from '@/bot/utils/formatter'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { isMarketOpenFor } from '@/lib/market-hours'
+import {
+  computeDeliveryStatus,
+  recordAlertHistory,
+  type AlertEventInput,
+} from './alert-history'
 
 const WATCHLIST_MHO_KEY = 'watchlist_market_hours_only'
 const WATCHLIST_MHO_LABEL = '관심종목 매수 알림 — 장중에만'
@@ -117,7 +122,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   })
 
   const priceMap = new Map(prices.map((p) => [p.ticker, p]))
-  const alerts: string[] = []
+  const events: AlertEventInput[] = []
 
   for (const p of prices) {
     // 환율은 별도 처리
@@ -128,9 +133,13 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
         sentToday.set(key, today)
 
         const direction = p.change > 0 ? '📈 상승' : '📉 하락'
-        alerts.push(
-          `💱 환율 ${direction}: ${p.price.toLocaleString('ko-KR')}원 (${p.change > 0 ? '+' : ''}${p.change.toFixed(0)}원)`
-        )
+        events.push({
+          kind: 'fx',
+          ticker: p.ticker,
+          price: p.price,
+          changePercent: p.changePercent,
+          message: `💱 환율 ${direction}: ${p.price.toLocaleString('ko-KR')}원 (${p.change > 0 ? '+' : ''}${p.change.toFixed(0)}원)`,
+        })
       }
       continue
     }
@@ -148,15 +157,23 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
     if (p.changePercent <= dropThreshold) {
       sentToday.set(key, today)
       const name = nameMap.get(p.ticker) ?? p.ticker
-      alerts.push(
-        `🔴 ${name} (${p.ticker}) 급락: ${formatPercent(p.changePercent)}`
-      )
+      events.push({
+        kind: 'drop',
+        ticker: p.ticker,
+        price: p.price,
+        changePercent: p.changePercent,
+        message: `🔴 ${name} (${p.ticker}) 급락: ${formatPercent(p.changePercent)}`,
+      })
     } else if (p.changePercent >= surgeThreshold) {
       sentToday.set(key, today)
       const name = nameMap.get(p.ticker) ?? p.ticker
-      alerts.push(
-        `🟢 ${name} (${p.ticker}) 급등: ${formatPercent(p.changePercent)}`
-      )
+      events.push({
+        kind: 'surge',
+        ticker: p.ticker,
+        price: p.price,
+        changePercent: p.changePercent,
+        message: `🟢 ${name} (${p.ticker}) 급등: ${formatPercent(p.changePercent)}`,
+      })
     }
   }
 
@@ -185,9 +202,12 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `target:${s.holding.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'target_hit',
+          ticker: s.holding.ticker,
+          price: currentPrice,
+          message: `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`,
+        })
       }
     }
 
@@ -195,9 +215,12 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `stoploss:${s.holding.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'stop_loss',
+          ticker: s.holding.ticker,
+          price: currentPrice,
+          message: `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`,
+        })
       }
     }
   }
@@ -227,9 +250,12 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `wbuy:${w.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'watch_buy',
+          ticker: w.ticker,
+          price: price.price,
+          message: `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`,
+        })
       }
     }
 
@@ -237,25 +263,36 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `wzone:${w.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'watch_zone',
+          ticker: w.ticker,
+          price: price.price,
+          message: `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`,
+        })
       }
     }
   }
 
-  if (alerts.length === 0) return
+  if (events.length === 0) return
 
   const bot = getBot()
-  const message = `⚡ <b>변동 알림</b>\n\n${alerts.join('\n')}`
+  const combined = `⚡ <b>변동 알림</b>\n\n${events.map((e) => e.message).join('\n')}`
 
+  let sendSuccess = 0
+  let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
-      await sendHtml(bot, chatId, message)
+      await sendHtml(bot, chatId, combined)
+      sendSuccess++
     } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
       console.error(`[notification] 변동 알림 발송 실패 (chatId: ${chatId}):`, error)
     }
   }
 
-  console.log(`[notification] 변동 알림 발송: ${alerts.length}건`)
+  // Phase 33-A (#416): 각 이벤트 이력 저장 (배송 상태 요약)
+  const status = computeDeliveryStatus(sendSuccess, chatIds.length)
+  await recordAlertHistory(events, status, chatIds.length, status === 'sent' ? undefined : lastError)
+
+  console.log(`[notification] 변동 알림 발송: ${events.length}건 → ${sendSuccess}/${chatIds.length} chats`)
 }

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -12,6 +12,11 @@ import { getBot } from '@/bot/index'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
 import { isMarketOpenFor } from '@/lib/market-hours'
+import {
+  computeDeliveryStatus,
+  recordAlertHistory,
+  type AlertEventInput,
+} from './alert-history'
 import type { TAReport } from '@/lib/ta/types'
 
 /** 당일 시그널 발송 기록 (키 → date string) */
@@ -213,12 +218,16 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
   if (tickerStrategies.size === 0) return
 
   // PriceCache.market을 결정적 소스로 사용 (Holding/Watchlist 간 market 불일치 방지)
-  // price-alert.ts와 동일한 패턴 (#261)
+  // price-alert.ts와 동일한 패턴 (#261). Phase 33-A: price/changePercent 도 함께 조회하여
+  // AlertHistory 에 시세 스냅샷 캡처 (사후 진단 유용).
   const priceCaches = await prisma.priceCache.findMany({
     where: { ticker: { in: Array.from(tickerStrategies.keys()) } },
-    select: { ticker: true, market: true },
+    select: { ticker: true, market: true, price: true, changePercent: true },
   })
   const marketByTicker = new Map(priceCaches.map((p) => [p.ticker, p.market]))
+  const snapshotByTicker = new Map(
+    priceCaches.map((p) => [p.ticker, { price: p.price, changePercent: p.changePercent }]),
+  )
 
   const results: SignalResult[] = []
 
@@ -314,19 +323,21 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
   const bot = getBot()
   const message = lines.join('\n')
 
-  let sendSuccess = false
+  let sendSuccess = 0
+  let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
       await sendHtml(bot, chatId, message)
-      sendSuccess = true
+      sendSuccess++
     } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
       console.error(`[ta-signal] 알림 발송 실패 (chatId: ${chatId}):`, error)
     }
   }
 
   // 발송 성공 시에만 dedupe + AI 쿨다운 기록 (실패 시 다음 주기 재시도).
   // AI 가이드가 붙었던 티커만 쿨다운 기록 → skip 된 티커는 다음 주기 재시도.
-  if (sendSuccess) {
+  if (sendSuccess > 0) {
     for (const r of results) {
       for (const sigId of r.signalIds) {
         sentToday.set(`ta:${r.ticker}:${sigId}`, today)
@@ -338,5 +349,20 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     }
   }
 
-  console.log(`[ta-signal] TA 시그널 알림: ${results.length}종목`)
+  // Phase 33-A (#416): 티커 단위 이력 저장 — 각 종목의 시그널을 한 이벤트로 통합.
+  // 시세 스냅샷 (price / changePercent) 을 함께 캡처하여 사후 진단시 참고.
+  const historyEvents: AlertEventInput[] = results.map((r) => {
+    const snap = snapshotByTicker.get(r.ticker)
+    return {
+      kind: 'ta_signal',
+      ticker: r.ticker,
+      price: snap?.price ?? null,
+      changePercent: snap?.changePercent ?? null,
+      message: `${r.displayName} (${r.ticker}) — ${r.strategy}: ${r.signals.join(', ')}`,
+    }
+  })
+  const status = computeDeliveryStatus(sendSuccess, chatIds.length)
+  await recordAlertHistory(historyEvents, status, chatIds.length, status === 'sent' ? undefined : lastError)
+
+  console.log(`[ta-signal] TA 시그널 알림: ${results.length}종목 → ${sendSuccess}/${chatIds.length} chats`)
 }

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -85,6 +85,7 @@ const ALLOWED_TOOLS = [
   'mcp__myfinance__delete_recurring_transaction',
   'mcp__myfinance__list_alert_configs',
   'mcp__myfinance__update_alert_config',
+  'mcp__myfinance__list_alert_history',
   'mcp__myfinance__create_rsu_schedule',
   'mcp__myfinance__update_rsu_schedule',
   'mcp__myfinance__delete_rsu_schedule',

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -102,6 +102,7 @@ export const SYSTEM_PROMPT = `당신은 myFinance의 가족 자산관리 AI 어�
 - list_budgets / set_budget / delete_budget: 카테고리별 월 예산 관리 (set은 upsert). **쓰기는 사용자 확인 후**
 - list_recurring_transactions / create_recurring_transaction / update_recurring_transaction / delete_recurring_transaction: 반복 거래 CRUD. **쓰기는 사용자 확인 후**
 - list_alert_configs / update_alert_config: 알림 임계값 설정 (기존 키만). **변경은 사용자 확인 후**
+- list_alert_history: 알림 발동 이력 조회. 필터: kind (surge/drop/fx/target_hit/stop_loss/watch_buy/watch_zone/ta_signal/custom_strategy), ticker, from~to (ISO 8601), limit (기본 50, 최대 200)
 - create_rsu_schedule / update_rsu_schedule / delete_rsu_schedule: RSU 베스팅 일정 CRUD (update/delete는 pending만). **쓰기는 사용자 확인 후**
 - vest_rsu: RSU 베스팅 처리 — 종가 자동 조회 후 BUY/SELL Trade + Holding 자동 반영. **사용자의 명시적 동의 후에만 호출**
 - create_stock_option / update_stock_option / delete_stock_option: 스톡옵션 CRUD (update 시 remainingShares 자동 재계산). **쓰기는 사용자 확인 후**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -36,6 +36,7 @@ import { listAssets, createAsset, updateAsset, deleteAsset, createAssetDeposit }
 import { listBudgets, setBudget, deleteBudget } from './tools/budget'
 import { listRecurringTransactions, createRecurringTransaction, updateRecurringTransaction, deleteRecurringTransaction } from './tools/recurring'
 import { listAlertConfigs, updateAlertConfig } from './tools/alert'
+import { listAlertHistory } from './tools/alert-history'
 import { createRsuSchedule, updateRsuSchedule, deleteRsuSchedule } from './tools/rsu-write'
 import { vestRsu } from './tools/rsu-vest'
 import {
@@ -759,6 +760,22 @@ server.tool(
     value: z.string().describe('숫자 문자열'),
   },
   async (args) => updateAlertConfig(args)
+)
+
+server.tool(
+  'list_alert_history',
+  '알림 발동 이력 조회. Phase 33-A (#416). 필터: kind, ticker, from~to (ISO 8601), limit (기본 50, 최대 200).',
+  {
+    kind: z
+      .enum(['surge', 'drop', 'fx', 'target_hit', 'stop_loss', 'watch_buy', 'watch_zone', 'ta_signal', 'custom_strategy'])
+      .optional()
+      .describe('알림 종류 필터'),
+    ticker: z.string().optional().describe('티커 필터 (예: AAPL, 005930.KS)'),
+    from: z.string().optional().describe('시작 시각 (ISO 8601)'),
+    to: z.string().optional().describe('종료 시각 (ISO 8601)'),
+    limit: z.number().int().positive().optional().describe('최대 반환 개수 (기본 50, 최대 200)'),
+  },
+  async (args) => listAlertHistory(args)
 )
 
 // --- RSU 스케줄 쓰기 ---

--- a/src/mcp/tools/__tests__/alert-history.test.ts
+++ b/src/mcp/tools/__tests__/alert-history.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { listAlertHistory } from '../alert-history'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+describe('listAlertHistory', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockReset()
+  })
+
+  it('알 수 없는 kind 는 toolError', async () => {
+    const result = await listAlertHistory({ kind: 'unknown' })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+    expect(result.content[0].text).toContain('알 수 없는 kind')
+  })
+
+  it('from 형식 오류 → toolError', async () => {
+    const result = await listAlertHistory({ from: 'not-a-date' })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+    expect(result.content[0].text).toContain('ISO 8601')
+  })
+
+  it('to 형식 오류 → toolError', async () => {
+    const result = await listAlertHistory({ to: 'invalid' })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+  })
+
+  it('limit 이 양수 아님 → toolError', async () => {
+    const result = await listAlertHistory({ limit: -1 })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+    expect(result.content[0].text).toContain('limit')
+  })
+
+  it('빈 결과 → "이력이 없습니다"', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    const result = await listAlertHistory({})
+    expect(result.content[0].text).toContain('이력이 없습니다')
+  })
+
+  it('limit 상한 200 초과 시 clamp', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    await listAlertHistory({ limit: 1000 })
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect(call?.take).toBe(200)
+  })
+
+  it('필터 조합이 where 로 전달됨', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    await listAlertHistory({
+      kind: 'surge',
+      ticker: 'AAPL',
+      from: '2026-07-01T00:00:00Z',
+      to: '2026-07-08T00:00:00Z',
+      limit: 30,
+    })
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect(call?.where).toEqual({
+      kind: 'surge',
+      ticker: 'AAPL',
+      firedAt: {
+        gte: new Date('2026-07-01T00:00:00Z'),
+        lte: new Date('2026-07-08T00:00:00Z'),
+      },
+    })
+    expect(call?.take).toBe(30)
+    expect(call?.orderBy).toEqual({ firedAt: 'desc' })
+  })
+
+  it('결과 rendering — 시간/kind 라벨/티커/상태/메시지 포함', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([
+      {
+        id: '1',
+        firedAt: new Date('2026-07-08T02:30:00Z'),
+        kind: 'drop',
+        ticker: 'AAPL',
+        price: 150,
+        changePercent: -6.2,
+        message: '🔴 AAPL 급락',
+        deliveryStatus: 'sent',
+        recipientCount: 1,
+        errorMessage: null,
+      },
+    ] as never)
+
+    const result = await listAlertHistory({})
+    const text = result.content[0].text
+    expect(text).toContain('🔴 급락')
+    expect(text).toContain('[AAPL]')
+    expect(text).toContain('전송')
+    expect(text).toContain('🔴 AAPL 급락')
+    expect(text).toContain('2026-07-08')
+  })
+})

--- a/src/mcp/tools/__tests__/alert-history.test.ts
+++ b/src/mcp/tools/__tests__/alert-history.test.ts
@@ -79,6 +79,15 @@ describe('listAlertHistory', () => {
     expect(call?.orderBy).toEqual({ firedAt: 'desc' })
   })
 
+  it('ticker 소문자/공백 입력을 trim().toUpperCase() 로 정규화 (Codex #423 P2 회귀 방지)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    await listAlertHistory({ ticker: '  aapl ' })
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect((call?.where as { ticker?: string })?.ticker).toBe('AAPL')
+  })
+
   it('결과 rendering — 시간/kind 라벨/티커/상태/메시지 포함', async () => {
     const { prisma } = await import('@/lib/prisma')
     vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([

--- a/src/mcp/tools/alert-history.ts
+++ b/src/mcp/tools/alert-history.ts
@@ -56,7 +56,10 @@ export async function listAlertHistory(args: ListAlertHistoryArgs = {}) {
       }
       where.kind = args.kind
     }
-    if (args.ticker) where.ticker = args.ticker
+    // 티커 정규화 — MCP 호출자가 자연어로 소문자/공백 포함으로 넘길 수 있음.
+    // Prisma 저장값은 대문자 정규화된 상태 (holdings/watchlist/priceCache 파이프라인).
+    // 미정규화 exact match 는 rows 있어도 "이력 없음" 오탐 (Codex #423 P2).
+    if (args.ticker) where.ticker = args.ticker.trim().toUpperCase()
 
     const from = parseISO(args.from)
     const to = parseISO(args.to)

--- a/src/mcp/tools/alert-history.ts
+++ b/src/mcp/tools/alert-history.ts
@@ -1,0 +1,102 @@
+/**
+ * Phase 33-A (#416) — MCP tool: `list_alert_history`.
+ * 텔레그램 AI 에서 최근 알림 발동 이력 조회.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { toolResult, toolError } from '../utils'
+import type { Prisma } from '@prisma/client'
+
+const KIND_LABELS: Record<string, string> = {
+  surge: '🟢 급등',
+  drop: '🔴 급락',
+  fx: '💱 환율',
+  target_hit: '🎯 목표가',
+  stop_loss: '🛑 손절가',
+  watch_buy: '💰 목표매수가',
+  watch_zone: '🔔 매수구간',
+  ta_signal: '📊 TA 시그널',
+  custom_strategy: '🧠 커스텀 전략',
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  sent: '전송',
+  partial: '일부 전송',
+  failed: '실패',
+}
+
+const MAX_LIMIT = 200
+const DEFAULT_LIMIT = 50
+
+/**
+ * ISO 8601 문자열 → Date. 잘못된 형식이면 null.
+ */
+function parseISO(s: string | undefined): Date | null {
+  if (!s) return null
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+export interface ListAlertHistoryArgs {
+  kind?: string
+  ticker?: string
+  from?: string
+  to?: string
+  limit?: number
+}
+
+export async function listAlertHistory(args: ListAlertHistoryArgs = {}) {
+  try {
+    const where: Prisma.AlertHistoryWhereInput = {}
+    if (args.kind) {
+      if (!(args.kind in KIND_LABELS)) {
+        return toolError(
+          `알 수 없는 kind: ${args.kind}. 사용 가능: ${Object.keys(KIND_LABELS).join(', ')}`,
+        )
+      }
+      where.kind = args.kind
+    }
+    if (args.ticker) where.ticker = args.ticker
+
+    const from = parseISO(args.from)
+    const to = parseISO(args.to)
+    if (args.from && !from) return toolError(`from 이 ISO 8601 형식이 아닙니다: ${args.from}`)
+    if (args.to && !to) return toolError(`to 가 ISO 8601 형식이 아닙니다: ${args.to}`)
+    if (from || to) {
+      where.firedAt = {}
+      if (from) where.firedAt.gte = from
+      if (to) where.firedAt.lte = to
+    }
+
+    const requested = args.limit ?? DEFAULT_LIMIT
+    if (!Number.isFinite(requested) || requested <= 0) {
+      return toolError('limit 은 양수여야 합니다.')
+    }
+    const limit = Math.min(Math.floor(requested), MAX_LIMIT)
+
+    const rows = await prisma.alertHistory.findMany({
+      where,
+      orderBy: { firedAt: 'desc' },
+      take: limit,
+    })
+
+    if (rows.length === 0) return toolResult('해당 조건의 알림 이력이 없습니다.')
+
+    const lines: string[] = [
+      `## 알림 이력 (${rows.length}건, 최신순, 최대 ${limit})`,
+      '',
+    ]
+    for (const r of rows) {
+      const time = r.firedAt.toISOString().replace('T', ' ').slice(0, 16)
+      const kindLabel = KIND_LABELS[r.kind] ?? r.kind
+      const statusLabel = STATUS_LABELS[r.deliveryStatus] ?? r.deliveryStatus
+      const tickerPart = r.ticker ? ` [${r.ticker}]` : ''
+      lines.push(`- ${time} · ${kindLabel}${tickerPart} · ${statusLabel}`)
+      lines.push(`  ${r.message}`)
+    }
+
+    return toolResult(lines.join('\n'))
+  } catch (error) {
+    return toolError(error)
+  }
+}


### PR DESCRIPTION
## Summary
모든 알림 발동을 DB 에 축적 → 33-B 이력 페이지 소스 + 재현 이슈 사후 진단.

- Master: #414 (15차). Spec: `docs/specs/416-alert-history.md`
- Prisma 신규 모델 `AlertHistory` (9개 kind, 배송 상태, 시세 스냅샷)
- Helper `alert-history.ts` (pure `computeDeliveryStatus` + `recordAlertHistory`)
- Hook 3곳: price-alert / ta-signal-alert / custom-strategy-alert
- MCP tool `list_alert_history` (kind zod enum, ISO 파싱, limit 상한 200)
- Migration `20260708022825_add_alert_history` 로컬 적용 완료

## Test plan
- [x] lint / typecheck / test (326) / build 통과
- [x] self-review (pr-review-toolkit) P2 0 / P1 0 / P0 1 (ta-signal price 캡처 → 반영)
- [ ] 배포 후 텔레그램 알림 발동 시 `AlertHistory` row 생성 확인
- [ ] MCP tool `list_alert_history` 텔레그램 AI 호출 성공

Closes #416