### PR TITLE
feat(strategy): 어닝 캘린더 조건 (Phase 34-A, #419)

### DIFF
--- a/docs/specs/419-earnings-condition.md
+++ b/docs/specs/419-earnings-condition.md
@@ -1,0 +1,93 @@
+# [Phase 34-A] 커스텀 전략 v3 — 어닝 캘린더 조건
+
+- **이슈**: #419
+- **마스터**: #414
+- **작성일**: 2026-07-08
+
+## 목표
+
+커스텀 전략 v2 조건에 **`earnings_within_days`** 추가. 어닝 임박 종목에 대한 진입 회피 (D-3 이내 skip) / 어닝 안전 지대 확인 (D+7 이상 진입) 자동화.
+
+## 데이터 소스
+
+`yahoo-finance2.quoteSummary(ticker, { modules: ['calendarEvents'] })` — 무료.
+- 응답: `calendarEvents.earnings.earningsDate: Date[]` (다음 예정 어닝 배열, 보통 1~2개)
+- 실패 시 (미국 외 일부 종목 지원 X) — 캐시 유지, false-safe.
+
+## 스키마
+
+### Prisma 신규 모델
+```prisma
+model EarningsCache {
+  ticker             String    @id
+  nextEarningsDate   DateTime?
+  lastFetchedAt      DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+}
+```
+
+### Condition 확장
+```ts
+type ConditionType =
+  ... // 기존
+  | 'earnings_within_days'   // 다음 어닝까지 남은 일수
+```
+- operator: `<` / `<=` / `>` / `>=` / `==` (numeric)
+- value: 정수 (일)
+- timeframe: 미사용
+
+**의미**: `earnings_within_days <= 3` = 다음 어닝까지 3일 이하 (오늘 = 0). 데이터 없거나 이미 지난 어닝만 있으면 조건 **false** (안전측 — 진입 회피 스타일 조건이라 매치 안 됨이 안전).
+
+## 파일 변경
+
+- `prisma/schema.prisma` + migration — `EarningsCache`
+- `src/lib/earnings/fetcher.ts` (신규) — yahoo-finance2 호출, 단일 티커
+- `src/lib/earnings/cache.ts` (신규) — upsert / getByTicker
+- `src/lib/earnings/cron.ts` (신규 또는 `src/lib/cron.ts` 확장) — 일 1회 스캔, 대상 = 활성 전략 티커 ∪ 관심종목 ∪ 보유종목
+- `src/lib/custom-strategy/types.ts` — `earnings_within_days` 추가 (NUMERIC_TYPES 확장)
+- `src/lib/custom-strategy/evaluator.ts` — 조건 평가 (EarningsCache 조회 + 일수 계산)
+- `src/lib/ai/system-prompt.ts` — AI 프롬프트에 예시 추가 (자연어 → 조건 변환용)
+- `src/app/strategies/*` — 편집 폼 조건 옵션 추가
+
+## Evaluator 로직
+
+```ts
+if (condition.type === 'earnings_within_days') {
+  const cache = snapshot.earnings  // cron 이 미리 로드한 { nextEarningsDate }
+  if (!cache?.nextEarningsDate) return false
+  const days = Math.ceil((cache.nextEarningsDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000))
+  if (days < 0) return false  // 이미 지난 어닝
+  return numericCompare(days, condition.operator, condition.value)
+}
+```
+
+## Cron
+
+- 매일 KST 06:00 (미국 장 마감 후, 한국 장 시작 전)
+- 대상 티커 수집:
+  - `SELECT ticker FROM CustomStrategy WHERE isActive = true`
+  - `SELECT ticker FROM Watchlist`
+  - `SELECT DISTINCT ticker FROM Holding WHERE shares > 0`
+- 병렬 fetch (concurrency 5)
+- fetch 실패 → `lastFetchedAt` 만 업데이트, `nextEarningsDate` 유지
+- 로그: `msg='earnings_scan'`, 성공/실패 카운트
+
+## 테스트
+
+- `validateCondition` — `earnings_within_days` 통과, 잘못된 value 거부
+- `evaluator` — null cache / 과거 어닝 / 미래 D-0/D-3/D-30 시나리오
+- `fetcher` — yahoo-finance2 mock 으로 성공/실패
+- `cron` — 티커 수집 로직 (mock prisma)
+
+## 완료 조건
+
+- [ ] Prisma migration 적용
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] verify: 실제 티커 (예: AAPL) 로 fetcher → cache 반영 → evaluator 통과 확인
+
+## 제외 (34-A 이후 후속 이슈)
+
+- **Post-earnings drift** — 어닝 직후 진입 조건 (`days_since_earnings`) 별도 조건 타입 필요. 34-A 는 pre-earnings 만.
+- **어닝 EPS 실적 조건** — surprise% 기반 조건
+- **한국주 어닝** — Yahoo 는 미국 종목 위주. KRX 어닝은 별도 소스 필요.

