### PR TITLE
feat(strategy): 크로스-티커 조건 (Phase 34-B, #420)

### DIFF
--- a/docs/specs/420-cross-ticker-condition.md
+++ b/docs/specs/420-cross-ticker-condition.md
@@ -1,0 +1,124 @@
+# [Phase 34-B] 커스텀 전략 v3 — 크로스-티커 조건
+
+- **이슈**: #420
+- **마스터**: #414
+- **선행**: #419 (34-A) — 어닝 조건. 34-B 는 다른 조건 프레임워크 활용.
+- **작성일**: 2026-07-09
+
+## 목표
+
+전략 대상 티커와 다른 티커의 상태 (예: SPY 하락, VIX 급등) 를 진입 조건으로 사용. 시장 컨텍스트 게이트 자동화.
+
+**대표 사용례**:
+- "SPY 가 -2% 하락한 날엔 개별 종목 매수 회피"
+- "VIX > 25 일 때만 콜/풋 스캘핑"
+- "QQQ 200SMA 위에 있을 때만 성장주 진입"
+
+## 조건 스키마
+
+```ts
+type ConditionType =
+  ... // 기존
+  | 'cross_ticker'   // 다른 티커의 price / changePercent 조건
+```
+
+### 구조
+```ts
+{
+  type: 'cross_ticker',
+  operator: '<' | '<=' | '>' | '>=' | '==',
+  value: number,
+  crossTicker: string,          // 참조 티커 (대문자 정규화)
+  metric: 'price' | 'change_percent',  // 어떤 값과 비교
+}
+```
+
+- `crossTicker` **신규 필수 필드** (기존 `timeframe` 처럼 조건별 오버라이드).
+- `metric='price'`: PriceCache 의 `price` 필드
+- `metric='change_percent'`: PriceCache 의 `changePercent` 필드 (일일)
+
+### 유효성 검증
+- crossTicker 는 비어 있지 않은 문자열 (자동 대문자 정규화)
+- metric 은 화이트리스트
+- operator 는 numeric (< / <= / > / >= / ==)
+- value 는 finite number
+- **자기 자신 참조 금지** — validateCondition 은 통과 (전략 편집 시점엔 strategy.ticker 알 수 없음), 대신 **evaluator 가 `crossTicker === context.strategyTicker` 이면 false 안전 판정**
+
+### 예시
+```json
+{"type":"cross_ticker","operator":"<=","value":-2,"crossTicker":"SPY","metric":"change_percent"}
+```
+
+## 평가 로직 (evaluator)
+
+```ts
+case 'cross_ticker': {
+  if (typeof cond.value !== 'number') return false
+  if (!cond.crossTicker || !cond.metric) return false
+  const normalized = cond.crossTicker.trim().toUpperCase()
+  if (normalized === context.strategyTicker) return false  // 자기 자신 회피
+  const cross = context.crossTickers?.get(normalized)
+  if (!cross) return false  // 데이터 없음 → false 안전
+  const actual = cond.metric === 'price' ? cross.price : cross.changePercent
+  if (actual == null) return false
+  return compareNumeric(actual, cond.operator, cond.value)
+}
+```
+
+## Context 확장
+
+```ts
+interface EvaluationContext {
+  ...
+  crossTickers?: Map<string, { price: number; changePercent: number | null }>
+}
+```
+
+`custom-strategy-alert.ts` 가 evaluate 전에 **전략들의 모든 crossTicker 를 수집** → 별도 PriceCache 조회 → context 에 주입.
+
+## Ticker 수집 헬퍼
+
+```ts
+// pure
+function collectCrossTickers(strategies: CustomStrategy[]): Set<string>
+```
+
+- 각 전략의 conditions 순회 → `type === 'cross_ticker'` 인 것들의 `crossTicker` 추출 (정규화).
+
+## PriceCache 조회
+
+기존 `priceCache.findMany` 를 확장 — 전략 티커 + 크로스 티커 합집합으로 한 번에 조회.
+
+## Cron 필요 여부
+
+새 fetch 불필요. `refreshPrices` cron 이 이미 관심종목 + 보유 종목 대상. 사용자는 크로스 티커도 관심종목에 등록하면 자연스럽게 커버. **spec 은 크로스 티커 자동 등록은 하지 않음** (사용자가 SPY/VIX 을 스스로 관심종목에 추가).
+
+## AI 파서 프롬프트
+
+- v3 섹션에 예시 추가 ("SPY -2% 이하 때만" / "VIX 25 초과 때 진입")
+- 미지원 리스트에서 "크로스-티커" 제거
+
+## 파일 변경
+
+- `src/lib/custom-strategy/types.ts` — `cross_ticker` 타입, crossTicker/metric 필드, validateCondition 확장, conditionToString 지원
+- `src/lib/custom-strategy/evaluator.ts` — `crossTickers` context 필드, `cross_ticker` case, `collectCrossTickers` pure
+- `src/lib/custom-strategy/parser.ts` — 프롬프트 v3 확장
+- `src/bot/notifications/custom-strategy-alert.ts` — crossTicker 수집 + PriceCache 확장 조회 + context 주입
+
+## 테스트
+
+- `types.test.ts` — cross_ticker 검증 (필수 필드, metric whitelist, 잘못된 operator)
+- `evaluator.test.ts` — 데이터 없음 / 자기 참조 / price 비교 / change_percent 비교 / 여러 시나리오
+- `custom-strategy-alert` 흐름 (option: e2e 하기 어려우면 pure `collectCrossTickers` 만 확실히 검증)
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] verify: 실제 running 서버에서 SPY 크로스 조건 전략 → 만족 시 발동
+
+## 제외 (후속)
+
+- 크로스 티커의 TA 지표 (RSI/MACD 등) — 조건 스키마 확장 필요
+- 여러 크로스 티커 AND 조건 (예: SPY 하락 AND VIX 급등) — 현재 스키마에서도 `cross_ticker` 조건 2개로 표현 가능 (자연스러움)
+- 크로스 티커 자동 관심종목 등록

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -24,6 +24,7 @@ import {
 import {
   evaluateStrategy,
   requiresTA,
+  collectCrossTickers,
   type MarketSnapshot,
 } from '@/lib/custom-strategy/evaluator'
 import {
@@ -133,12 +134,20 @@ async function runScan(chatIds: number[]): Promise<void> {
   })
   if (strategies.length === 0) return
 
-  // ticker 단위로 PriceCache 미리 조회
-  const tickers = Array.from(new Set(strategies.map((s) => s.ticker)))
+  // Phase 34-B (#420): 전략들이 참조하는 크로스 티커도 함께 조회 (같은 쿼리에 병합).
+  const strategyTickers = Array.from(new Set(strategies.map((s) => s.ticker)))
+  const crossSet = collectCrossTickers(strategies)
+  const tickers = strategyTickers
+  const allPriceTickers = Array.from(new Set([...strategyTickers, ...crossSet]))
   const prices = await prisma.priceCache.findMany({
-    where: { ticker: { in: tickers } },
+    where: { ticker: { in: allPriceTickers } },
   })
   const priceMap = new Map(prices.map((p) => [p.ticker, p]))
+  const crossTickersMap = new Map<string, { price: number; changePercent: number | null }>()
+  for (const t of crossSet) {
+    const p = priceMap.get(t)
+    if (p) crossTickersMap.set(t, { price: p.price, changePercent: p.changePercent })
+  }
 
   // 보유 티커 조회 — holding_status 조건 평가용 (Phase 31-A v2).
   // shares > 0 만 홀딩으로 간주. 여러 계좌에서 같은 티커 보유해도 Set 이므로 중복 무관.
@@ -207,7 +216,7 @@ async function runScan(chatIds: number[]): Promise<void> {
       conds,
       s.logic === 'OR' ? 'OR' : 'AND',
       snapshot,
-      { now, holdings, strategyTicker: s.ticker },
+      { now, holdings, strategyTicker: s.ticker, crossTickers: crossTickersMap },
     )
 
     if (!satisfied) continue

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateStrategy,
   requiresTA,
   daysUntilEarnings,
+  collectCrossTickers,
   type MarketSnapshot,
   type EvaluationContext,
 } from '../evaluator'
