### PR TITLE
feat(alert): 알림 이력 페이지 (/alerts/history) (Phase 33-B, #417)

### DIFF
--- a/docs/specs/417-alert-history-page.md
+++ b/docs/specs/417-alert-history-page.md
@@ -1,0 +1,123 @@
+# [Phase 33-B] 알림 이력 페이지 (/alerts/history)
+
+- **이슈**: #417
+- **마스터**: #414
+- **선행**: #416 (AlertHistory 모델, 이미 머지됨)
+- **작성일**: 2026-07-08
+
+## 목표
+
+웹에서 알림 발동 이력을 필터·통계와 함께 조회. AI 자연어 질의 (`list_alert_history` MCP) 의 웹 UI 대응.
+
+## 사용자 흐름
+
+1. 텔레그램 알림을 받은 뒤 웹에서 "어떤 알림이 언제 왔나" 확인 → `/alerts/history` 진입
+2. 기본: 최근 7일 전체 kind
+3. 필요 시 기간(7/30/90일) / kind(칩 토글) / ticker 검색 조합 필터
+4. 상단 통계 카드로 발동 추이 요약, 하단 리스트로 개별 이벤트 상세
+
+## API 설계
+
+### `GET /api/alerts/history`
+
+Query params:
+- `kind` (optional): kind 필터 (단일)
+- `ticker` (optional): 대문자 정규화 후 exact match
+- `from`, `to` (optional): ISO 8601. 미지정 시 최근 7일
+- `limit` (optional): 기본 50, 최대 200
+- `offset` (optional): 기본 0
+
+Response (envelope):
+```
+{
+  success: true,
+  data: [ AlertHistoryRow, ... ],
+  meta: { total: number, limit: number, offset: number },
+}
+```
+
+### `GET /api/alerts/history/stats`
+
+Query params: 동일 (kind/ticker/from/to)
+
+Response:
+```
+{
+  success: true,
+  data: {
+    total: number,
+    byStatus: { sent: number, partial: number, failed: number },
+    byKind: [ { kind, count }, ... ],
+    byDay: [ { date: 'YYYY-MM-DD', count: number }, ... ],
+  }
+}
+```
+
+## 페이지 (`src/app/alerts/history/page.tsx` + `AlertHistoryClient.tsx`)
+
+### 레이아웃 (기존 site 패턴 재사용 — 별도 프로토타입 없이 dashboard-prototype 톤 그대로)
+
+```
+┌ Header(title, sub) ────────────────────────────────┐
+│                                                    │
+│ [필터 바] 기간 · kind 칩 · ticker 검색            │
+│                                                    │
+│ [Stat 4개]  총건수  성공률  종류수  티커수         │
+│                                                    │
+│ [Chart 2개] 일별 발동 라인 (Recharts)              │
+│             종류별 파이 (또는 스택 바)             │
+│                                                    │
+│ [리스트]  시각 · kind 뱃지 · ticker · 메시지 · 상태│
+│ [페이지네이션] Prev / N / M / Next                 │
+└────────────────────────────────────────────────────┘
+```
+
+### 색상/스타일
+
+- 기존 다크 톤 + `sejin=#34d399` 강조
+- kind 뱃지 컬러:
+  - surge → emerald (성공)
+  - drop → red
+  - fx → sky
+  - target_hit / watch_buy → sejin (green)
+  - stop_loss → red
+  - watch_zone → amber
+  - ta_signal → violet
+  - custom_strategy → orange
+- 상태 뱃지:
+  - sent → sejin
+  - partial → amber
+  - failed → red
+
+### 반응형
+
+- 모바일: 필터 세로 스택, 차트 1열, 리스트 카드 형태
+- 데스크톱: 필터 가로, 차트 2열 (라인/파이 병렬), 리스트 테이블
+
+## 파일 변경
+
+- `src/app/api/alerts/history/route.ts` (신규) — GET list
+- `src/app/api/alerts/history/stats/route.ts` (신규) — GET stats
+- `src/app/alerts/history/page.tsx` (신규)
+- `src/app/alerts/history/AlertHistoryClient.tsx` (신규)
+- 네비게이션 링크 (설정 페이지 등에서 접근 가능하도록) — 위치는 착수 시 결정
+
+## 테스트
+
+- API route: 필터 조합 검증 (envelope + pagination)
+- Stats: kind/status 집계 + byDay bucket 정합성
+- Client 유닛: 기간 프리셋 로직 pure, kind toggle set
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] 로컬 실행 후 필터/차트/리스트 정상 렌더링 확인 (verify skill)
+- [ ] 모바일 뷰포트 검증
+
+## 제외 사항
+
+- 알림 상세 모달 (kind 별 컨텍스트 표시) — v2
+- 이력 export (CSV) — v2
+- 알림 재발송 / 재시도 — 별도 스코프
+- 접근 제한 (관리자 전용) — 개인 서비스라 인증 미적용 상태 유지

--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -88,7 +88,14 @@ export default function AlertHistoryClient() {
         setTotal(listJson?.meta?.total ?? 0)
         setStats(statsJson?.data ?? null)
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : '알림 이력 조회 중 오류')
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : '알림 이력 조회 중 오류')
+          // Codex #424 P2 (2회차): 필터/페이지 refresh 실패 시 이전 rows/total/stats 를
+          // 그대로 두면 새 필터에 대해 stale 한 데이터 + 에러가 동시에 보임 → 초기화.
+          setRows([])
+          setTotal(0)
+          setStats(null)
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }

--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -1,0 +1,381 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ResponsiveContainer,
+  LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip as RTooltip,
+  PieChart, Pie, Cell, Legend,
+} from 'recharts'
+import { KIND_META, kindMetaOf, STATUS_META, type AlertKind } from './kinds'
+import { formatFiredAt, stripHtml, periodFromISO } from './client-utils'
+
+interface HistoryRow {
+  id: string
+  firedAt: string
+  kind: string
+  ticker: string | null
+  price: number | null
+  changePercent: number | null
+  message: string
+  deliveryStatus: string
+  recipientCount: number
+  errorMessage: string | null
+}
+
+interface Stats {
+  total: number
+  byStatus: { sent: number; partial: number; failed: number }
+  byKind: Array<{ kind: string; count: number }>
+  byDay: Array<{ date: string; count: number }>
+}
+
+const PERIOD_OPTIONS = [
+  { key: 7, label: '7일' },
+  { key: 30, label: '30일' },
+  { key: 90, label: '90일' },
+] as const
+
+const PAGE_SIZE = 30
+
+export default function AlertHistoryClient() {
+  const [days, setDays] = useState<number>(7)
+  const [selectedKinds, setSelectedKinds] = useState<Set<AlertKind>>(new Set())
+  const [tickerInput, setTickerInput] = useState('')
+  const [tickerFilter, setTickerFilter] = useState('')
+  const [rows, setRows] = useState<HistoryRow[]>([])
+  const [total, setTotal] = useState(0)
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // 단일 kind 필터: 여러 선택 시 클라이언트 사이드 필터링 (API 는 단일 kind 만 지원)
+  // 이력 수집 초기라 서버 데이터는 소량 → 클라 필터가 실사용에 충분. 대용량 축적 후 재검토.
+  const kindQueryParam = useMemo(() => {
+    if (selectedKinds.size === 1) return Array.from(selectedKinds)[0]
+    return undefined
+  }, [selectedKinds])
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const from = periodFromISO(days)
+        const listParams = new URLSearchParams()
+        listParams.set('from', from)
+        listParams.set('limit', String(PAGE_SIZE))
+        listParams.set('offset', String(offset))
+        if (kindQueryParam) listParams.set('kind', kindQueryParam)
+        if (tickerFilter) listParams.set('ticker', tickerFilter)
+
+        const statsParams = new URLSearchParams()
+        statsParams.set('from', from)
+        if (kindQueryParam) statsParams.set('kind', kindQueryParam)
+        if (tickerFilter) statsParams.set('ticker', tickerFilter)
+
+        const [listRes, statsRes] = await Promise.all([
+          fetch(`/api/alerts/history?${listParams.toString()}`),
+          fetch(`/api/alerts/history/stats?${statsParams.toString()}`),
+        ])
+        const listJson = await listRes.json()
+        const statsJson = await statsRes.json()
+        if (cancelled) return
+        if (!listRes.ok) throw new Error(listJson?.error ?? '이력 조회 실패')
+        if (!statsRes.ok) throw new Error(statsJson?.error ?? '통계 조회 실패')
+
+        let fetchedRows: HistoryRow[] = listJson?.data ?? []
+        const fetchedTotal: number = listJson?.meta?.total ?? 0
+
+        // 클라 사이드 다중 kind 필터 (선택 2개 이상일 때만)
+        if (selectedKinds.size >= 2) {
+          fetchedRows = fetchedRows.filter((r) => selectedKinds.has(r.kind as AlertKind))
+        }
+
+        setRows(fetchedRows)
+        setTotal(fetchedTotal)
+        setStats(statsJson?.data ?? null)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : '알림 이력 조회 중 오류')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [days, kindQueryParam, tickerFilter, offset, selectedKinds])
+
+  const toggleKind = (k: AlertKind) => {
+    setOffset(0)
+    setSelectedKinds((prev) => {
+      const next = new Set(prev)
+      if (next.has(k)) next.delete(k)
+      else next.add(k)
+      return next
+    })
+  }
+
+  const applyTicker = () => {
+    setOffset(0)
+    setTickerFilter(tickerInput.trim().toUpperCase())
+  }
+
+  const clearFilters = () => {
+    setSelectedKinds(new Set())
+    setTickerInput('')
+    setTickerFilter('')
+    setOffset(0)
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
+  const successRate = useMemo(() => {
+    if (!stats || stats.total === 0) return null
+    const success = stats.byStatus.sent + stats.byStatus.partial * 0.5
+    return (success / stats.total) * 100
+  }, [stats])
+
+  return (
+    <div className="space-y-5">
+      {/* Filter bar */}
+      <section className="rounded-[14px] border border-border bg-card p-4 sm:p-5 space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {PERIOD_OPTIONS.map((p) => (
+            <button
+              key={p.key}
+              onClick={() => { setDays(p.key); setOffset(0) }}
+              className={`px-3 py-1.5 text-[12px] font-semibold rounded-md border transition-colors ${
+                days === p.key
+                  ? 'bg-sejin/25 text-sejin border-sejin/40'
+                  : 'bg-surface border-border text-sub hover:text-bright'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+          <div className="ml-auto flex items-center gap-2">
+            <input
+              value={tickerInput}
+              onChange={(e) => setTickerInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') applyTicker() }}
+              placeholder="티커 검색"
+              className="bg-surface-dim border border-border rounded-md px-3 py-1.5 text-[13px] text-bright placeholder:text-dim focus:outline-none focus:border-sejin w-32"
+            />
+            <button
+              onClick={applyTicker}
+              className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+            >
+              적용
+            </button>
+            {(selectedKinds.size > 0 || tickerFilter) && (
+              <button
+                onClick={clearFilters}
+                className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+              >
+                초기화
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {KIND_META.map((m) => {
+            const active = selectedKinds.has(m.key)
+            return (
+              <button
+                key={m.key}
+                onClick={() => toggleKind(m.key)}
+                className={`px-2.5 py-1 text-[11px] font-semibold rounded-md border transition-colors ${
+                  active ? m.colorClass : 'bg-surface border-border text-sub hover:text-bright'
+                }`}
+              >
+                {m.icon} {m.label}
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="총 발동" value={stats?.total ?? 0} tone="bright" />
+        <StatCard
+          label="전송 성공률"
+          value={successRate == null ? '—' : `${successRate.toFixed(0)}%`}
+          tone="sejin"
+        />
+        <StatCard label="종류" value={stats?.byKind.length ?? 0} tone="sodam" />
+        <StatCard
+          label="실패"
+          value={stats?.byStatus.failed ?? 0}
+          tone={stats?.byStatus.failed ? 'dasom' : 'sub'}
+        />
+      </section>
+
+      {/* Charts */}
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <div className="rounded-[14px] border border-border bg-card p-4">
+          <div className="text-[12px] text-sub mb-2">일별 발동 건수</div>
+          <div className="h-[220px]">
+            {stats && stats.byDay.length > 0 ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={stats.byDay} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.15)" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fill: '#94a3b8', fontSize: 11 }}
+                    tickFormatter={(s: string) => s.slice(5)}
+                  />
+                  <YAxis
+                    tick={{ fill: '#94a3b8', fontSize: 11 }}
+                    allowDecimals={false}
+                  />
+                  <RTooltip
+                    contentStyle={{ background: '#0f172a', border: '1px solid #334155', color: '#e2e8f0' }}
+                  />
+                  <Line type="monotone" dataKey="count" stroke="#34d399" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-full text-dim text-[13px]">데이터 없음</div>
+            )}
+          </div>
+        </div>
+        <div className="rounded-[14px] border border-border bg-card p-4">
+          <div className="text-[12px] text-sub mb-2">종류별 발동</div>
+          <div className="h-[220px]">
+            {stats && stats.byKind.length > 0 ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={stats.byKind}
+                    dataKey="count"
+                    nameKey="kind"
+                    innerRadius={45}
+                    outerRadius={80}
+                    paddingAngle={2}
+                  >
+                    {stats.byKind.map((entry, idx) => (
+                      <Cell key={idx} fill={kindMetaOf(entry.kind)?.hex ?? '#94a3b8'} />
+                    ))}
+                  </Pie>
+                  <RTooltip
+                    contentStyle={{ background: '#0f172a', border: '1px solid #334155', color: '#e2e8f0' }}
+                    formatter={(value, name) => [value as number, kindMetaOf(String(name))?.label ?? String(name)]}
+                  />
+                  <Legend
+                    formatter={(value: string) => kindMetaOf(value)?.label ?? value}
+                    wrapperStyle={{ fontSize: '11px' }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-full text-dim text-[13px]">데이터 없음</div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* List */}
+      <section className="rounded-[14px] border border-border bg-card overflow-hidden">
+        <div className="px-5 py-3 border-b border-border bg-surface-dim flex items-center gap-2">
+          <div className="text-[13px] font-bold text-bright">이력</div>
+          <div className="text-[11px] text-sub">
+            {total.toLocaleString()}건 · 페이지 {currentPage}/{totalPages}
+          </div>
+          {loading && <div className="ml-auto text-[11px] text-sub">불러오는 중…</div>}
+        </div>
+        {error && (
+          <div className="px-5 py-4 text-[13px] text-red-400">{error}</div>
+        )}
+        {!error && rows.length === 0 && !loading && (
+          <div className="px-5 py-8 text-center text-dim text-[13px]">해당 조건의 알림 이력이 없습니다.</div>
+        )}
+        {rows.length > 0 && (
+          <ul>
+            {rows.map((r) => {
+              const meta = kindMetaOf(r.kind)
+              const status = STATUS_META[r.deliveryStatus] ?? { label: r.deliveryStatus, colorClass: 'bg-surface text-sub border-border' }
+              return (
+                <li
+                  key={r.id}
+                  className="px-5 py-3 border-b border-border last:border-b-0 hover:bg-surface-dim transition-colors"
+                >
+                  <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                    <span className="text-sub tabular-nums">{formatFiredAt(r.firedAt)}</span>
+                    <span className={`px-2 py-0.5 rounded border font-semibold ${meta?.colorClass ?? 'bg-surface text-sub border-border'}`}>
+                      {meta?.icon} {meta?.label ?? r.kind}
+                    </span>
+                    {r.ticker && (
+                      <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
+                        {r.ticker}
+                      </span>
+                    )}
+                    <span className={`ml-auto px-2 py-0.5 rounded border font-semibold ${status.colorClass}`}>
+                      {status.label} · {r.recipientCount}
+                    </span>
+                  </div>
+                  <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
+                    {stripHtml(r.message)}
+                  </div>
+                  {r.errorMessage && (
+                    <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        {total > PAGE_SIZE && (
+          <div className="px-5 py-3 border-t border-border flex items-center justify-between text-[12px]">
+            <button
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0}
+              className="px-3 py-1.5 rounded-md border border-border text-sub hover:text-bright disabled:opacity-40 disabled:hover:text-sub"
+            >
+              이전
+            </button>
+            <span className="text-sub">
+              {currentPage}/{totalPages}
+            </span>
+            <button
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= total}
+              className="px-3 py-1.5 rounded-md border border-border text-sub hover:text-bright disabled:opacity-40 disabled:hover:text-sub"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function StatCard({
+  label, value, tone,
+}: {
+  label: string
+  value: number | string
+  tone: 'bright' | 'sejin' | 'sodam' | 'dasom' | 'sub'
+}) {
+  const toneClass = {
+    bright: 'text-bright',
+    sejin:  'text-sejin',
+    sodam:  'text-sodam',
+    dasom:  'text-dasom',
+    sub:    'text-dim',
+  }[tone]
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className={`text-[22px] font-extrabold tabular-nums ${toneClass}`}>
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </div>
+      <div className="text-[11px] text-sub mt-0.5">{label}</div>
+    </div>
+  )
+}

--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -49,12 +49,9 @@ export default function AlertHistoryClient() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // 단일 kind 필터: 여러 선택 시 클라이언트 사이드 필터링 (API 는 단일 kind 만 지원)
-  // 이력 수집 초기라 서버 데이터는 소량 → 클라 필터가 실사용에 충분. 대용량 축적 후 재검토.
-  const kindQueryParam = useMemo(() => {
-    if (selectedKinds.size === 1) return Array.from(selectedKinds)[0]
-    return undefined
-  }, [selectedKinds])
+  // Codex P2 (#417 PR #424): 다중 kind 를 서버 쿼리로 전달 (`?kind=a&kind=b`) →
+  // API 가 `in` 절로 필터 + 페이지네이션·집계가 정합. 클라 사이드 후처리 제거.
+  const kindsKey = useMemo(() => Array.from(selectedKinds).sort().join(','), [selectedKinds])
 
   useEffect(() => {
     let cancelled = false
@@ -63,16 +60,18 @@ export default function AlertHistoryClient() {
       setError(null)
       try {
         const from = periodFromISO(days)
+        const kinds = kindsKey ? kindsKey.split(',') : []
+
         const listParams = new URLSearchParams()
         listParams.set('from', from)
         listParams.set('limit', String(PAGE_SIZE))
         listParams.set('offset', String(offset))
-        if (kindQueryParam) listParams.set('kind', kindQueryParam)
+        for (const k of kinds) listParams.append('kind', k)
         if (tickerFilter) listParams.set('ticker', tickerFilter)
 
         const statsParams = new URLSearchParams()
         statsParams.set('from', from)
-        if (kindQueryParam) statsParams.set('kind', kindQueryParam)
+        for (const k of kinds) statsParams.append('kind', k)
         if (tickerFilter) statsParams.set('ticker', tickerFilter)
 
         const [listRes, statsRes] = await Promise.all([
@@ -85,16 +84,8 @@ export default function AlertHistoryClient() {
         if (!listRes.ok) throw new Error(listJson?.error ?? '이력 조회 실패')
         if (!statsRes.ok) throw new Error(statsJson?.error ?? '통계 조회 실패')
 
-        let fetchedRows: HistoryRow[] = listJson?.data ?? []
-        const fetchedTotal: number = listJson?.meta?.total ?? 0
-
-        // 클라 사이드 다중 kind 필터 (선택 2개 이상일 때만)
-        if (selectedKinds.size >= 2) {
-          fetchedRows = fetchedRows.filter((r) => selectedKinds.has(r.kind as AlertKind))
-        }
-
-        setRows(fetchedRows)
-        setTotal(fetchedTotal)
+        setRows(listJson?.data ?? [])
+        setTotal(listJson?.meta?.total ?? 0)
         setStats(statsJson?.data ?? null)
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : '알림 이력 조회 중 오류')
@@ -106,7 +97,7 @@ export default function AlertHistoryClient() {
     return () => {
       cancelled = true
     }
-  }, [days, kindQueryParam, tickerFilter, offset, selectedKinds])
+  }, [days, kindsKey, tickerFilter, offset])
 
   const toggleKind = (k: AlertKind) => {
     setOffset(0)

--- a/src/app/alerts/history/__tests__/client-utils.test.ts
+++ b/src/app/alerts/history/__tests__/client-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { periodFromISO, formatFiredAt, stripHtml } from '../client-utils'
+
+describe('periodFromISO', () => {
+  it('N일 전 시각을 ISO 8601 로 반환 (now 주입)', () => {
+    const now = Date.parse('2026-07-08T00:00:00Z')
+    expect(periodFromISO(7, now)).toBe('2026-07-01T00:00:00.000Z')
+    expect(periodFromISO(30, now)).toBe('2026-06-08T00:00:00.000Z')
+    expect(periodFromISO(0, now)).toBe('2026-07-08T00:00:00.000Z')
+  })
+})
+
+describe('formatFiredAt', () => {
+  it('UTC ISO → KST MM-DD HH:mm', () => {
+    // UTC 00:00:00 = KST 09:00
+    expect(formatFiredAt('2026-07-08T00:00:00Z')).toBe('07-08 09:00')
+  })
+
+  it('자정 넘김 (UTC 15:30 → KST 다음날 00:30)', () => {
+    expect(formatFiredAt('2026-07-08T15:30:00Z')).toBe('07-09 00:30')
+  })
+})
+
+describe('stripHtml', () => {
+  it('<b> 태그 제거', () => {
+    expect(stripHtml('🔴 <b>AAPL</b> 급락')).toBe('🔴 AAPL 급락')
+  })
+
+  it('<br> 는 개행으로 변환', () => {
+    expect(stripHtml('a<br>b<br/>c')).toBe('a\nb\nc')
+  })
+
+  it('HTML 엔티티 역디코드 (escapeHtml 결과 원상복원)', () => {
+    expect(stripHtml('&amp; &lt;script&gt; &quot;x&quot; &#39;y&#39;')).toBe(`& <script> "x" 'y'`)
+  })
+
+  it('중첩 태그와 속성 모두 제거', () => {
+    expect(stripHtml('<b>hello <i class="x">world</i></b>')).toBe('hello world')
+  })
+
+  it('평문은 변경 없음', () => {
+    expect(stripHtml('안녕하세요')).toBe('안녕하세요')
+  })
+})

--- a/src/app/alerts/history/client-utils.ts
+++ b/src/app/alerts/history/client-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Phase 33-B (#417) — 알림 이력 클라이언트 유틸 (pure).
+ * `AlertHistoryClient.tsx` 로 분리해 테스트 편이.
+ */
+
+/** UTC now 로부터 N일 전 시각 반환 (ISO 8601) */
+export function periodFromISO(days: number, now: number = Date.now()): string {
+  const d = new Date(now - days * 24 * 60 * 60 * 1000)
+  return d.toISOString()
+}
+
+/** ISO 8601 → "MM-DD HH:mm" (KST 기준) */
+export function formatFiredAt(iso: string): string {
+  const d = new Date(iso)
+  const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  const s = kst.toISOString()
+  return `${s.slice(5, 10)} ${s.slice(11, 16)}`
+}
+
+/**
+ * message 는 텔레그램 발송용 HTML (자체 코드에서 escapeHtml + `<b>` 삽입).
+ * 웹에서는 XSS 방어와 시각 단순성을 위해 태그 제거 + HTML 엔티티 역디코드 후 plain text.
+ */
+export function stripHtml(s: string): string {
+  return s
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/?[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}

--- a/src/app/alerts/history/kinds.ts
+++ b/src/app/alerts/history/kinds.ts
@@ -1,0 +1,47 @@
+/**
+ * Phase 33-B (#417) — 알림 kind 메타 (라벨/색상).
+ * Server (`route.ts`) 와 UI 모두 참조 가능한 pure 상수. AlertConfig 카테고리와는 별도
+ * (kind 는 발동 종류, alert-config category 는 설정 그룹).
+ */
+
+export type AlertKind =
+  | 'surge' | 'drop' | 'fx'
+  | 'target_hit' | 'stop_loss'
+  | 'watch_buy' | 'watch_zone'
+  | 'ta_signal' | 'custom_strategy'
+
+export interface KindMeta {
+  key: AlertKind
+  label: string
+  icon: string
+  /** Tailwind 배경/텍스트 짝 (뱃지·차트 색상용) */
+  colorClass: string
+  /** Recharts 등 SVG 용 hex */
+  hex: string
+}
+
+export const KIND_META: KindMeta[] = [
+  { key: 'surge',           label: '급등',        icon: '🟢', colorClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30', hex: '#34d399' },
+  { key: 'drop',            label: '급락',        icon: '🔴', colorClass: 'bg-red-500/15 text-red-400 border-red-500/30',              hex: '#f87171' },
+  { key: 'fx',              label: '환율',        icon: '💱', colorClass: 'bg-sky-500/15 text-sky-400 border-sky-500/30',              hex: '#38bdf8' },
+  { key: 'target_hit',      label: '목표가',      icon: '🎯', colorClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30', hex: '#34d399' },
+  { key: 'stop_loss',       label: '손절가',      icon: '🛑', colorClass: 'bg-red-500/15 text-red-400 border-red-500/30',              hex: '#ef4444' },
+  { key: 'watch_buy',       label: '목표매수가',  icon: '💰', colorClass: 'bg-sejin/15 text-sejin border-sejin/30',                    hex: '#34d399' },
+  { key: 'watch_zone',      label: '매수구간',    icon: '🔔', colorClass: 'bg-amber-500/15 text-amber-400 border-amber-500/30',        hex: '#fbbf24' },
+  { key: 'ta_signal',       label: 'TA 시그널',   icon: '📊', colorClass: 'bg-violet-500/15 text-violet-400 border-violet-500/30',     hex: '#a78bfa' },
+  { key: 'custom_strategy', label: '커스텀 전략', icon: '🧠', colorClass: 'bg-dasom/15 text-dasom border-dasom/30',                    hex: '#fb923c' },
+]
+
+export const KIND_BY_KEY: Record<AlertKind, KindMeta> = Object.fromEntries(
+  KIND_META.map((m) => [m.key, m]),
+) as Record<AlertKind, KindMeta>
+
+export function kindMetaOf(key: string): KindMeta | undefined {
+  return KIND_BY_KEY[key as AlertKind]
+}
+
+export const STATUS_META: Record<string, { label: string; colorClass: string }> = {
+  sent:    { label: '전송',       colorClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30' },
+  partial: { label: '일부 전송',  colorClass: 'bg-amber-500/15 text-amber-400 border-amber-500/30' },
+  failed:  { label: '실패',       colorClass: 'bg-red-500/15 text-red-400 border-red-500/30' },
+}

--- a/src/app/alerts/history/page.tsx
+++ b/src/app/alerts/history/page.tsx
@@ -1,0 +1,18 @@
+import Header from '@/components/layout/Header'
+import AlertHistoryClient from './AlertHistoryClient'
+
+export const dynamic = 'force-dynamic'
+
+export default function AlertHistoryPage() {
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[1200px]">
+      <Header
+        title="알림 이력"
+        sub="텔레그램으로 발송된 알림 히스토리 (기간·종류·티커 필터)"
+      />
+      <div className="mt-5">
+        <AlertHistoryClient />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/alerts/history/__tests__/shared.test.ts
+++ b/src/app/api/alerts/history/__tests__/shared.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets } from '../shared'
+
+describe('KNOWN_KINDS', () => {
+  it('9종 kind 를 모두 포함 (33-A AlertHistory 매핑과 동기화)', () => {
+    for (const k of [
+      'surge', 'drop', 'fx',
+      'target_hit', 'stop_loss',
+      'watch_buy', 'watch_zone',
+      'ta_signal', 'custom_strategy',
+    ]) {
+      expect(KNOWN_KINDS.has(k)).toBe(true)
+    }
+    expect(KNOWN_KINDS.size).toBe(9)
+  })
+
+  it('알려지지 않은 값은 false', () => {
+    expect(KNOWN_KINDS.has('unknown')).toBe(false)
+    expect(KNOWN_KINDS.has('')).toBe(false)
+  })
+})
+
+describe('parseISOOrNull', () => {
+  it('ISO 문자열 → Date', () => {
+    const d = parseISOOrNull('2026-07-08T00:00:00Z')
+    expect(d?.toISOString()).toBe('2026-07-08T00:00:00.000Z')
+  })
+
+  it('잘못된 형식 → null', () => {
+    expect(parseISOOrNull('not-a-date')).toBeNull()
+    expect(parseISOOrNull('2026-13-40')).toBeNull()
+  })
+
+  it('undefined/null/빈문자열 → null', () => {
+    expect(parseISOOrNull(undefined)).toBeNull()
+    expect(parseISOOrNull(null)).toBeNull()
+    expect(parseISOOrNull('')).toBeNull()
+  })
+})
+
+describe('kstDateKey', () => {
+  it('UTC 00:00 → KST 09:00 → 같은 날짜', () => {
+    expect(kstDateKey(new Date('2026-07-08T00:00:00Z'))).toBe('2026-07-08')
+  })
+  it('UTC 15:00 → KST 00:00 (다음날)', () => {
+    expect(kstDateKey(new Date('2026-07-07T15:00:00Z'))).toBe('2026-07-08')
+  })
+  it('UTC 14:59 → KST 23:59 (같은 날)', () => {
+    expect(kstDateKey(new Date('2026-07-07T14:59:00Z'))).toBe('2026-07-07')
+  })
+})
+
+describe('buildKstDayBuckets (self-review P1 회귀 방지 #417)', () => {
+  it('간단 3일 범위, 이벤트 없음 → 연속 버킷 3개', () => {
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-03T00:00:00Z')
+    const buckets = buildKstDayBuckets(new Map(), from, to)
+    expect(buckets.map((b) => b.date)).toEqual(['2026-07-01', '2026-07-02', '2026-07-03'])
+    expect(buckets.every((b) => b.count === 0)).toBe(true)
+  })
+
+  it('KST 자정 넘어가는 from/to (UTC 시각 불일치) 도 trailing 날짜 포함', () => {
+    // effectiveFrom = 07-01 14:59 UTC = 07-01 23:59 KST → key 07-01
+    // effectiveTo   = 07-08 15:00 UTC = 07-09 00:00 KST → key 07-09
+    // 이전 버그: cursor 가 UTC 14:59 고정으로 진행 → 07-08 14:59 UTC 에서 종료 → 07-09 누락.
+    const from = new Date('2026-07-01T14:59:00Z')
+    const to = new Date('2026-07-08T15:00:00Z')
+    const buckets = buildKstDayBuckets(new Map(), from, to)
+    const dates = buckets.map((b) => b.date)
+    expect(dates[0]).toBe('2026-07-01')
+    expect(dates[dates.length - 1]).toBe('2026-07-09')
+    expect(dates).toContain('2026-07-08')
+    expect(dates).toContain('2026-07-09')
+    // 중복/누락 없이 연속 KST 날짜 9개
+    expect(dates.length).toBe(9)
+  })
+
+  it('countsByKey 값이 있으면 해당 날짜 count 반영', () => {
+    const counts = new Map([['2026-07-02', 3], ['2026-07-03', 1]])
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-03T00:00:00Z')
+    const buckets = buildKstDayBuckets(counts, from, to)
+    expect(buckets).toEqual([
+      { date: '2026-07-01', count: 0 },
+      { date: '2026-07-02', count: 3 },
+      { date: '2026-07-03', count: 1 },
+    ])
+  })
+
+  it('to < from → 빈 배열', () => {
+    const buckets = buildKstDayBuckets(
+      new Map(),
+      new Date('2026-07-05T00:00:00Z'),
+      new Date('2026-07-01T00:00:00Z'),
+    )
+    expect(buckets).toEqual([])
+  })
+
+  it('같은 날 (from == to) → 1개 버킷', () => {
+    const d = new Date('2026-07-08T05:00:00Z')
+    const buckets = buildKstDayBuckets(new Map([['2026-07-08', 2]]), d, d)
+    expect(buckets).toEqual([{ date: '2026-07-08', count: 2 }])
+  })
+})

--- a/src/app/api/alerts/history/__tests__/shared.test.ts
+++ b/src/app/api/alerts/history/__tests__/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets } from '../shared'
+import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets, parseKindsParam } from '../shared'
 
 describe('KNOWN_KINDS', () => {
   it('9종 kind 를 모두 포함 (33-A AlertHistory 매핑과 동기화)', () => {
@@ -35,6 +35,46 @@ describe('parseISOOrNull', () => {
     expect(parseISOOrNull(undefined)).toBeNull()
     expect(parseISOOrNull(null)).toBeNull()
     expect(parseISOOrNull('')).toBeNull()
+  })
+})
+
+describe('parseKindsParam (Codex #424 P2 회귀 방지)', () => {
+  it('반복 파라미터 (`?kind=a&kind=b`) → kinds 배열', () => {
+    const p = new URLSearchParams('kind=drop&kind=surge')
+    const r = parseKindsParam(p)
+    expect(new Set(r.kinds)).toEqual(new Set(['drop', 'surge']))
+    expect(r.invalid).toEqual([])
+  })
+
+  it('CSV (`?kind=a,b`) 도 지원', () => {
+    const p = new URLSearchParams('kind=drop,surge')
+    const r = parseKindsParam(p)
+    expect(new Set(r.kinds)).toEqual(new Set(['drop', 'surge']))
+  })
+
+  it('반복 + CSV 혼합, 중복 제거', () => {
+    const p = new URLSearchParams('kind=drop,surge&kind=drop&kind=fx')
+    const r = parseKindsParam(p)
+    expect(new Set(r.kinds)).toEqual(new Set(['drop', 'surge', 'fx']))
+  })
+
+  it('알려지지 않은 kind → invalid 로 분리', () => {
+    const p = new URLSearchParams('kind=drop&kind=nope&kind=xyz')
+    const r = parseKindsParam(p)
+    expect(r.kinds).toEqual(['drop'])
+    expect(new Set(r.invalid)).toEqual(new Set(['nope', 'xyz']))
+  })
+
+  it('kind 파라미터 없음 → 빈 배열', () => {
+    const r = parseKindsParam(new URLSearchParams(''))
+    expect(r.kinds).toEqual([])
+    expect(r.invalid).toEqual([])
+  })
+
+  it('공백/빈 문자열 제거', () => {
+    const p = new URLSearchParams('kind=  ,,drop, ')
+    const r = parseKindsParam(p)
+    expect(r.kinds).toEqual(['drop'])
   })
 })
 

--- a/src/app/api/alerts/history/route.ts
+++ b/src/app/api/alerts/history/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { paginated, fail } from '@/lib/api-response'
 import type { Prisma } from '@prisma/client'
-import { KNOWN_KINDS, parseISOOrNull } from './shared'
+import { parseISOOrNull, parseKindsParam } from './shared'
 
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
@@ -19,15 +19,15 @@ export const dynamic = 'force-dynamic'
 export async function GET(req: NextRequest) {
   try {
     const url = req.nextUrl
-    const kind = url.searchParams.get('kind')?.trim() || undefined
+    const { kinds, invalid } = parseKindsParam(url.searchParams)
     const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
     const fromStr = url.searchParams.get('from')?.trim() || undefined
     const toStr = url.searchParams.get('to')?.trim() || undefined
     const limitStr = url.searchParams.get('limit')
     const offsetStr = url.searchParams.get('offset')
 
-    if (kind && !KNOWN_KINDS.has(kind)) {
-      return fail(`알 수 없는 kind: ${kind}`, 400)
+    if (invalid.length > 0) {
+      return fail(`알 수 없는 kind: ${invalid.join(', ')}`, 400)
     }
     const from = parseISOOrNull(fromStr)
     const to = parseISOOrNull(toStr)
@@ -49,13 +49,16 @@ export async function GET(req: NextRequest) {
     const where: Prisma.AlertHistoryWhereInput = {
       firedAt: { gte: effectiveFrom, lte: effectiveTo },
     }
-    if (kind) where.kind = kind
+    if (kinds.length === 1) where.kind = kinds[0]
+    else if (kinds.length > 1) where.kind = { in: kinds }
     if (rawTicker) where.ticker = rawTicker.toUpperCase()
 
     const [rows, total] = await Promise.all([
       prisma.alertHistory.findMany({
         where,
-        orderBy: { firedAt: 'desc' },
+        // Codex P2 (#417 PR #424): 동일 firedAt (배치 발송 시 다수 이벤트) 에서 page skip
+        // 순서가 비결정적 → 페이지 넘김 시 rows 누락/중복. id 로 tiebreak.
+        orderBy: [{ firedAt: 'desc' }, { id: 'desc' }],
         skip: offset,
         take: limit,
       }),

--- a/src/app/api/alerts/history/route.ts
+++ b/src/app/api/alerts/history/route.ts
@@ -1,0 +1,86 @@
+/**
+ * Phase 33-B (#417) — 알림 발동 이력 조회 API.
+ * GET /api/alerts/history?kind=&ticker=&from=&to=&limit=&offset=
+ * envelope: paginated({ items, meta })
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { paginated, fail } from '@/lib/api-response'
+import type { Prisma } from '@prisma/client'
+import { KNOWN_KINDS, parseISOOrNull } from './shared'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+const DEFAULT_LOOKBACK_DAYS = 7
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const kind = url.searchParams.get('kind')?.trim() || undefined
+    const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
+    const fromStr = url.searchParams.get('from')?.trim() || undefined
+    const toStr = url.searchParams.get('to')?.trim() || undefined
+    const limitStr = url.searchParams.get('limit')
+    const offsetStr = url.searchParams.get('offset')
+
+    if (kind && !KNOWN_KINDS.has(kind)) {
+      return fail(`알 수 없는 kind: ${kind}`, 400)
+    }
+    const from = parseISOOrNull(fromStr)
+    const to = parseISOOrNull(toStr)
+    if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
+    if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
+
+    let limit = limitStr ? parseInt(limitStr, 10) : DEFAULT_LIMIT
+    if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT
+    limit = Math.min(limit, MAX_LIMIT)
+
+    let offset = offsetStr ? parseInt(offsetStr, 10) : 0
+    if (!Number.isFinite(offset) || offset < 0) offset = 0
+
+    // 기본 기간: 최근 N일 (from/to 미지정 시)
+    const now = new Date()
+    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+    const effectiveTo = to ?? now
+
+    const where: Prisma.AlertHistoryWhereInput = {
+      firedAt: { gte: effectiveFrom, lte: effectiveTo },
+    }
+    if (kind) where.kind = kind
+    if (rawTicker) where.ticker = rawTicker.toUpperCase()
+
+    const [rows, total] = await Promise.all([
+      prisma.alertHistory.findMany({
+        where,
+        orderBy: { firedAt: 'desc' },
+        skip: offset,
+        take: limit,
+      }),
+      prisma.alertHistory.count({ where }),
+    ])
+
+    return paginated(
+      rows.map((r) => ({
+        id: r.id,
+        firedAt: r.firedAt.toISOString(),
+        kind: r.kind,
+        ticker: r.ticker,
+        price: r.price,
+        changePercent: r.changePercent,
+        message: r.message,
+        deliveryStatus: r.deliveryStatus,
+        recipientCount: r.recipientCount,
+        errorMessage: r.errorMessage,
+      })),
+      total,
+      limit,
+      offset,
+    )
+  } catch (error) {
+    console.error('GET /api/alerts/history error:', error)
+    return fail('알림 이력 조회에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/alerts/history/shared.ts
+++ b/src/app/api/alerts/history/shared.ts
@@ -1,0 +1,50 @@
+/**
+ * Phase 33-B (#417) — /api/alerts/history 및 stats 라우트 공용.
+ */
+
+export const KNOWN_KINDS = new Set([
+  'surge', 'drop', 'fx',
+  'target_hit', 'stop_loss',
+  'watch_buy', 'watch_zone',
+  'ta_signal', 'custom_strategy',
+])
+
+export function parseISOOrNull(s: string | undefined | null): Date | null {
+  if (!s) return null
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/** UTC Date → KST YYYY-MM-DD (버킷 키) */
+export function kstDateKey(d: Date): string {
+  const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  return kst.toISOString().slice(0, 10)
+}
+
+/**
+ * KST 기준 [from, to] 범위의 모든 날짜 버킷을 반환 (라인 차트 X 축용).
+ *
+ * 이전 구현 (self-review P1, #417): effectiveFrom 의 UTC time-of-day 를 고정한 채
+ * `+24h` 씩 순회 → from/to 의 UTC 시각이 KST 자정을 사이에 두고 어긋나면 마지막
+ * KST 날짜 버킷이 loop 조건에서 누락되어 byDayMap 은 count 있지만 결과에서 사라짐.
+ *
+ * 대신 KST 달력 일을 직접 순회 — `${key}T00:00:00Z` 를 baseline 으로 하고 +24h UTC
+ * (=+1일 KST) 씩 진행하며 kstDateKey 를 다시 계산.
+ */
+export function buildKstDayBuckets(
+  countsByKey: Map<string, number>,
+  from: Date,
+  to: Date,
+): Array<{ date: string; count: number }> {
+  const startKey = kstDateKey(from)
+  const endKey = kstDateKey(to)
+  if (startKey > endKey) return []
+  const out: Array<{ date: string; count: number }> = []
+  let cursor = new Date(`${startKey}T00:00:00Z`)
+  while (kstDateKey(cursor) <= endKey) {
+    const key = kstDateKey(cursor)
+    out.push({ date: key, count: countsByKey.get(key) ?? 0 })
+    cursor = new Date(cursor.getTime() + 24 * 60 * 60 * 1000)
+  }
+  return out
+}

--- a/src/app/api/alerts/history/shared.ts
+++ b/src/app/api/alerts/history/shared.ts
@@ -15,6 +15,25 @@ export function parseISOOrNull(s: string | undefined | null): Date | null {
   return Number.isNaN(d.getTime()) ? null : d
 }
 
+/**
+ * `kind` 쿼리 파라미터 정규화 — repeated (`?kind=a&kind=b`) 와 CSV (`?kind=a,b`) 모두 허용.
+ * Codex P2 (#417 PR #424): 다중 kind 를 서버에서 지원해야 페이지네이션/집계가
+ * 정합. 이전 구현은 클라 다중 선택 시 서버 필터를 skip 하고 페이지 후 클라 필터 →
+ * 페이지 넘어간 rows 누락, 총계/stats 는 전체 kind 반영 (부정확).
+ *
+ * 반환: `{ kinds, invalid }` — invalid 는 whitelist 에 없는 kind 리스트 (400 응답용).
+ */
+export function parseKindsParam(params: URLSearchParams): {
+  kinds: string[]
+  invalid: string[]
+} {
+  const raw = params.getAll('kind').flatMap((v) => v.split(',')).map((s) => s.trim()).filter(Boolean)
+  const unique = Array.from(new Set(raw))
+  const kinds = unique.filter((k) => KNOWN_KINDS.has(k))
+  const invalid = unique.filter((k) => !KNOWN_KINDS.has(k))
+  return { kinds, invalid }
+}
+
 /** UTC Date → KST YYYY-MM-DD (버킷 키) */
 export function kstDateKey(d: Date): string {
   const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000)

--- a/src/app/api/alerts/history/stats/route.ts
+++ b/src/app/api/alerts/history/stats/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { ok, fail } from '@/lib/api-response'
 import type { Prisma } from '@prisma/client'
-import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets } from '../shared'
+import { parseISOOrNull, parseKindsParam, buildKstDayBuckets, kstDateKey } from '../shared'
 
 const DEFAULT_LOOKBACK_DAYS = 7
 
@@ -17,13 +17,13 @@ export const dynamic = 'force-dynamic'
 export async function GET(req: NextRequest) {
   try {
     const url = req.nextUrl
-    const kind = url.searchParams.get('kind')?.trim() || undefined
+    const { kinds, invalid } = parseKindsParam(url.searchParams)
     const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
     const fromStr = url.searchParams.get('from')?.trim() || undefined
     const toStr = url.searchParams.get('to')?.trim() || undefined
 
-    if (kind && !KNOWN_KINDS.has(kind)) {
-      return fail(`알 수 없는 kind: ${kind}`, 400)
+    if (invalid.length > 0) {
+      return fail(`알 수 없는 kind: ${invalid.join(', ')}`, 400)
     }
     const from = parseISOOrNull(fromStr)
     const to = parseISOOrNull(toStr)
@@ -37,7 +37,8 @@ export async function GET(req: NextRequest) {
     const where: Prisma.AlertHistoryWhereInput = {
       firedAt: { gte: effectiveFrom, lte: effectiveTo },
     }
-    if (kind) where.kind = kind
+    if (kinds.length === 1) where.kind = kinds[0]
+    else if (kinds.length > 1) where.kind = { in: kinds }
     if (rawTicker) where.ticker = rawTicker.toUpperCase()
 
     const rows = await prisma.alertHistory.findMany({

--- a/src/app/api/alerts/history/stats/route.ts
+++ b/src/app/api/alerts/history/stats/route.ts
@@ -1,0 +1,82 @@
+/**
+ * Phase 33-B (#417) — 알림 이력 통계.
+ * GET /api/alerts/history/stats?kind=&ticker=&from=&to=
+ * 반환: total, byStatus, byKind, byDay (KST 기준 날짜 버킷).
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
+import type { Prisma } from '@prisma/client'
+import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets } from '../shared'
+
+const DEFAULT_LOOKBACK_DAYS = 7
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const kind = url.searchParams.get('kind')?.trim() || undefined
+    const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
+    const fromStr = url.searchParams.get('from')?.trim() || undefined
+    const toStr = url.searchParams.get('to')?.trim() || undefined
+
+    if (kind && !KNOWN_KINDS.has(kind)) {
+      return fail(`알 수 없는 kind: ${kind}`, 400)
+    }
+    const from = parseISOOrNull(fromStr)
+    const to = parseISOOrNull(toStr)
+    if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
+    if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
+
+    const now = new Date()
+    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+    const effectiveTo = to ?? now
+
+    const where: Prisma.AlertHistoryWhereInput = {
+      firedAt: { gte: effectiveFrom, lte: effectiveTo },
+    }
+    if (kind) where.kind = kind
+    if (rawTicker) where.ticker = rawTicker.toUpperCase()
+
+    const rows = await prisma.alertHistory.findMany({
+      where,
+      select: { firedAt: true, kind: true, deliveryStatus: true },
+    })
+
+    const byKindMap = new Map<string, number>()
+    const byStatusMap = new Map<string, number>()
+    const byDayMap = new Map<string, number>()
+
+    for (const r of rows) {
+      byKindMap.set(r.kind, (byKindMap.get(r.kind) ?? 0) + 1)
+      byStatusMap.set(r.deliveryStatus, (byStatusMap.get(r.deliveryStatus) ?? 0) + 1)
+      const day = kstDateKey(r.firedAt)
+      byDayMap.set(day, (byDayMap.get(day) ?? 0) + 1)
+    }
+
+    // 기간 내 모든 KST 날짜를 0 으로 채워 연속 버킷 반환 (라인 차트용).
+    // self-review P1 (#417): KST 자정을 사이에 둔 from/to 조합에서 trailing KST 날짜
+    // 누락 → shared.ts 의 buildKstDayBuckets 로 분리해 pure test 로 회귀 방지.
+    const byDay = buildKstDayBuckets(byDayMap, effectiveFrom, effectiveTo)
+
+    const byKind = Array.from(byKindMap.entries())
+      .map(([k, count]) => ({ kind: k, count }))
+      .sort((a, b) => b.count - a.count)
+
+    return ok({
+      total: rows.length,
+      byStatus: {
+        sent: byStatusMap.get('sent') ?? 0,
+        partial: byStatusMap.get('partial') ?? 0,
+        failed: byStatusMap.get('failed') ?? 0,
+      },
+      byKind,
+      byDay,
+    })
+  } catch (error) {
+    console.error('GET /api/alerts/history/stats error:', error)
+    return fail('알림 이력 통계 조회에 실패했습니다.', 500)
+  }
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -56,6 +56,7 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     title: '설정',
     items: [
+      { href: '/alerts/history', icon: '🔔', label: '알림 이력' },
       { href: '/settings', icon: '⚙️', label: '설정', hiddenOnMobile: true },
     ],
   },


### PR DESCRIPTION
## Summary
#416 에서 축적된 AlertHistory 를 웹에서 조회 (필터·차트·리스트). 텔레그램 알림 사후 확인용.

- Master: #414 (15차). Spec: `docs/specs/417-alert-history-page.md`
- API 2개: 리스트 (paginated) + stats (byStatus/byKind/byDay KST 연속 버킷)
- 페이지: 기간·kind 칩·ticker 필터, Recharts (라인/파이), 리스트+페이지네이션
- 보안: 미들웨어 auth 통과, message 는 `stripHtml` 로 plain text 렌더 (XSS 방어)
- 네비: `NAV_GROUPS` 설정 그룹에 자동 노출 (사이드바+모바일 파생)

## Verify skill 결과 (실행 파일 참조 아닌 실제 running 서버)
- 200 render, 401 without auth (curl 검증)
- 400 on bad kind/from
- ticker=aapl → 정규화 → AAPL 매치
- limit=1000 → 200 clamp, limit=-5 → 50 fallback
- stats 필터 조합 시 byStatus/byKind 정확
- byDay 연속 버킷 (empty 도 0 으로 채움)

## Self-review (pr-review-toolkit)
- P2 0 / **P1 1 (byDay KST 자정 넘김 trailing 날짜 누락)** → 반영: `buildKstDayBuckets` pure 함수 분리 + 회귀 방지 테스트
- P0 0

## Test plan
- [x] lint / typecheck / test (348) / build 통과
- [x] self-review P1 반영
- [x] verify (API surface 전수)
- [ ] 브라우저 하이드레이션 검증 (Chrome extension 필요 — 배포 후 사용자 확인)

Closes #417