--- a/prisma/migrations/20260708085511_add_earnings_cache/migration.sql
+++ b/prisma/migrations/20260708085511_add_earnings_cache/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "EarningsCache" (
+    "ticker" TEXT NOT NULL,
+    "nextEarningsDate" TIMESTAMP(3),
+    "lastFetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EarningsCache_pkey" PRIMARY KEY ("ticker")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -437,3 +437,12 @@ model CustomStrategy {
 
   @@index([ticker, isActive])
 }
+
+// Phase 34-A (#419): 어닝 캘린더 캐시. cron 이 일 1회 yahoo-finance2 로 갱신하고
+// evaluator 의 `earnings_within_days` 조건이 참조.
+model EarningsCache {
+  ticker           String    @id
+  nextEarningsDate DateTime?
+  lastFetchedAt    DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+}

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -15,6 +15,7 @@ import { getBot } from '@/bot/index'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { generateTAReport } from '@/lib/ta/engine'
 import type { TAReport } from '@/lib/ta/types'
+import { getEarningsMany } from '@/lib/earnings/cache'
 import {
   computeDeliveryStatus,
   recordAlertHistory,
@@ -147,6 +148,10 @@ async function runScan(chatIds: number[]): Promise<void> {
   })
   const holdings = new Set(holdingRows.map((h) => h.ticker))
 
+  // Phase 34-A (#419): 어닝 캐시 (전략 전체 티커 대상 미리 조회).
+  // 캐시 없으면 evaluator 가 자동으로 false 처리 → 안전.
+  const earningsMap = await getEarningsMany(tickers)
+
   // TA 필요한 ticker 만 리포트 생성 (병렬 + 실패 허용)
   const taByTicker = new Map<string, TAReport | null>()
 
@@ -189,11 +194,13 @@ async function runScan(chatIds: number[]): Promise<void> {
     if (!shouldFire(s.frequency, s.lastTriggeredAt, now)) continue
 
     const priceRow = priceMap.get(s.ticker)
+    const earningsRow = earningsMap.get(s.ticker)
     const snapshot: MarketSnapshot = {
       price: priceRow
         ? { price: priceRow.price, changePercent: priceRow.changePercent }
         : null,
       ta: taByTicker.get(s.ticker) ?? null,
+      earnings: earningsRow ? { nextEarningsDate: earningsRow.nextEarningsDate } : null,
     }
 
     const { satisfied, perCondition } = evaluateStrategy(

--- a/src/bot/standalone.ts
+++ b/src/bot/standalone.ts
@@ -9,7 +9,7 @@
 
 import 'dotenv/config'
 import { getBot } from './index'
-import { schedulePriceUpdates, scheduleSnapshots, scheduleKrxSync, scheduleRecurring, scheduleVestingStatusUpdate } from '@/lib/cron'
+import { schedulePriceUpdates, scheduleSnapshots, scheduleKrxSync, scheduleRecurring, scheduleVestingStatusUpdate, scheduleEarningsScan } from '@/lib/cron'
 import { scheduleNotifications } from './notifications/scheduler'
 import { sanitizeError } from './utils/error'
 
@@ -31,6 +31,7 @@ async function main(): Promise<void> {
   scheduleKrxSync()
   scheduleRecurring()
   scheduleVestingStatusUpdate()
+  scheduleEarningsScan()
   scheduleNotifications()
   console.log('[bot] cron + 알림 스케줄러 등록 완료')
 

--- a/src/lib/__tests__/kst-date.test.ts
+++ b/src/lib/__tests__/kst-date.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { kstMidnightUtc, isSameOrFutureKstDay, kstDayDiff } from '../kst-date'
+
+describe('kstMidnightUtc', () => {
+  it('KST 자정 (UTC 15:00 전날) 을 그 UTC 값으로 반환', () => {
+    // 2026-07-30 00:00 KST = 2026-07-29 15:00 UTC
+    const d = new Date('2026-07-30T05:00:00Z')  // KST 14:00
+    expect(new Date(kstMidnightUtc(d)).toISOString()).toBe('2026-07-29T15:00:00.000Z')
+  })
+
+  it('UTC 자정도 KST 09:00 → 같은 KST 캘린더 일', () => {
+    const d = new Date('2026-07-30T00:00:00Z')  // KST 09:00
+    const midnight = new Date('2026-07-30T05:00:00Z')  // KST 14:00 (같은 KST 날짜)
+    expect(kstMidnightUtc(d)).toBe(kstMidnightUtc(midnight))
+  })
+})
+
+describe('isSameOrFutureKstDay (Codex #426 P2 회귀 방지)', () => {
+  it('yahoo earnings 값이 UTC 자정 (=KST 09:00) 인데 스캔이 KST 오후 → 같은 KST 날 → true', () => {
+    const earnings = new Date('2026-07-30T00:00:00Z')  // KST 07-30 09:00
+    const scanNow = new Date('2026-07-30T05:00:00Z')   // KST 07-30 14:00
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(true)
+  })
+
+  it('어닝이 KST 어제 자정 → false', () => {
+    const earnings = new Date('2026-07-29T20:00:00Z')  // KST 07-30 05:00 (같은 KST 날)
+    const scanNow = new Date('2026-07-31T05:00:00Z')   // KST 07-31 14:00
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(false)
+  })
+
+  it('어닝이 KST 내일 → true', () => {
+    const earnings = new Date('2026-07-31T00:00:00Z')  // KST 07-31 09:00
+    const scanNow = new Date('2026-07-30T05:00:00Z')   // KST 07-30
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(true)
+  })
+
+  it('KST 자정 경계 정확도: now 가 KST 23:59, 어닝이 KST 다음날 00:00 → future', () => {
+    const scanNow = new Date('2026-07-30T14:59:00Z')   // KST 07-30 23:59
+    const earnings = new Date('2026-07-30T15:00:00Z')  // KST 07-31 00:00
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(true)
+  })
+})
+
+describe('kstDayDiff', () => {
+  it('같은 KST 날 → 0 (시각 무관)', () => {
+    const a = new Date('2026-07-30T00:00:00Z')  // KST 09:00
+    const b = new Date('2026-07-30T14:00:00Z')  // KST 23:00
+    expect(kstDayDiff(a, b)).toBe(0)
+    expect(kstDayDiff(b, a)).toBe(0)
+  })
+
+  it('내일 vs 오늘 → +1 / -1', () => {
+    const today = new Date('2026-07-30T00:00:00Z')
+    const tomorrow = new Date('2026-07-31T00:00:00Z')
+    expect(kstDayDiff(tomorrow, today)).toBe(1)
+    expect(kstDayDiff(today, tomorrow)).toBe(-1)
+  })
+
+  it('3일 뒤 → 3', () => {
+    const today = new Date('2026-07-30T00:00:00Z')
+    const d3 = new Date('2026-08-02T20:00:00Z')  // KST 08-03 05:00 → 4일 뒤 아님, 3일 뒤 KST 8-2
+    // 실제로 2026-07-30 (KST 07-30 09:00) → 2026-08-02T20:00Z (KST 08-03 05:00): 4일 뒤
+    // 다른 예시 사용
+    const d3proper = new Date('2026-08-01T20:00:00Z')  // KST 08-02 05:00 → 3일 뒤
+    expect(kstDayDiff(d3proper, today)).toBe(3)
+    // sanity
+    expect(kstDayDiff(d3, today)).toBe(4)
+  })
+})

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -138,6 +138,42 @@ export function scheduleSnapshots(): void {
 }
 
 /**
+ * Phase 34-A (#419) — 어닝 캘린더 갱신 스케줄러.
+ * 매일 06:00 KST — 스냅샷과 겹치지 않는 5분 앞 슬롯. 미국장 마감 후 신선.
+ * 부팅 후 첫 실행은 다음 06:00 을 기다림 (부팅 즉시 실행하면 rate limit 부담).
+ */
+export function scheduleEarningsScan(): void {
+  const guard = createCronGuard('어닝 스캔', 5 * 60 * 1000)
+
+  async function runOnce(): Promise<void> {
+    await guard(async () => {
+      const { runEarningsScan } = await import('./earnings/cron')
+      const result = await runEarningsScan()
+      console.log(`[cron] 어닝 스캔 완료: attempted=${result.attempted} ok=${result.ok} failed=${result.failed}`)
+    })
+  }
+
+  cron.schedule('0 6 * * *', () => { void runOnce() }, { timezone: 'Asia/Seoul' })
+
+  // 부팅 즉시 초기 시드 — cache 가 비어 있으면 다음 06:00 KST 까지 대기하는 대신 채움.
+  // 신규 배포 후 최대 24h dead window (모든 earnings_within_days 조건 false) 회피
+  // (self-review P1, #419). scheduleKrxSync 와 동일 패턴 (cron.ts scheduleKrxSync 참고).
+  void (async () => {
+    try {
+      const count = await prisma.earningsCache.count()
+      if (count === 0) {
+        console.log('[cron] EarningsCache empty → 초기 시드 실행')
+        await runOnce()
+      }
+    } catch (error) {
+      console.error('[cron] 어닝 초기 시드 실패:', error)
+    }
+  })()
+
+  console.log('[cron] 어닝 스캔 스케줄러 등록 (매일 06:00 KST)')
+}
+
+/**
  * KRX 종목 리스트 동기화 스케줄러.
  * 매주 월요일 07:00 KST 실행.
  */

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -3,6 +3,7 @@ import {
   evaluateCondition,
   evaluateStrategy,
   requiresTA,
+  daysUntilEarnings,
   type MarketSnapshot,
   type EvaluationContext,
 } from '../evaluator'
@@ -250,6 +251,90 @@ describe('evaluateCondition — v2 holding_status', () => {
   })
 })
 
+describe('daysUntilEarnings (v3 pure, #419) — KST 캘린더 일수', () => {
+  // KST 자정 기준. 2026-01-05 00:00 KST = 2026-01-04 15:00 UTC.
+  const now = new Date('2026-01-04T15:00:00Z')  // KST 2026-01-05 00:00
+
+  it('null / undefined → null', () => {
+    expect(daysUntilEarnings(null, now)).toBeNull()
+    expect(daysUntilEarnings(undefined, now)).toBeNull()
+  })
+
+  it('과거 어닝 (KST 어제) → null', () => {
+    // KST 2026-01-04 12:00 = UTC 2026-01-04 03:00 (now 보다 12h 이전)
+    expect(daysUntilEarnings(new Date('2026-01-04T03:00:00Z'), now)).toBeNull()
+  })
+
+  it('같은 KST 날짜 어닝 → 0', () => {
+    // KST 2026-01-05 15:00 = UTC 2026-01-05 06:00
+    expect(daysUntilEarnings(new Date('2026-01-05T06:00:00Z'), now)).toBe(0)
+  })
+
+  it('내일 (KST 2026-01-06 아무 시각) → 1', () => {
+    // KST 2026-01-06 00:30 = UTC 2026-01-05 15:30
+    expect(daysUntilEarnings(new Date('2026-01-05T15:30:00Z'), now)).toBe(1)
+    // KST 2026-01-06 23:59 = UTC 2026-01-06 14:59
+    expect(daysUntilEarnings(new Date('2026-01-06T14:59:00Z'), now)).toBe(1)
+  })
+
+  it('KST 3일 뒤 어닝 → 3', () => {
+    // KST 2026-01-08 09:00 = UTC 2026-01-08 00:00
+    expect(daysUntilEarnings(new Date('2026-01-08T00:00:00Z'), now)).toBe(3)
+  })
+
+  it('now 가 KST 23:59, 어닝이 다음 KST 00:00 → D-1 (자정 경계)', () => {
+    // now KST 2026-01-05 23:59 = UTC 2026-01-05 14:59
+    const late = new Date('2026-01-05T14:59:00Z')
+    // 어닝 KST 2026-01-06 00:00 = UTC 2026-01-05 15:00
+    expect(daysUntilEarnings(new Date('2026-01-05T15:00:00Z'), late)).toBe(1)
+  })
+})
+
+describe('evaluateCondition — v3 earnings_within_days (#419)', () => {
+  // now = KST 2026-01-05 00:00 = UTC 2026-01-04 15:00
+  const now = new Date('2026-01-04T15:00:00Z')
+  const ctx = makeContext({ now })
+  // KST 날짜 → UTC 00:00 shift (KST 는 UTC-9h). 편의 헬퍼.
+  const kstDate = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d - 1, 15, 0, 0))
+
+  it('데이터 없음 → false (안전측)', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    expect(evaluateCondition(cond, makeSnapshot({ earnings: null }), ctx)).toBe(false)
+    // earnings undefined 도 같은 처리
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('과거 어닝 → false', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 3) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(false)
+  })
+
+  it('KST 3일 뒤 어닝 (D-3), <=3 → true', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 8) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(true)
+  })
+
+  it('KST 7일 뒤 어닝, <=3 → false', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 12) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(false)
+  })
+
+  it('KST 7일 뒤 어닝, >=5 → true', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '>=', value: 5 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 12) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(true)
+  })
+
+  it('value 문자열 → false (validate 통과했더라도 evaluator 방어)', () => {
+    const cond = { type: 'earnings_within_days', operator: '<=', value: '3' } as unknown as Condition
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 8) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(false)
+  })
+})
+
 describe('evaluateStrategy', () => {
   const c1: Condition = { type: 'price', operator: '<=', value: 200 }
   const c2: Condition = { type: 'price', operator: '>=', value: 50 }
@@ -306,5 +391,9 @@ describe('requiresTA', () => {
     expect(requiresTA([{ type: 'time_window', operator: 'is', value: '09:00~15:30' }])).toBe(false)
     expect(requiresTA([{ type: 'weekday', operator: 'is', value: ['MON'] }])).toBe(false)
     expect(requiresTA([{ type: 'holding_status', operator: 'is', value: 'HELD' }])).toBe(false)
+  })
+
+  it('v3 earnings_within_days → TA 불필요 (EarningsCache 만 참조)', () => {
+    expect(requiresTA([{ type: 'earnings_within_days', operator: '<=', value: 3 }])).toBe(false)
   })
 })