@@ -335,6 +336,141 @@ describe('evaluateCondition — v3 earnings_within_days (#419)', () => {
   })
 })
 
+describe('evaluateCondition — v3 cross_ticker (Phase 34-B / #420)', () => {
+  const ctx = makeContext({ strategyTicker: 'SOXL' })
+
+  it('crossTickers 미주입 → false', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('참조 티커 데이터 없음 → false', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    const c = makeContext({ strategyTicker: 'SOXL', crossTickers: new Map() })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(false)
+  })
+
+  it('SPY change_percent -3 이 -2 이하 → true', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SPY', { price: 400, changePercent: -3 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(true)
+  })
+
+  it('VIX price > 25 (가격 지표) 통과', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    }
+    const c = makeContext({
+      strategyTicker: 'QQQ',
+      crossTickers: new Map([['VIX', { price: 30, changePercent: 10 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(true)
+  })
+
+  it('changePercent 이 null 이면 false', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SPY', { price: 400, changePercent: null }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(false)
+  })
+
+  it('자기 자신 참조 → false (tautology 방지)', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: 200,
+      crossTicker: 'SOXL', metric: 'price',
+    }
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SOXL', { price: 100, changePercent: 0 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(false)
+  })
+
+  it('소문자 crossTicker 도 대문자로 정규화하여 조회', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'vix', metric: 'price',
+    }
+    const c = makeContext({
+      strategyTicker: 'QQQ',
+      crossTickers: new Map([['VIX', { price: 30, changePercent: 10 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(true)
+  })
+
+  it('crossTicker/metric 누락 → false (evaluator 방어)', () => {
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SPY', { price: 400, changePercent: -3 }]]),
+    })
+    expect(evaluateCondition(
+      { type: 'cross_ticker', operator: '<=', value: 0 } as unknown as Condition,
+      makeSnapshot(), c,
+    )).toBe(false)
+  })
+})
+
+describe('collectCrossTickers (pure, Phase 34-B / #420)', () => {
+  it('여러 전략의 cross_ticker 참조 통합 + 대문자 정규화 + 중복 제거', () => {
+    const strategies = [
+      { ticker: 'SOXL', conditions: [
+        { type: 'cross_ticker', crossTicker: 'spy', metric: 'change_percent' },
+        { type: 'price', value: 50 },
+      ] },
+      { ticker: 'QQQ', conditions: [
+        { type: 'cross_ticker', crossTicker: 'VIX', metric: 'price' },
+        { type: 'cross_ticker', crossTicker: 'SPY', metric: 'change_percent' }, // 중복 (다른 전략)
+      ] },
+    ]
+    expect(collectCrossTickers(strategies)).toEqual(new Set(['SPY', 'VIX']))
+  })
+
+  it('자기 자신 참조는 제외', () => {
+    const strategies = [
+      { ticker: 'SPY', conditions: [
+        { type: 'cross_ticker', crossTicker: 'SPY', metric: 'price' },
+        { type: 'cross_ticker', crossTicker: 'VIX', metric: 'price' },
+      ] },
+    ]
+    expect(collectCrossTickers(strategies)).toEqual(new Set(['VIX']))
+  })
+
+  it('conditions 배열이 아니거나 손상된 조건은 무시', () => {
+    const strategies = [
+      { ticker: 'SOXL', conditions: 'not-an-array' },
+      { ticker: 'QQQ', conditions: [
+        { type: 'cross_ticker' }, // crossTicker 누락
+        { type: 'cross_ticker', crossTicker: '' },
+        null,
+        { type: 'cross_ticker', crossTicker: 'SPY', metric: 'price' },
+      ] },
+    ]
+    expect(collectCrossTickers(strategies)).toEqual(new Set(['SPY']))
+  })
+
+  it('빈 입력 → 빈 Set', () => {
+    expect(collectCrossTickers([])).toEqual(new Set())
+  })
+})
+
 describe('evaluateStrategy', () => {
   const c1: Condition = { type: 'price', operator: '<=', value: 200 }
   const c2: Condition = { type: 'price', operator: '>=', value: 50 }
@@ -395,5 +531,12 @@ describe('requiresTA', () => {
 
   it('v3 earnings_within_days → TA 불필요 (EarningsCache 만 참조)', () => {
     expect(requiresTA([{ type: 'earnings_within_days', operator: '<=', value: 3 }])).toBe(false)
+  })
+
+  it('v3 cross_ticker → TA 불필요 (PriceCache 만 참조)', () => {
+    expect(requiresTA([{
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }])).toBe(false)
   })
 })

--- a/src/lib/custom-strategy/__tests__/types.test.ts
+++ b/src/lib/custom-strategy/__tests__/types.test.ts
@@ -248,3 +248,54 @@ describe('earnings_within_days (v3, Phase 34-A / #419)', () => {
     ).toBe(true)
   })
 })
+
+describe('cross_ticker (v3, Phase 34-B / #420)', () => {
+  it('필수 필드 (crossTicker + metric + operator + value) 모두 있으면 통과', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    })).toBe(true)
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    })).toBe(true)
+  })
+
+  it('crossTicker 누락 → false', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0, metric: 'price',
+    })).toBe(false)
+  })
+
+  it('crossTicker 빈 문자열 → false', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0, crossTicker: '   ', metric: 'price',
+    })).toBe(false)
+  })
+
+  it('metric 화이트리스트 외 → false', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0,
+      crossTicker: 'SPY', metric: 'rsi',
+    })).toBe(false)
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0, crossTicker: 'SPY',
+    })).toBe(false)
+  })
+
+  it('is 연산자 거부 (numeric 타입)', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: 'is', value: 0,
+      crossTicker: 'SPY', metric: 'price',
+    })).toBe(false)
+  })
+})
+
+describe('conditionToString — cross_ticker', () => {
+  it('SPY.change_percent <= -2 형태', () => {
+    expect(conditionToString({
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    })).toBe('SPY.change_percent <= -2')
+  })
+})

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -43,6 +43,12 @@ export interface EvaluationContext {
   holdings: Set<string>
   /** 평가 대상 티커 — holding_status 판정용 (Strategy.ticker 주입) */
   strategyTicker: string
+  /**
+   * Phase 34-B (#420): 크로스-티커 조건 참조용 스냅샷 맵.
+   * key = 대문자 정규화된 티커. 호출자가 전략들의 모든 crossTicker 를 미리 조회해 주입.
+   * 미주입 or 특정 티커 없음 → cross_ticker 조건 false (안전측).
+   */
+  crossTickers?: Map<string, { price: number; changePercent: number | null }>
 }
 
 /** 지원 조건 타입 중 TA 필요 여부 판단 — 평가 전에 TAReport fetch 여부 결정 */