--- a/src/lib/custom-strategy/__tests__/types.test.ts
+++ b/src/lib/custom-strategy/__tests__/types.test.ts
@@ -201,4 +201,50 @@ describe('conditionToString', () => {
       conditionToString({ type: 'holding_status', operator: 'is', value: 'HELD' }),
     ).toBe('holding_status is HELD')
   })
+
+  it('earnings_within_days 정수 (v3)', () => {
+    expect(
+      conditionToString({ type: 'earnings_within_days', operator: '<=', value: 3 }),
+    ).toBe('earnings_within_days <= 3')
+  })
+})
+
+describe('earnings_within_days (v3, Phase 34-A / #419)', () => {
+  it('숫자 연산자 5개 모두 허용, 정수 값', () => {
+    for (const op of ['<', '<=', '>', '>=', '==']) {
+      expect(
+        validateCondition({ type: 'earnings_within_days', operator: op, value: 3 }),
+      ).toBe(true)
+    }
+  })
+
+  it('음수 값 거부 (미래 카운트다운 의미상)', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '>=', value: -1 }),
+    ).toBe(false)
+  })
+
+  it('소수 값 거부 (일 단위 정수만)', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '<=', value: 1.5 }),
+    ).toBe(false)
+  })
+
+  it('is 연산자 거부 (numeric 타입)', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: 'is', value: 3 }),
+    ).toBe(false)
+  })
+
+  it('value 문자열 거부', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '<=', value: '3' }),
+    ).toBe(false)
+  })
+
+  it('0 (오늘 어닝) 허용', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '==', value: 0 }),
+    ).toBe(true)
+  })
 })

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -24,6 +24,11 @@ export interface PriceSnapshot {
 export interface MarketSnapshot {
   price: PriceSnapshot | null
   ta: TAReport | null
+  /**
+   * Phase 34-A (#419): 어닝 캘린더 스냅샷. `earnings_within_days` 조건 평가용.
+   * cron 이 upsert 한 EarningsCache 를 호출자가 주입.
+   */
+  earnings?: { nextEarningsDate: Date | null } | null
 }
 
 /**
@@ -74,6 +79,32 @@ function kstWeekday(now: Date): WeekdayCode {
   const dow = kst.getUTCDay() // 0=Sun, 1=Mon, ...
   const codes: WeekdayCode[] = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
   return codes[dow]
+}
+
+/**
+ * Pure — 다음 어닝까지 남은 KST 캘린더 일수.
+ * 양쪽을 KST 자정으로 정규화한 뒤 계산 → 사용자 인식 ("D-3") 과 정합.
+ *
+ * 예시 (KST):
+ *   - now 07-08 15:00, earnings 07-08 20:00 → 0  (오늘)
+ *   - now 07-08 15:00, earnings 07-09 00:30 → 1  (내일)
+ *   - now 07-08 00:01, earnings 07-11 23:59 → 3  (D-3)
+ *   - now 07-08 23:59, earnings 07-09 00:00 → 1  (자정 넘어감 → D-1)
+ * 이미 지난 어닝 (KST 어제 이전) → `null` → evaluator false.
+ */
+export function daysUntilEarnings(nextEarningsDate: Date | null | undefined, now: Date): number | null {
+  if (!nextEarningsDate) return null
+  // KST 자정 정규화: UTC 를 +9h shift 한 뒤 시/분/초/ms 를 0 으로 잘라 KST 자정 UTC 표현.
+  const kstMidnightUtc = (d: Date): number => {
+    const shifted = d.getTime() + 9 * 60 * 60 * 1000
+    const day = Math.floor(shifted / (24 * 60 * 60 * 1000))
+    return day * 24 * 60 * 60 * 1000
+  }
+  const nowDay = kstMidnightUtc(now)
+  const earningsDay = kstMidnightUtc(nextEarningsDate)
+  const diffDays = Math.round((earningsDay - nowDay) / (24 * 60 * 60 * 1000))
+  if (diffDays < 0) return null
+  return diffDays
 }
 
 /** "HH:MM~HH:MM" 파싱 → 분 단위 [start, end]. wraparound (end < start) 도 허용. */
@@ -162,6 +193,14 @@ export function evaluateCondition(
       if (cond.value === 'HELD') return isHeld
       if (cond.value === 'NOT_HELD') return !isHeld
       return false
+    }
+    // ── v3 (Phase 34-A #419) —
+    case 'earnings_within_days': {
+      if (typeof cond.value !== 'number') return false
+      const days = daysUntilEarnings(snapshot.earnings?.nextEarningsDate ?? null, context.now)
+      // 데이터 없음 or 과거 어닝만 있음 → false (안전측 — pre-earnings 회피 조건 사용 흐름 상)
+      if (days == null) return false
+      return compareNumeric(days, cond.operator, cond.value)
     }
     default:
       return false

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -15,6 +15,7 @@
 import type { Condition, WeekdayCode } from './types'
 import { TIME_WINDOW_RE } from './types'
 import type { TAReport } from '@/lib/ta/types'
+import { kstDayDiff } from '@/lib/kst-date'
 
 export interface PriceSnapshot {
   price: number
@@ -94,15 +95,7 @@ function kstWeekday(now: Date): WeekdayCode {
  */
 export function daysUntilEarnings(nextEarningsDate: Date | null | undefined, now: Date): number | null {
   if (!nextEarningsDate) return null
-  // KST 자정 정규화: UTC 를 +9h shift 한 뒤 시/분/초/ms 를 0 으로 잘라 KST 자정 UTC 표현.
-  const kstMidnightUtc = (d: Date): number => {
-    const shifted = d.getTime() + 9 * 60 * 60 * 1000
-    const day = Math.floor(shifted / (24 * 60 * 60 * 1000))
-    return day * 24 * 60 * 60 * 1000
-  }
-  const nowDay = kstMidnightUtc(now)
-  const earningsDay = kstMidnightUtc(nextEarningsDate)
-  const diffDays = Math.round((earningsDay - nowDay) / (24 * 60 * 60 * 1000))
+  const diffDays = kstDayDiff(nextEarningsDate, now)
   if (diffDays < 0) return null
   return diffDays
 }

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -26,6 +26,9 @@ const PROMPT_HEADER = `
 - weekday (배열, 요일 코드 ["MON","TUE","WED","THU","FRI","SAT","SUN"] 중 부분집합)
 - holding_status (문자열, "HELD" 또는 "NOT_HELD" — 사용자가 해당 ticker 보유 여부)
 
+## 지원 조건 타입 (v3 — 어닝 캘린더)
+- earnings_within_days (숫자 정수, 0 이상, 다음 어닝까지 남은 일수 — Yahoo Finance 캘린더)
+
 ## 연산자
 - 숫자 타입: < <= > >= ==
 - 문자열/배열 타입: is (전용)
@@ -62,9 +65,20 @@ const PROMPT_HEADER = `
     {"type":"holding_status","operator":"is","value":"HELD"}
   ], "logic":"AND"}
 
+## v3 예시 (어닝 캘린더)
+- "AAPL 어닝 3일 이내면 알림 (매수 회피용)" →
+  {"conditions": [
+    {"type":"earnings_within_days","operator":"<=","value":3}
+  ], "logic":"AND"}
+- "NVDA RSI 30 이하 + 어닝 7일 이상 남았을 때만 진입" →
+  {"conditions": [
+    {"type":"rsi","operator":"<=","value":30},
+    {"type":"earnings_within_days","operator":">=","value":7}
+  ], "logic":"AND"}
+
 ## 규칙
 - 지원 타입 외 조건 요구되면 { "error": "지원 안함: ..." } 로만 응답
-- 뉴스/펀더멘털/어닝/크로스-티커 조건은 미지원 (지원 타입 외 로 처리)
+- 뉴스/펀더멘털/크로스-티커 조건은 미지원 (지원 타입 외 로 처리). 어닝은 v3 로 지원 시작.
 - ticker 알 수 없으면 { "error": "ticker 를 명확히 지정해주세요" }
 - 사용자가 시간대를 "미국장" / "한국장" 등으로 지칭하면 KST 로 환산 (미국장 = 대략 22:30~05:00 KST DST 무관 단순화, 한국장 = 09:00~15:30)
 

--- a/src/lib/custom-strategy/types.ts
+++ b/src/lib/custom-strategy/types.ts
@@ -17,6 +17,8 @@ export type ConditionType =
   | 'time_window'     // KST 시각 범위 필터 (HH:MM~HH:MM)
   | 'weekday'         // KST 요일 필터 (MON/TUE/…)
   | 'holding_status'  // 사용자 보유 여부
+  // v3 additions (Phase 34) —
+  | 'earnings_within_days'  // 다음 어닝까지 남은 일수 (data 없거나 과거만 있으면 false)
 
 export type Operator = '<' | '<=' | '>' | '>=' | '==' | 'is'
 
@@ -60,7 +62,7 @@ const VALID_WEEKDAYS_SET = new Set<WeekdayCode>(VALID_WEEKDAYS)
 /** HH:MM~HH:MM 포맷 (00~23:00~59). 자정 wraparound 는 evaluator 가 판정. */
 export const TIME_WINDOW_RE = /^([01]\d|2[0-3]):([0-5]\d)~([01]\d|2[0-3]):([0-5]\d)$/
 
-const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct'])
+const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days'])
 const SINGLE_STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position', 'holding_status'])
 const NUMERIC_OPS = new Set<Operator>(['<', '<=', '>', '>=', '=='])
 const IS_OP: Operator = 'is'
@@ -71,6 +73,7 @@ const VALID_TIMEFRAMES = new Set<Timeframe>(['1d', '5d', '20d'])
 const VALID_TYPES = new Set<ConditionType>([
   'price', 'rsi', 'macd_signal', 'sma_cross', 'bb_position', 'change_pct',
   'time_window', 'weekday', 'holding_status',
+  'earnings_within_days',
 ])
 
 /** Condition 유효성 검증 — evaluator 진입 전 방어 */
@@ -87,6 +90,10 @@ export function validateCondition(c: unknown): c is Condition {
     if (type === 'change_pct') {
       // timeframe 필수 — evaluator 폴백을 방지해 조건 의도가 명확해지도록
       if (!VALID_TIMEFRAMES.has(cond.timeframe as Timeframe)) return false
+    }
+    if (type === 'earnings_within_days') {
+      // 어닝 일수는 정수 + 음수는 무의미 (미래 카운트다운). 소수/음수 거부.
+      if (!Number.isInteger(cond.value) || cond.value < 0) return false
     }
     return true
   }

--- a/src/lib/earnings/__tests__/cache.test.ts
+++ b/src/lib/earnings/__tests__/cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    earningsCache: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}))
+
+import { getEarnings, getEarningsMany, upsertEarningsResults } from '../cache'
+
+describe('getEarnings', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.findUnique).mockReset()
+  })
+
+  it('row 있음 → snapshot 반환', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const date = new Date('2026-02-01T00:00:00Z')
+    vi.mocked(prisma.earningsCache.findUnique).mockResolvedValueOnce({
+      ticker: 'AAPL',
+      nextEarningsDate: date,
+      lastFetchedAt: new Date(),
+      updatedAt: new Date(),
+    } as never)
+
+    const r = await getEarnings('AAPL')
+    expect(r?.ticker).toBe('AAPL')
+    expect(r?.nextEarningsDate).toEqual(date)
+  })
+
+  it('row 없음 → null', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.findUnique).mockResolvedValueOnce(null)
+    expect(await getEarnings('UNKNOWN')).toBeNull()
+  })
+})
+
+describe('getEarningsMany', () => {
+  it('빈 배열 입력 → 빈 Map, findMany 호출 없음', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.findMany).mockReset()
+    const r = await getEarningsMany([])
+    expect(r.size).toBe(0)
+    expect(prisma.earningsCache.findMany).not.toHaveBeenCalled()
+  })
+
+  it('여러 티커 조회 → ticker 별 Map', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const d1 = new Date('2026-02-01T00:00:00Z')
+    const d2 = new Date('2026-03-01T00:00:00Z')
+    vi.mocked(prisma.earningsCache.findMany).mockResolvedValueOnce([
+      { ticker: 'AAPL', nextEarningsDate: d1, lastFetchedAt: new Date(), updatedAt: new Date() },
+      { ticker: 'MSFT', nextEarningsDate: d2, lastFetchedAt: new Date(), updatedAt: new Date() },
+    ] as never)
+
+    const r = await getEarningsMany(['AAPL', 'MSFT'])
+    expect(r.get('AAPL')?.nextEarningsDate).toEqual(d1)
+    expect(r.get('MSFT')?.nextEarningsDate).toEqual(d2)
+  })
+})
+
+describe('upsertEarningsResults', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.upsert).mockReset()
+    vi.mocked(prisma.earningsCache.updateMany).mockReset()
+  })
+
+  it('성공 결과 → upsert 호출, ok 카운트', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.upsert).mockResolvedValue({} as never)
+
+    const r = await upsertEarningsResults([
+      { ticker: 'AAPL', nextEarningsDate: new Date('2026-02-01T00:00:00Z') },
+      { ticker: 'MSFT', nextEarningsDate: null },
+    ])
+    expect(r).toEqual({ ok: 2, failed: 0 })
+    expect(prisma.earningsCache.upsert).toHaveBeenCalledTimes(2)
+  })
+
+  it('error 결과 → updateMany 로 lastFetchedAt 만 갱신, failed 카운트', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.updateMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    const r = await upsertEarningsResults([
+      { ticker: 'BAD', nextEarningsDate: null, error: '404' },
+    ])
+    expect(r).toEqual({ ok: 0, failed: 1 })
+    expect(prisma.earningsCache.upsert).not.toHaveBeenCalled()
+    expect(prisma.earningsCache.updateMany).toHaveBeenCalledWith({
+      where: { ticker: 'BAD' },
+      data: expect.objectContaining({ lastFetchedAt: expect.any(Date) }),
+    })
+  })
+
+  it('성공 + 실패 혼합', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.upsert).mockResolvedValue({} as never)
+    vi.mocked(prisma.earningsCache.updateMany).mockResolvedValue({ count: 0 } as never)
+
+    const r = await upsertEarningsResults([
+      { ticker: 'AAPL', nextEarningsDate: new Date() },
+      { ticker: 'BAD', nextEarningsDate: null, error: 'timeout' },
+    ])
+    expect(r).toEqual({ ok: 1, failed: 1 })
+  })
+})

--- a/src/lib/earnings/__tests__/cron.test.ts
+++ b/src/lib/earnings/__tests__/cron.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    customStrategy: { findMany: vi.fn() },
+    watchlist: { findMany: vi.fn() },
+    holding: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('../fetcher', () => ({
+  fetchEarningsMany: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  upsertEarningsResults: vi.fn(),
+}))
+
+import { gatherTargetTickers, runEarningsScan } from '../cron'
+
+describe('gatherTargetTickers', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockReset()
+    vi.mocked(prisma.watchlist.findMany).mockReset()
+    vi.mocked(prisma.holding.findMany).mockReset()
+  })
+
+  it('3소스 union, 중복 제거, 알파벳 정렬', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([
+      { ticker: 'AAPL' }, { ticker: 'MSFT' },
+    ] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([
+      { ticker: 'MSFT' }, { ticker: 'NVDA' },
+    ] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([
+      { ticker: 'AAPL' }, { ticker: 'TSLA' },
+    ] as never)
+
+    const result = await gatherTargetTickers()
+    expect(result).toEqual(['AAPL', 'MSFT', 'NVDA', 'TSLA'])
+  })
+
+  it('3소스 모두 비면 빈 배열', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([] as never)
+
+    expect(await gatherTargetTickers()).toEqual([])
+  })
+})
+
+describe('runEarningsScan', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockReset()
+    vi.mocked(prisma.watchlist.findMany).mockReset()
+    vi.mocked(prisma.holding.findMany).mockReset()
+    const { fetchEarningsMany } = await import('../fetcher')
+    const { upsertEarningsResults } = await import('../cache')
+    vi.mocked(fetchEarningsMany).mockReset()
+    vi.mocked(upsertEarningsResults).mockReset()
+  })
+
+  it('타깃 없으면 fetch/upsert 스킵', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([] as never)
+
+    const { fetchEarningsMany } = await import('../fetcher')
+    const { upsertEarningsResults } = await import('../cache')
+
+    const r = await runEarningsScan()
+    expect(r).toEqual({ attempted: 0, ok: 0, failed: 0 })
+    expect(fetchEarningsMany).not.toHaveBeenCalled()
+    expect(upsertEarningsResults).not.toHaveBeenCalled()
+  })
+
+  it('fetch 결과를 upsert 로 전달, 요약 반환', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([{ ticker: 'AAPL' }] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([] as never)
+
+    const { fetchEarningsMany } = await import('../fetcher')
+    const { upsertEarningsResults } = await import('../cache')
+    vi.mocked(fetchEarningsMany).mockResolvedValueOnce([
+      { ticker: 'AAPL', nextEarningsDate: new Date('2026-02-01T00:00:00Z') },
+    ])
+    vi.mocked(upsertEarningsResults).mockResolvedValueOnce({ ok: 1, failed: 0 })
+
+    const r = await runEarningsScan()
+    expect(r).toEqual({ attempted: 1, ok: 1, failed: 0 })
+    expect(fetchEarningsMany).toHaveBeenCalledWith(['AAPL'], 5)
+  })
+})