@@ -195,9 +201,48 @@ export function evaluateCondition(
       if (days == null) return false
       return compareNumeric(days, cond.operator, cond.value)
     }
+    // ── v3 (Phase 34-B #420) —
+    case 'cross_ticker': {
+      if (typeof cond.value !== 'number') return false
+      if (typeof cond.crossTicker !== 'string' || !cond.crossTicker.trim()) return false
+      if (cond.metric !== 'price' && cond.metric !== 'change_percent') return false
+      const target = cond.crossTicker.trim().toUpperCase()
+      // 자기 자신 참조 방지 — 사용자가 실수로 등록해도 무의미한 tautology 회피.
+      if (target === context.strategyTicker) return false
+      const cross = context.crossTickers?.get(target)
+      if (!cross) return false
+      const actual = cond.metric === 'price' ? cross.price : cross.changePercent
+      if (actual == null || !Number.isFinite(actual)) return false
+      return compareNumeric(actual, cond.operator, cond.value)
+    }
     default:
       return false
   }
+}
+
+/**
+ * Pure — 전략 집합에서 참조되는 모든 크로스 티커를 대문자 정규화하여 수집.
+ * 자기 자신 참조 (strategyTicker == crossTicker) 는 evaluator 가 false 처리하지만
+ * 수집 단계에서도 제외해 PriceCache 조회 최적화.
+ */
+export function collectCrossTickers(
+  strategies: Array<{ ticker: string; conditions: unknown }>,
+): Set<string> {
+  const out = new Set<string>()
+  for (const s of strategies) {
+    const self = s.ticker.trim().toUpperCase()
+    const raw = Array.isArray(s.conditions) ? (s.conditions as unknown[]) : []
+    for (const c of raw) {
+      if (!c || typeof c !== 'object') continue
+      const cond = c as { type?: string; crossTicker?: string }
+      if (cond.type !== 'cross_ticker') continue
+      if (typeof cond.crossTicker !== 'string') continue
+      const t = cond.crossTicker.trim().toUpperCase()
+      if (!t || t === self) continue
+      out.add(t)
+    }
+  }
+  return out
 }
 
 export interface EvaluationResult {

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -26,8 +26,13 @@ const PROMPT_HEADER = `
 - weekday (배열, 요일 코드 ["MON","TUE","WED","THU","FRI","SAT","SUN"] 중 부분집합)
 - holding_status (문자열, "HELD" 또는 "NOT_HELD" — 사용자가 해당 ticker 보유 여부)
 
-## 지원 조건 타입 (v3 — 어닝 캘린더)
+## 지원 조건 타입 (v3 — 어닝 캘린더 / 크로스-티커)
 - earnings_within_days (숫자 정수, 0 이상, 다음 어닝까지 남은 일수 — Yahoo Finance 캘린더)
+- cross_ticker — 다른 티커의 price / change_percent 비교. 필수 필드:
+  - crossTicker: 참조 티커 (대문자 정규화). 자기 자신 참조 금지
+  - metric: "price" 또는 "change_percent"
+  - operator: 숫자 연산자 (< / <= / > / >= / ==)
+  - value: 숫자
 
 ## 연산자
 - 숫자 타입: < <= > >= ==
@@ -76,9 +81,18 @@ const PROMPT_HEADER = `
     {"type":"earnings_within_days","operator":">=","value":7}
   ], "logic":"AND"}
 
+## v3 예시 (크로스-티커)
+- "SPY -2% 이하 하락한 날에는 SOXL 진입 회피 → SOXL 매수 조건에 SPY 안 떨어진 조건 추가"
+  ticker: "SOXL", conditions: [
+    {"type":"cross_ticker","operator":">","value":-2,"crossTicker":"SPY","metric":"change_percent"}
+  ], "logic":"AND"
+- "VIX 25 초과 시 QQQ 콜 스캘핑" — ticker: "QQQ", conditions: [
+    {"type":"cross_ticker","operator":">","value":25,"crossTicker":"VIX","metric":"price"}
+  ]
+
 ## 규칙
 - 지원 타입 외 조건 요구되면 { "error": "지원 안함: ..." } 로만 응답
-- 뉴스/펀더멘털/크로스-티커 조건은 미지원 (지원 타입 외 로 처리). 어닝은 v3 로 지원 시작.
+- 뉴스/펀더멘털 조건은 미지원 (지원 타입 외 로 처리). 어닝 / 크로스-티커는 v3 로 지원 시작.
 - ticker 알 수 없으면 { "error": "ticker 를 명확히 지정해주세요" }
 - 사용자가 시간대를 "미국장" / "한국장" 등으로 지칭하면 KST 로 환산 (미국장 = 대략 22:30~05:00 KST DST 무관 단순화, 한국장 = 09:00~15:30)
 