--- a/src/lib/earnings/__tests__/fetcher.test.ts
+++ b/src/lib/earnings/__tests__/fetcher.test.ts
@@ -67,6 +67,31 @@ describe('fetchEarnings', () => {
     expect(r.error).toBeUndefined()
   })
 
+  it('어닝 UTC 자정 (=KST 09:00) 이고 스캔이 같은 KST 날 오후 → 놓치지 않음 (Codex #426 P2)', async () => {
+    // FIXED_NOW = 2026-07-08T00:00:00Z (KST 07-08 09:00) — 오전. 어닝을 이후 시간대로.
+    // KST 07-08 스캔이 KST 07-08 오후에 실행되고, 어닝 timestamp 가 그 스캔 시각보다 이전이지만
+    // 같은 KST 날짜 이면 유지되어야 함.
+    vi.setSystemTime(new Date('2026-07-08T05:00:00Z')) // KST 14:00
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2026-07-08T00:00:00Z'] }, // KST 09:00 (5h 이전 raw)
+      },
+    })
+    const r = await fetchEarnings('AAPL')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-07-08T00:00:00.000Z')
+  })
+
+  it('KST 어제로 넘어간 어닝은 제외', async () => {
+    vi.setSystemTime(new Date('2026-07-09T05:00:00Z')) // KST 07-09 14:00
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2026-07-07T15:00:00Z'] }, // KST 07-08 00:00 (어제)
+      },
+    })
+    const r = await fetchEarnings('AAPL')
+    expect(r.nextEarningsDate).toBeNull()
+  })
+
   it('과거 + 미래 혼합 → 미래 중 가장 이른 것', async () => {
     quoteSummaryMock.mockResolvedValueOnce({
       calendarEvents: {

--- a/src/lib/earnings/__tests__/fetcher.test.ts
+++ b/src/lib/earnings/__tests__/fetcher.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { quoteSummaryMock } = vi.hoisted(() => ({ quoteSummaryMock: vi.fn() }))
+
+vi.mock('yahoo-finance2', () => {
+  class YahooFinance {
+    quoteSummary = quoteSummaryMock
+  }
+  return { default: YahooFinance }
+})
+
+import { fetchEarnings, fetchEarningsMany } from '../fetcher'
+
+const FIXED_NOW = Date.parse('2026-07-08T00:00:00Z')
+
+beforeEach(() => {
+  quoteSummaryMock.mockReset()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(FIXED_NOW))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('fetchEarnings', () => {
+  it('array of ISO strings → 미래 중 가장 이른 date 반환', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2026-07-30T20:00:00.000Z', '2026-10-30T20:00:00.000Z'] },
+      },
+    })
+    const r = await fetchEarnings('AAPL')
+    expect(r.ticker).toBe('AAPL')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-07-30T20:00:00.000Z')
+    expect(r.error).toBeUndefined()
+  })
+
+  it('array of Date 인스턴스 도 파싱', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: [new Date('2026-08-01T20:00:00Z')] },
+      },
+    })
+    const r = await fetchEarnings('MSFT')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-08-01T20:00:00.000Z')
+  })
+
+  it('단일 Date (배열 아님) 도 정규화하여 파싱', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: new Date('2026-09-01T00:00:00Z') },
+      },
+    })
+    const r = await fetchEarnings('GOOG')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-09-01T00:00:00.000Z')
+  })
+
+  it('과거 date 만 있으면 nextEarningsDate = null (미래 없음)', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2025-01-01T00:00:00Z', '2026-06-01T00:00:00Z'] },
+      },
+    })
+    const r = await fetchEarnings('OLD')
+    expect(r.nextEarningsDate).toBeNull()
+    expect(r.error).toBeUndefined()
+  })
+
+  it('과거 + 미래 혼합 → 미래 중 가장 이른 것', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: [
+          '2026-06-01T00:00:00Z',            // 과거
+          '2026-10-01T00:00:00Z',            // 미래
+          '2026-07-30T20:00:00Z',            // 미래 (더 가까움)
+        ] },
+      },
+    })
+    const r = await fetchEarnings('MIX')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-07-30T20:00:00.000Z')
+  })
+
+  it('calendarEvents 자체가 없어도 crash X → null 반환', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({})
+    const r = await fetchEarnings('NONE')
+    expect(r.nextEarningsDate).toBeNull()
+    expect(r.error).toBeUndefined()
+  })
+
+  it('parseable date 가 아닌 문자열 skip', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['not-a-date', '2026-08-15T00:00:00Z'] },
+      },
+    })
+    const r = await fetchEarnings('BAD')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-08-15T00:00:00.000Z')
+  })
+
+  it('quoteSummary 가 throw → error 필드로 반환 (예외 전파 X)', async () => {
+    quoteSummaryMock.mockRejectedValueOnce(new Error('rate limit'))
+    const r = await fetchEarnings('FAIL')
+    expect(r.ticker).toBe('FAIL')
+    expect(r.nextEarningsDate).toBeNull()
+    expect(r.error).toContain('rate limit')
+  })
+})
+
+describe('fetchEarningsMany', () => {
+  it('여러 티커 순회, 각 결과 반환 (실패 포함)', async () => {
+    quoteSummaryMock
+      .mockResolvedValueOnce({
+        calendarEvents: { earnings: { earningsDate: ['2026-08-01T00:00:00Z'] } },
+      })
+      .mockRejectedValueOnce(new Error('404'))
+      .mockResolvedValueOnce({
+        calendarEvents: { earnings: { earningsDate: ['2026-09-01T00:00:00Z'] } },
+      })
+
+    const results = await fetchEarningsMany(['A', 'B', 'C'], 2)
+    expect(results).toHaveLength(3)
+    const byTicker = Object.fromEntries(results.map((r) => [r.ticker, r]))
+    expect(byTicker.A.nextEarningsDate?.toISOString()).toBe('2026-08-01T00:00:00.000Z')
+    expect(byTicker.B.error).toContain('404')
+    expect(byTicker.C.nextEarningsDate?.toISOString()).toBe('2026-09-01T00:00:00.000Z')
+  })
+
+  it('빈 tickers → 빈 배열, quoteSummary 호출 없음', async () => {
+    const results = await fetchEarningsMany([], 5)
+    expect(results).toEqual([])
+    expect(quoteSummaryMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/earnings/cache.ts
+++ b/src/lib/earnings/cache.ts
@@ -1,0 +1,79 @@
+/**
+ * Phase 34-A (#419) — EarningsCache 접근 헬퍼.
+ */
+
+import { prisma } from '@/lib/prisma'
+import type { EarningsFetchResult } from './fetcher'
+
+export interface EarningsSnapshot {
+  ticker: string
+  nextEarningsDate: Date | null
+  lastFetchedAt: Date
+}
+
+export async function getEarnings(ticker: string): Promise<EarningsSnapshot | null> {
+  const row = await prisma.earningsCache.findUnique({ where: { ticker } })
+  if (!row) return null
+  return {
+    ticker: row.ticker,
+    nextEarningsDate: row.nextEarningsDate,
+    lastFetchedAt: row.lastFetchedAt,
+  }
+}
+
+export async function getEarningsMany(tickers: string[]): Promise<Map<string, EarningsSnapshot>> {
+  if (tickers.length === 0) return new Map()
+  const rows = await prisma.earningsCache.findMany({
+    where: { ticker: { in: tickers } },
+  })
+  return new Map(rows.map((r) => [
+    r.ticker,
+    { ticker: r.ticker, nextEarningsDate: r.nextEarningsDate, lastFetchedAt: r.lastFetchedAt },
+  ]))
+}
+
+/**
+ * fetcher 결과를 upsert. 실패한 티커 (error 있음) 는 nextEarningsDate 를
+ * 이전 값 유지 (best-effort — 일시적 네트워크 오류로 캐시 무효화 방지).
+ * 성공한 티커는 nextEarningsDate 를 새 값으로 갱신 (null 도 유효한 성공값).
+ */
+export async function upsertEarningsResults(results: EarningsFetchResult[]): Promise<{
+  ok: number
+  failed: number
+}> {
+  let ok = 0
+  let failed = 0
+  for (const r of results) {
+    if (r.error) {
+      failed++
+      // 실패 시엔 lastFetchedAt 만 업데이트 (row 없으면 새로 생성 X — noise 방지)
+      try {
+        await prisma.earningsCache.updateMany({
+          where: { ticker: r.ticker },
+          data: { lastFetchedAt: new Date() },
+        })
+      } catch {
+        // ignore
+      }
+      continue
+    }
+    ok++
+    try {
+      await prisma.earningsCache.upsert({
+        where: { ticker: r.ticker },
+        create: {
+          ticker: r.ticker,
+          nextEarningsDate: r.nextEarningsDate,
+          lastFetchedAt: new Date(),
+        },
+        update: {
+          nextEarningsDate: r.nextEarningsDate,
+          lastFetchedAt: new Date(),
+        },
+      })
+    } catch (error) {
+      console.error(`[earnings/cache] upsert 실패 (${r.ticker}):`, error)
+    }
+  }
+  return { ok, failed }
+}

--- a/src/lib/earnings/cron.ts
+++ b/src/lib/earnings/cron.ts
@@ -1,0 +1,50 @@
+/**
+ * Phase 34-A (#419) — 어닝 캘린더 갱신 cron.
+ * 매일 KST 06:00 (미국장 마감 후, 한국장 시작 전).
+ * 대상 = 활성 CustomStrategy 티커 ∪ Watchlist ∪ 보유 종목 (shares > 0).
+ */
+
+import { prisma } from '@/lib/prisma'
+import { fetchEarningsMany } from './fetcher'
+import { upsertEarningsResults } from './cache'
+
+/**
+ * DB 에서 대상 티커 3소스 조회 → 중복 제거된 정렬 배열 반환 (테스트 가능하도록 export).
+ * concurrency 를 유지하기 위해 안정된 순서 (알파벳순) 로 반환.
+ */
+export async function gatherTargetTickers(): Promise<string[]> {
+  const [strategies, watchlist, holdings] = await Promise.all([
+    prisma.customStrategy.findMany({
+      where: { isActive: true },
+      select: { ticker: true },
+    }),
+    prisma.watchlist.findMany({ select: { ticker: true } }),
+    prisma.holding.findMany({
+      where: { shares: { gt: 0 } },
+      select: { ticker: true },
+      distinct: ['ticker'],
+    }),
+  ])
+
+  const set = new Set<string>()
+  for (const row of strategies) set.add(row.ticker)
+  for (const row of watchlist) set.add(row.ticker)
+  for (const row of holdings) set.add(row.ticker)
+  return Array.from(set).sort()
+}
+
+/**
+ * 한 번의 어닝 스캔 실행 — 대상 티커 수집 → fetch → upsert.
+ * 결과 요약을 반환 (로그 및 테스트용).
+ */
+export async function runEarningsScan(): Promise<{
+  attempted: number
+  ok: number
+  failed: number
+}> {
+  const tickers = await gatherTargetTickers()
+  if (tickers.length === 0) return { attempted: 0, ok: 0, failed: 0 }
+  const results = await fetchEarningsMany(tickers, 5)
+  const { ok, failed } = await upsertEarningsResults(results)
+  return { attempted: tickers.length, ok, failed }
+}

--- a/src/lib/earnings/fetcher.ts
+++ b/src/lib/earnings/fetcher.ts
@@ -5,6 +5,7 @@
  */
 
 import YahooFinance from 'yahoo-finance2'
+import { isSameOrFutureKstDay } from '@/lib/kst-date'
 
 const yahooFinance = new YahooFinance()
 
@@ -30,9 +31,13 @@ export async function fetchEarnings(ticker: string): Promise<EarningsFetchResult
       .filter((d) => !Number.isNaN(d.getTime()))
       .sort((a, b) => a.getTime() - b.getTime())
 
-    // 다음 어닝 = 미래 중 가장 이른 것 (yahoo 는 과거를 넘겨줄 수도 있음)
-    const now = Date.now()
-    const nextEarningsDate = parsed.find((d) => d.getTime() >= now) ?? null
+    // 다음 어닝 = KST 캘린더 기준 오늘 이후 중 가장 이른 것.
+    // Codex #426 P2: 원 코드가 raw timestamp (`>= Date.now()`) 로 비교 →
+    // "2026-07-30T00:00Z" (=KST 07-30 09:00) 어닝이 KST 07-30 오후 스캔에서 이미 지난 것으로
+    // 판정 → cache null → evaluator (KST 자정 정규화) 는 D-0 로 취급하려 하지만 nextEarningsDate 가
+    // 이미 null 이라 조건 false. KST 자정 기준으로 두면 evaluator 와 정합.
+    const nowDate = new Date()
+    const nextEarningsDate = parsed.find((d) => isSameOrFutureKstDay(d, nowDate)) ?? null
 
     return { ticker, nextEarningsDate }
   } catch (error) {

--- a/src/lib/earnings/fetcher.ts
+++ b/src/lib/earnings/fetcher.ts
@@ -1,0 +1,65 @@
+/**
+ * Phase 34-A (#419) — 어닝 캘린더 fetcher.
+ * yahoo-finance2 `quoteSummary(ticker, { modules: ['calendarEvents'] })` 사용.
+ * 무료. 미국주 위주 — 한국 종목은 대부분 미지원 (nextEarningsDate=null 로 그레이스풀).
+ */
+
+import YahooFinance from 'yahoo-finance2'
+
+const yahooFinance = new YahooFinance()
+
+export interface EarningsFetchResult {
+  ticker: string
+  nextEarningsDate: Date | null
+  error?: string
+}
+
+/**
+ * 단일 티커 어닝 조회. 실패해도 예외 던지지 않고 error 필드로 반환.
+ * 성공 시 다음 예정 어닝 중 가장 가까운 날짜를 반환.
+ */
+export async function fetchEarnings(ticker: string): Promise<EarningsFetchResult> {
+  try {
+    const result = await yahooFinance.quoteSummary(ticker, {
+      modules: ['calendarEvents'],
+    })
+    const raw = result?.calendarEvents?.earnings?.earningsDate
+    const dates = Array.isArray(raw) ? raw : raw ? [raw] : []
+    const parsed = dates
+      .map((d) => (d instanceof Date ? d : new Date(d as unknown as string)))
+      .filter((d) => !Number.isNaN(d.getTime()))
+      .sort((a, b) => a.getTime() - b.getTime())
+
+    // 다음 어닝 = 미래 중 가장 이른 것 (yahoo 는 과거를 넘겨줄 수도 있음)
+    const now = Date.now()
+    const nextEarningsDate = parsed.find((d) => d.getTime() >= now) ?? null
+
+    return { ticker, nextEarningsDate }
+  } catch (error) {
+    return {
+      ticker,
+      nextEarningsDate: null,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * 여러 티커 병렬 조회 (concurrency 제한). yahoo API 부담 방지.
+ */
+export async function fetchEarningsMany(
+  tickers: string[],
+  concurrency = 5,
+): Promise<EarningsFetchResult[]> {
+  const results: EarningsFetchResult[] = []
+  const queue = [...tickers]
+  const workers = Array.from({ length: Math.min(concurrency, tickers.length) }, async () => {
+    while (queue.length > 0) {
+      const t = queue.shift()
+      if (!t) return
+      results.push(await fetchEarnings(t))
+    }
+  })
+  await Promise.all(workers)
+  return results
+}

--- a/src/lib/kst-date.ts
+++ b/src/lib/kst-date.ts
@@ -1,0 +1,33 @@
+/**
+ * KST 캘린더 일수 유틸 (pure).
+ *
+ * MyFinance 는 여러 곳 (evaluator earnings, fetcher, cron 등) 에서 "KST 기준 오늘·같은 날"
+ * 판정을 하며 이들이 raw UTC 시각으로 나뉘어 있으면 경계 조건에서 불일치가 발생 (Codex #426 P2).
+ * → 이 파일 하나로 통일.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+
+/**
+ * `d` 가 속한 KST 캘린더 일의 자정 (KST 00:00) 을 UTC 타임스탬프 (ms) 로 반환.
+ * 두 날짜의 KST 캘린더 일수 차이는 `(kstMidnightUtc(a) - kstMidnightUtc(b)) / DAY_MS`.
+ */
+export function kstMidnightUtc(d: Date): number {
+  const shifted = d.getTime() + KST_OFFSET_MS
+  const day = Math.floor(shifted / DAY_MS)
+  // shift 공간의 자정을 다시 실제 UTC 로 되돌림 (KST 00:00 = UTC 전날 15:00).
+  return day * DAY_MS - KST_OFFSET_MS
+}
+
+/** `d` 가 속한 KST 캘린더 일이 `ref` 의 KST 캘린더 일 이후인지 (같은 날 포함). */
+export function isSameOrFutureKstDay(d: Date, ref: Date): boolean {
+  return kstMidnightUtc(d) >= kstMidnightUtc(ref)
+}
+
+/**
+ * 두 시각의 KST 캘린더 일수 차이 (`d - ref`). 정수. `d` 가 미래면 양수, 과거면 음수.
+ */
+export function kstDayDiff(d: Date, ref: Date): number {
+  return Math.round((kstMidnightUtc(d) - kstMidnightUtc(ref)) / DAY_MS)
+}


### PR DESCRIPTION
## Summary
커스텀 전략 v3 첫 확장. `earnings_within_days` 조건 추가 — 어닝 임박 회피 (D-3 이내 skip) / 어닝 안전 지대 (D+7 이상 진입) 자동화.

- Master: #414. Spec: `docs/specs/419-earnings-condition.md`
- Prisma `EarningsCache` + migration
- Fetcher (yahoo-finance2 calendarEvents), Cache, Cron (매일 06:00 KST + **부팅 즉시 초기 시드**)
- Evaluator: KST 캘린더 자정 정규화 후 일수 계산
- AI 파서 프롬프트: v3 섹션 + 예시 2개 (D-3 회피, D+7 안전지대)
- 알림 흐름: `getEarningsMany` 로 미리 로드해 evaluator 로 주입

## Test plan (435 pass)
- [x] lint / typecheck / test / build 통과
- [x] verify: 실제 AAPL Yahoo 호출 → 2026-07-30 파싱
- [x] self-review P1 3건 (부팅 시드 / KST 자정 / fetcher 유닛) 모두 반영

## 제외 (후속)
- Post-earnings drift (`days_since_earnings`) — 별도 조건 타입 필요
- EPS surprise / KRX 어닝

Closes #419