--- a/src/lib/custom-strategy/types.ts
+++ b/src/lib/custom-strategy/types.ts
@@ -19,11 +19,15 @@ export type ConditionType =
   | 'holding_status'  // 사용자 보유 여부
   // v3 additions (Phase 34) —
   | 'earnings_within_days'  // 다음 어닝까지 남은 일수 (data 없거나 과거만 있으면 false)
+  | 'cross_ticker'          // 다른 티커의 price/changePercent 조건 (SPY, VIX 등 벤치마크 게이트)
 
 export type Operator = '<' | '<=' | '>' | '>=' | '==' | 'is'
 
 /** timeframe 지원 조건 타입 (change_pct 전용) */
 export type Timeframe = '1d' | '5d' | '20d'
+
+/** cross_ticker 조건에서 비교할 지표 */
+export type CrossTickerMetric = 'price' | 'change_percent'
 
 /** 요일 코드 (KST 기준) */
 export type WeekdayCode = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN'
@@ -34,6 +38,10 @@ export interface Condition {
   /** number (수치 조건) | string (단일 상태) | WeekdayCode[] (weekday 배열) */
   value: number | string | WeekdayCode[]
   timeframe?: Timeframe
+  /** cross_ticker 전용 — 참조할 티커 (대문자 정규화) */
+  crossTicker?: string
+  /** cross_ticker 전용 — 어떤 지표와 비교할지 */
+  metric?: CrossTickerMetric
 }
 
 export type LogicOp = 'AND' | 'OR'
@@ -62,7 +70,8 @@ const VALID_WEEKDAYS_SET = new Set<WeekdayCode>(VALID_WEEKDAYS)
 /** HH:MM~HH:MM 포맷 (00~23:00~59). 자정 wraparound 는 evaluator 가 판정. */
 export const TIME_WINDOW_RE = /^([01]\d|2[0-3]):([0-5]\d)~([01]\d|2[0-3]):([0-5]\d)$/
 
-const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days'])
+const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days', 'cross_ticker'])
+const VALID_CROSS_METRICS = new Set<CrossTickerMetric>(['price', 'change_percent'])
 const SINGLE_STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position', 'holding_status'])
 const NUMERIC_OPS = new Set<Operator>(['<', '<=', '>', '>=', '=='])
 const IS_OP: Operator = 'is'
@@ -73,7 +82,7 @@ const VALID_TIMEFRAMES = new Set<Timeframe>(['1d', '5d', '20d'])
 const VALID_TYPES = new Set<ConditionType>([
   'price', 'rsi', 'macd_signal', 'sma_cross', 'bb_position', 'change_pct',
   'time_window', 'weekday', 'holding_status',
-  'earnings_within_days',
+  'earnings_within_days', 'cross_ticker',
 ])
 
 /** Condition 유효성 검증 — evaluator 진입 전 방어 */
@@ -94,6 +103,12 @@ export function validateCondition(c: unknown): c is Condition {
     if (type === 'earnings_within_days') {
       // 어닝 일수는 정수 + 음수는 무의미 (미래 카운트다운). 소수/음수 거부.
       if (!Number.isInteger(cond.value) || cond.value < 0) return false
+    }
+    if (type === 'cross_ticker') {
+      // crossTicker: 비어있지 않은 문자열 (정규화는 evaluator 가 처리 — 원본 보존).
+      if (typeof cond.crossTicker !== 'string' || cond.crossTicker.trim() === '') return false
+      // metric: 화이트리스트
+      if (!VALID_CROSS_METRICS.has(cond.metric as CrossTickerMetric)) return false
     }
     return true
   }
@@ -143,6 +158,9 @@ export function conditionToString(c: Condition): string {
   const timeframe = c.timeframe ? `(${c.timeframe})` : ''
   if (c.type === 'weekday' && Array.isArray(c.value)) {
     return `weekday ${c.operator} [${c.value.join(',')}]`
+  }
+  if (c.type === 'cross_ticker') {
+    return `${c.crossTicker ?? '?'}.${c.metric ?? '?'} ${c.operator} ${c.value}`
   }
   return `${c.type}${timeframe} ${c.operator} ${c.value}`
 }


### PR DESCRIPTION
## Summary
커스텀 전략 v3 확장 2단계. `cross_ticker` 조건 — SPY / VIX 등 벤치마크의 price / change_percent 를 개별 종목 진입 게이트로.

- Master: #414. Spec: `docs/specs/420-cross-ticker-condition.md`
- 새 조건: crossTicker + metric ('price' | 'change_percent') optional 필드 추가 (다른 조건 타입엔 undefined)
- 자기 자신 참조는 collectCrossTickers + evaluator 이중 방어
- PriceCache 를 strategy ∪ cross union 으로 한 번에 조회 (추가 쿼리 없음)
- AI 파서 프롬프트에 v3 예시 2개 (SPY/VIX)

## Test plan (465 pass, +30)
- [x] lint / typecheck / test / build 통과
- [x] self-review P0/P1/P2 = 0
- [ ] 배포 후 실제 SPY 크로스 조건 전략 등록 → 발동 확인

## 제외 (후속)
- 크로스 티커의 TA 지표 (RSI/MACD) — 조건 스키마 확장 필요
- 크로스 티커 자동 관심종목 등록

Closes #420