### PR TITLE
Release v0.13.0 — 15차 마일스톤 (관측 & 이력 & 전략 확장)

### DIFF
--- a/docs/mcp-log-schema.md
+++ b/docs/mcp-log-schema.md
@@ -1,0 +1,157 @@
+# MCP 로그 스키마
+
+**출처**: pino JSON lines. Phase 32-C 에서 도입 (`src/mcp/logger.ts`), Phase 33-C (#418) 로 문서화. #409 흡수.
+
+## 파일 위치
+
+- `logs/mcp-YYYY-MM-DD.log` — 전체 로그 (info 이상)
+- `logs/mcp-crash-YYYY-MM-DD.log` — **fatal 만** 별도 tee (33-C 신규). pm2 crash 진단 시 이 파일만 스캔.
+- 날짜는 KST 기준. 매일 자정에 rotation. 14일 retention 자동 정리.
+
+## 공통 필드 (모든 라인)
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `level` | string | `info` / `warn` / `error` / `fatal` |
+| `time` | string | ISO 8601 UTC (`pino.stdTimeFunctions.isoTime`) |
+| `pid` | number | 프로세스 PID |
+| `service` | string | 항상 `"mcp"` (base pair) |
+| `msg` | string | 이벤트 종류 (아래 목록 참조) |
+
+`redact` 대상 필드 (`args.password`, `args.token`, `args.secret`, `args.apiKey`, `*.password`, `*.token`, `*.secret`, `*.apiKey`, `*.jwt`, `args.body.password`, `args.body.token`, `DATABASE_URL`, `TELEGRAM_BOT_TOKEN`) 는 pino 가 `[REDACTED]` 로 치환. `summarizeArgs` 는 그 이전에 대소문자 무관 sensitive key normalize + 특수 타입 방어 (`Date`, `Buffer`, `Error`, `Map`, `Set`).
+
+## 이벤트 목록
+
+### `tool_call` (info)
+MCP tool 호출 성공 (handler 정상 return).
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `tool` | string | 호출된 tool 이름 (예: `get_portfolio`) |
+| `args` | object | 인자 요약. 200자 초과 시 `{ _truncated: true, preview }` |
+| `latency_ms` | number | handler 실행 시간 (밀리초) |
+| `traceId` | string | 8자 hex (`newTraceId`) — 요청 상관관계 |
+| `status` | string | 항상 `"ok"` |
+
+### `tool_call_reported_error` (warn)
+Handler 가 `toolError({...})` 로 정상 반환 (biz error).
+
+| 필드 | 추가 |
+|---|---|
+| `status` | `"error"` |
+| `err.kind` | `"tool_reported_error"` |
+| `err.message` | handler 가 반환한 사용자 대상 메시지 |
+
+`tool` / `args` / `traceId` 는 tool_call 과 동일.
+
+### `tool_call_failed` (error)
+Handler 가 예외를 throw. instrumentation wrapper 가 rethrow 전에 기록.
+
+| 필드 | 값 |
+|---|---|
+| `tool` | tool 이름 |
+| `args` | summarizeArgs 결과 |
+| `latency_ms` | throw 발생 시점까지의 시간 |
+| `traceId` | 8자 hex |
+| `status` | `"error"` |
+| `err.name` / `err.message` / `err.stack` | 예외 정보 |
+
+### `tool_call_sdk_error` / `sdk_error` (warn)
+Handler 가 실행 전/후 SDK 레벨 오류 (Zod 검증 실패, 미등록 tool, empty response 등).
+
+| 필드 | 값 |
+|---|---|
+| `tool` | 감지 가능한 경우 (unknown 가능) |
+| `args` | summarizeArgs 결과 (없으면 생략) |
+| `status` | `"error"` |
+| `err.kind` | `"sdk_error"` |
+| `err.code` | SDK 에러 코드 (있으면) |
+| `err.message` | 원인 요약 (`handler not invoked (no response captured)` 등) |
+
+### `transport_ready` (info)
+서버 부팅 완료.
+
+| 필드 | 값 |
+|---|---|
+| `transport` | `"stdio"` 또는 `"http"` |
+| `host` | HTTP 모드에서만. 기본 `127.0.0.1` |
+| `port` | HTTP 모드에서만. 기본 4210 |
+
+### `http_server_error` (fatal)
+HTTP 서버 자체 부팅/binding 오류 (예: `EADDRINUSE`). **crash 파일에도 기록.**
+
+| 필드 | 값 |
+|---|---|
+| `err.message` | 예: `bind EADDRINUSE 127.0.0.1:4210` |
+| `err.stack` | 스택 |
+
+### `http_request` (info)
+HTTP 모드에서 SDK 로 위임한 요청 처리 완료.
+
+| 필드 | 값 |
+|---|---|
+| `httpMethod` | `GET` / `POST` 등 |
+| `rpcMethod` | JSON-RPC method (`tools/call`, `initialize` 등) |
+| `sid` | 세션 ID (신규는 `(new)`) |
+| `latency_ms` | 요청 처리 시간 |
+
+### `http_request_error` (error)
+개별 HTTP 요청 처리 중 예외 (transport 이벤트 등).
+
+### `session_initialized` / `session_closed` (info)
+HTTP 모드 세션 라이프사이클.
+
+| 필드 | 값 |
+|---|---|
+| `sid` | 세션 ID |
+| `total` | 현재 활성 세션 수 |
+
+### `session_sweep` (info)
+만료된 세션 정리 (30분 idle TTL).
+
+| 필드 | 값 |
+|---|---|
+| `count` | 정리된 세션 수 |
+| `ttl_min` | 30 (분) |
+
+### `transport_close_error` (warn)
+세션 닫기 중 오류 (best-effort).
+
+### `shutdown_started` / `http_server_closed` / `force_exit_timeout` (info/warn)
+SIGTERM/SIGINT 처리.
+
+| 필드 | 값 |
+|---|---|
+| `signal` | `SIGTERM` / `SIGINT` |
+| `active_sessions` | 종료 시점 세션 수 |
+
+### `server_fatal` (fatal)
+`startServer` 최상단 catch. **crash 파일에도 기록.**
+
+| 필드 | 값 |
+|---|---|
+| `err.message` | 오류 |
+| `err.stack` | 스택 |
+
+### `uncaught_exception` / `unhandled_rejection` (fatal)
+`installCrashHandlers` 등록 프로세스 이벤트. **crash 파일에도 기록** → 이후 100ms 뒤 `process.exit(1)` (PM2 재시작 유도).
+
+| 필드 | 값 |
+|---|---|
+| `err.name` | 오류 종류 |
+| `err.message` | 메시지 |
+| `err.stack` | 스택 (Error 인 경우) |
+
+## 진단 팁
+
+**"MCP tool 호출이 실패하는데 원인이 뭐지?"**
+1. `grep '"msg":"tool_call_sdk_error"' logs/mcp-*.log` → SDK 우회 실패 (스키마 오류 등)
+2. `grep '"msg":"tool_call_reported_error"' logs/mcp-*.log` → 비즈니스 예외 (사용자 대상 메시지)
+3. `grep '"msg":"tool_call_failed"' logs/mcp-*.log` → handler 가 throw 한 예외 (stack 포함)
+
+**"서버가 재시작됐다."**
+1. `logs/mcp-crash-YYYY-MM-DD.log` 열기 → fatal 만 있음
+2. `msg` 별로 원인 확인 (`http_server_error` = 포트 바인딩, `uncaught_exception` = 예상 못한 오류)
+
+**"특정 요청 flow 를 추적하고 싶다."**
+`traceId` 로 필터. 요청 한 건에 대한 `tool_call` (+ 관련 sdk_error 등) 모두 같은 traceId.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -386,3 +386,20 @@
 - [x] **32-A**: HTTP transport PoC (multi-session stateful 패턴 확정)
 - [x] **32-B**: MCP server HTTP transport 정식 도입 + PM2 승격
 - [x] **32-C**: 구조화 로깅 (pino + 파일 rotation + SDK bypass 감지)
+
+---
+
+# 15차 마일스톤 — 관측 & 이력 & 전략 확장
+
+> 알림 발동 이력 웹 조회, MCP 로그 대시보드, 커스텀 전략 v3 (어닝 · 크로스-티커).
+
+## Phase 33: 관측 & 이력 & 정책
+- [x] **33-D**: 관심종목 알림 시간대 토글 (24h ↔ 장중 only)
+- [x] **33-A**: AlertHistory 모델 + 발동 hook (9개 kind 자동 저장)
+- [x] **33-B**: 알림 이력 페이지 `/alerts/history` (필터·차트·리스트)
+- [x] **33-C**: MCP 로그 대시보드 `/admin/mcp-logs` + crash 파일 분리 + 스키마 문서화 (#409 흡수)
+
+## Phase 34: 커스텀 전략 v3
+- [x] **34-A**: 어닝 캘린더 조건 (`earnings_within_days`, yahoo-finance2 무료)
+- [x] **34-B**: 크로스-티커 조건 (`cross_ticker` SPY/VIX 등 벤치마크 게이트)
+- [ ] **34-C**: 뉴스 조건 (외부 API 승인 후 별도 마일스톤으로 이월, #421)

--- a/docs/specs/414-milestone-15-master.md
+++ b/docs/specs/414-milestone-15-master.md
@@ -1,0 +1,146 @@
+# 15차 마일스톤 — 관측 & 이력 & 전략 확장 (마스터)
+
+- **작성일**: 2026-07-08
+- **타입**: 마일스톤 (마스터 스펙, sub-phase 로 분할 진행)
+- **참조**: 14차 마스터 #402, `memory/project_next_milestone_15.md`
+
+## 1. 배경
+
+14차 마일스톤 (#402) 완료로 MCP 서버가 상시 상주 HTTP 프로세스로 격상되고 pino 구조화 로그가 파일에 남게 되면서 **사후 관찰 기반**이 마련되었다. 15차는 이 관찰 기반을 실사용자 가시성으로 확장하고, 알림 정책·전략 조건을 강화한다.
+
+**사용자가 명시한 두 축**:
+1. **관측 강화** — 알림 발동 이력 (당장 재현되는 장외 알림 원인 데이터로 파악) + MCP tool 호출 대시보드 (32-C 로그의 UI화)
+2. **전략 확장** — 커스텀 전략 v3 (어닝/크로스-티커/뉴스 조건)
+
+**부수 발견**: 사용자로부터 "장 마감 후에도 관심종목 매수구간 알림이 오는 문제"가 재현된다는 리포트. 코드 확인 결과 spec 상 관심종목/목표가/환율 알림은 24h 허용이 정상 동작이나 **사용자 인식과 불일치** → 33-D 로 사용자 토글 도입.
+
+## 2. 목표
+
+15차 종료 시:
+- ✅ 알림 발동 이력이 DB 에 축적되고 웹 UI 로 조회 가능
+- ✅ MCP tool 호출 대시보드 (호출량/에러율/latency) 제공 + 크래시 별도 파일 분리
+- ✅ 관심종목 알림 시간대 (24h vs 장중 only) 사용자 설정 가능
+- ✅ 커스텀 전략에 어닝 임박·크로스-티커 조건 추가 (뉴스는 착수 시 승인)
+
+## 3. Sub-Phase 분할
+
+### Phase 33: 관측 & 이력 & 알림 정책
+
+#### 33-D: 관심종목 알림 시간대 토글 (선행 — spec 명확)
+
+**목적**: 사용자 인식과 spec 일치. 매수구간/목표매수가 알림을 장중 only 로 제한할 수 있게.
+
+- [ ] `AlertConfig` (owner 별) 에 `watchlistMarketHoursOnly: boolean` 필드 추가 (기본 `false` = 24h 하위호환)
+- [ ] `price-alert.ts` 의 관심종목 loop (line 179~205) 에서 config 참조하여 `isMarketOpenFor` 필터 조건부 적용
+- [ ] `settings` 페이지의 AlertConfig UI 에 스위치 추가 ("관심종목 매수 알림 — 장중에만")
+- [ ] 테스트: 장중/장외 시나리오 x 토글 on/off 조합
+
+**의존성**: 없음 (독립)
+**노력**: XS (반나절)
+
+#### 33-A: AlertHistory 모델 + 발동 hook
+
+**목적**: 모든 알림 발동을 DB 에 저장 → 33-B 이력 페이지와 재현 이슈 사후 진단의 데이터 소스.
+
+- [ ] Prisma 신규 모델 `AlertHistory`:
+  - id, firedAt, kind (`surge` | `drop` | `target_hit` | `stop_loss` | `watch_buy` | `watch_zone` | `fx` | `ta_signal` | `custom_strategy`)
+  - ticker (nullable — 환율 등), price, changePercent, message, deliveryStatus (`sent` | `failed`)
+  - chatId (Int64), errorMessage (nullable)
+- [ ] Migration
+- [ ] `price-alert.ts`, `ta-signal-alert.ts`, 커스텀 전략 알림 각 hook 지점에 `prisma.alertHistory.create` 호출 (트랜잭션 밖 — 실패 시 로그만)
+- [ ] MCP tool 추가: `list_alert_history(kind, ticker, from, to, limit)` — 텔레그램 AI 에서도 조회 가능
+- [ ] 테스트: 각 알림 종류별 저장 검증
+
+**의존성**: 33-D 이후 (같은 정책 적용 상태에서 이력 기록)
+**노력**: S (하루)
+
+#### 33-B: 알림 이력 페이지
+
+**목적**: 웹에서 알림 발동 이력 시각화.
+
+- [ ] `/alerts/history` 라우트
+- [ ] 필터: 기간 (7/30/90일), 종류 (multi), 티커 검색
+- [ ] 리스트: 시각, 종목, 종류 뱃지, 메시지, 성공/실패
+- [ ] 상단 요약: 기간 내 총 건수, 종류별 파이 차트, 일별 발동 건수 라인 차트
+- [ ] mobile 반응형 (14차 마일스톤 15와 별도 — 이 페이지만 우선)
+- [ ] 디자인: `frontend-design` 스킬 활용, `docs/designs/` 저장
+
+**의존성**: 33-A
+**노력**: S (하루)
+
+#### 33-C: MCP 로그 대시보드 + #409 follow-up
+
+**목적**: 32-C 의 pino JSON 로그 파일을 웹에서 조회 가능하게 + #409 (crash 분리, 스키마 문서화) 병행.
+
+- [ ] `/admin/mcp-logs` 라우트 (관리 페이지 — 접근 제한 방식은 착수 시 결정)
+- [ ] 로그 파일 파서 (`logs/mcp-YYYY-MM-DD.log` JSON lines)
+- [ ] 필터: 날짜, level (info/warn/error/fatal), msg (tool_call, sdk_error, http_server_error 등), tool 이름, traceId
+- [ ] 통계: 날짜별 호출 건수, tool 별 평균 latency, 에러율
+- [ ] **#409 통합**:
+  - `logs/mcp-crash-YYYY-MM-DD.log` 별도 파일 (fatal + uncaughtException 만)
+  - `docs/mcp-log-schema.md` — 각 msg 종류별 필드 문서화
+- [ ] 성능: 대용량 파일 대비 tail-N 우선 로드 + 페이지네이션
+
+**의존성**: 없음 (33-A/B 와 병행 가능)
+**노력**: M (1~2일)
+
+### Phase 34: 커스텀 전략 v3
+
+#### 34-A: 어닝 캘린더 조건
+
+**목적**: 어닝 임박/직후 종목 진입/회피 자동화.
+
+- [ ] `yahoo-finance2` 의 `quoteSummary(ticker, { modules: ['calendarEvents'] })` 활용 (무료)
+- [ ] 커스텀 전략 v2 조건에 `earnings_within_days` 추가 (예: D-3 이내면 skip, D+1 이후 진입)
+- [ ] 캐시: `EarningsCache` 모델 (ticker, nextEarningsDate, updatedAt) — cron 으로 일 1회 갱신
+- [ ] UI: `/strategies` 편집 폼에 조건 추가
+- [ ] 테스트: 어닝 D-3/당일/D+1 시나리오
+
+**의존성**: 없음 (v2 확장)
+**노력**: S (하루)
+
+#### 34-B: 크로스-티커 조건
+
+**목적**: SPY, VIX 등 벤치마크 상태를 개별 종목 진입 조건으로.
+
+- [ ] 조건 스키마: `cross_ticker` — `{ ticker: 'SPY', metric: 'changePercent' | 'price', operator: '<=' | '>=', threshold: number }`
+- [ ] 평가 로직: 대상 티커의 PriceCache 조회 후 threshold 비교
+- [ ] UI: 다중 조건 with 다른 티커 선택
+- [ ] 테스트
+
+**의존성**: 34-A (같은 조건 프레임워크)
+**노력**: S (하루)
+
+#### 34-C: 뉴스 조건 (외부 API 도입)
+
+**목적**: 종목/섹터 관련 뉴스 이벤트 조건.
+
+- [ ] 후보 API 조사 & 승인: newsapi.org (무료 tier 제한), alpha vantage news (제한적), benzinga (유료). 착수 시 별도 스펙.
+- [ ] Rate limit / 캐시 전략
+- [ ] 조건 스키마: `news_keyword` — `{ keyword, timeframe: '24h' | '7d', min_count: number }`
+- [ ] 착수 승인 후 진행 (뒤로 미룰 수 있음)
+
+**의존성**: 34-B, 사용자 승인
+**노력**: M (2~3일, API 조사 포함)
+
+## 4. 착수 순서
+
+```
+33-D (선행, 사용자 pain 해결) → 33-A (모델) → 33-B (이력 UI)
+→ 33-C (대시보드) → 34-A → 34-B → 34-C (승인 후)
+```
+
+## 5. 제외 사항
+
+- 알림 자체 로직 변경 (급등락 임계값 등) — 별도 이슈
+- 모바일 웹 UX 전면 재검토 — 16차 후보로 이월
+- 백테스트 UX 확장 — 16차 후보로 이월
+- 성능/부하 튜닝 — 33-C 결과 관찰 후 필요 시 별도 이슈
+
+## 6. 산출물
+
+- `docs/specs/*` (sub-phase 별)
+- `docs/designs/33-B-*`, `docs/designs/33-C-*` (UI 시안)
+- `docs/mcp-log-schema.md` (33-C 결과물)
+- Prisma migrations: `AlertHistory`, `AlertConfig.watchlistMarketHoursOnly`, `EarningsCache`
+- 신규 페이지: `/alerts/history`, `/admin/mcp-logs`

--- a/docs/specs/415-watchlist-market-hours-toggle.md
+++ b/docs/specs/415-watchlist-market-hours-toggle.md
@@ -1,0 +1,81 @@
+# [Phase 33-D] 관심종목 알림 시간대 토글
+
+- **이슈**: #415
+- **마스터**: #414 (`docs/specs/414-milestone-15-master.md`)
+- **작성일**: 2026-07-08
+- **타입**: 기능 확장 (알림 정책)
+
+## 1. 배경
+
+관심종목 알림 (💰 목표매수가 도달, 🔔 매수구간 진입) 은 spec 상 24h 허용이 정상이나 사용자 인식과 불일치 — 장 마감 후에 오는 관심종목 알림을 노이즈로 인식.
+
+`src/bot/notifications/price-alert.ts` line 179~205 의 watchlist loop 는 `isMarketOpenFor` 필터를 적용하지 않음 (반면 급등락 line 107 은 적용). 이는 CLAUDE.md 규칙:
+> 환율/목표가/매수구간 알림은 24시간.
+
+과 일치하지만, 사용자는 관심종목 알림만 장중 only 로 제한하는 옵션을 원함.
+
+## 2. 접근
+
+`AlertConfig` 는 key-value 스키마 (Prisma schema.prisma:322). **스키마 변경 없이 새 key 추가로 처리**.
+
+- Key: `watchlist_market_hours_only`
+- Value: `on` / `off` (toggle)
+- 기본값: `off` (하위호환 — 기존 24h 동작 유지)
+- 카테고리: `price`
+- Input type: `toggle`
+
+## 3. 변경 상세
+
+### 3.1 `src/bot/notifications/price-alert.ts`
+
+- 상수 추가: `WATCHLIST_MHO_KEY`, `WATCHLIST_MHO_LABEL`
+- `ensureWatchlistMarketHoursOnlySetting()` 함수 export (다른 `ensure*` 와 동일 패턴)
+- `checkPriceAlerts()` 내:
+  - `findMany` 의 `key: { in: [...] }` 배열에 새 key 추가
+  - `configMap.get(WATCHLIST_MHO_KEY)?.toLowerCase() === 'on'` boolean 산출
+  - watchlist loop (line 179~) 진입 시: `if (marketHoursOnly && !isMarketOpenFor(price.market, w.ticker)) continue`
+
+적용 범위:
+- 💰 `targetBuy` (목표매수가)
+- 🔔 매수구간 진입
+
+환율/보유종목 목표가/손절가는 무영향.
+
+### 3.2 `src/lib/alert-config/categories.ts`
+
+- `ALERT_KEY_CATEGORY['watchlist_market_hours_only'] = 'price'`
+- `ALERT_KEY_INPUT_TYPE['watchlist_market_hours_only'] = 'toggle'`
+- `ALERT_KEY_DESCRIPTION['watchlist_market_hours_only'] = '관심종목 목표매수가/매수구간 알림을 각 시장 거래시간에만 발송 (기본 off = 24h)'`
+
+### 3.3 `src/bot/notifications/scheduler.ts`
+
+- `ensureWatchlistMarketHoursOnlySetting` import + `.catch` 로 호출 등록 (다른 ensure 와 동일)
+
+### 3.4 UI
+
+`AlertConfigEditor` 는 key-value 리스트를 자동 렌더링하므로 **UI 코드 변경 불필요**. 새 key 가 설정 페이지의 "가격 / 환율 알림" 카테고리에 자동 등장.
+
+## 4. 테스트
+
+`src/bot/notifications/__tests__/price-alert-watchlist.test.ts` 신규:
+
+시나리오 (4개):
+1. `off` + 장중 → 알림 발동
+2. `off` + 장외 → 알림 발동 (하위호환)
+3. `on` + 장중 → 알림 발동
+4. `on` + 장외 → 알림 **차단**
+
+또한 카테고리 매핑 테스트 (`src/lib/alert-config/__tests__/categories.test.ts` 확장).
+
+## 5. 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] 코드 리뷰 P1/P2 = 0
+- [ ] 서버 배포 후 설정 페이지 "가격 / 환율 알림" 에 새 토글 노출 확인
+- [ ] 실제 켠 상태로 장 마감 후 관심종목 매수구간 알림 미발동 확인
+
+## 6. 제외 사항
+
+- 보유종목 목표가/손절가 시간대 필터링 — 현행 24h 유지 (spec 그대로)
+- 환율 알림 필터링 — 24h 유지
+- 종목별 개별 토글 (마스터 스펙에 언급된 대안) — 이번엔 글로벌 토글만. 종목별은 후속 이슈로 이월 가능

--- a/docs/specs/416-alert-history.md
+++ b/docs/specs/416-alert-history.md
@@ -1,0 +1,99 @@
+# [Phase 33-A] AlertHistory 모델 + 발동 hook
+
+- **이슈**: #416
+- **마스터**: #414
+- **작성일**: 2026-07-08
+
+## 목표
+
+모든 알림 발동을 DB 에 저장 → 33-B 이력 페이지 + 사후 진단 (예: 재현 이슈) 데이터 소스.
+
+## 스키마
+
+```prisma
+model AlertHistory {
+  id             String   @id @default(cuid())
+  firedAt        DateTime @default(now())
+  kind           String   // surge / drop / fx / target_hit / stop_loss / watch_buy / watch_zone / ta_signal / custom_strategy
+  ticker         String?  // null 허용 (환율 등)
+  price          Float?
+  changePercent  Float?
+  message        String   // 발송 본문 (per-event HTML)
+  deliveryStatus String   // 'sent' | 'partial' | 'failed'
+  recipientCount Int      @default(0)
+  errorMessage   String?
+
+  @@index([firedAt])
+  @@index([kind, firedAt])
+  @@index([ticker, firedAt])
+}
+```
+
+- **1 행 = 1 이벤트** (한 번의 텔레그램 발송에 여러 이벤트가 들어가면 여러 행 저장)
+- `deliveryStatus` 는 배치 발송 결과 요약 (chatIds 전원 성공 = sent, 일부 = partial, 전원 실패 = failed)
+- `errorMessage` 는 실패 시 마지막 예외 (진단용)
+
+## Helper — `src/bot/notifications/alert-history.ts`
+
+- `type AlertKind = ...`
+- `type DeliveryStatus = 'sent' | 'partial' | 'failed'`
+- `computeDeliveryStatus(successCount, total)` — pure
+- `recordAlertHistory(events, deliveryStatus, recipientCount, errorMessage?)` — Prisma createMany. 실패는 로그만.
+
+## Hook 지점
+
+기존 알림 스캐너 3곳 각각 이벤트 수집 후 저장:
+
+### `price-alert.ts`
+- 급등 → `surge`
+- 급락 → `drop`
+- 환율 → `fx`
+- 보유종목 목표가 도달 → `target_hit`
+- 보유종목 손절가 도달 → `stop_loss`
+- 관심종목 목표매수가 → `watch_buy`
+- 관심종목 매수구간 진입 → `watch_zone`
+
+문자열 `alerts.push(...)` 대신 구조체 `events.push({ kind, ticker, price, changePercent, message })` 로 변경. 배치 발송 후 `recordAlertHistory` 호출.
+
+### `ta-signal-alert.ts`
+- `ta_signal` — 한 티커의 여러 signal 을 하나의 event 로 통합 (`signals.join(', ')` 을 message 로)
+- 발송 성공 후 저장
+
+### `custom-strategy-alert.ts`
+- `custom_strategy` — 한 전략 발동 = 한 이벤트
+- 발송 성공 후 저장
+
+## MCP tool — `src/mcp/tools/alert-history.ts`
+
+```
+list_alert_history(kind?, ticker?, from?, to?, limit?)
+```
+
+- `kind`: 필터 (미지정 시 전체)
+- `ticker`: 필터
+- `from` / `to`: ISO 8601 문자열
+- `limit`: 기본 50, 최대 200
+- 결과: markdown 리스트 (시각 / 종류 / 종목 / 메시지 요약 / 배송 상태)
+
+`src/mcp/server.ts` 에 tool 등록.
+
+## 테스트
+
+- `alert-history.test.ts`:
+  - `computeDeliveryStatus` — total=0 → failed, 전원 성공 → sent, 전원 실패 → failed, 일부 성공 → partial
+  - `recordAlertHistory` — 빈 events 는 no-op
+- `price-alert-history-integration.test.ts` — pure 부분만 (event 수집 로직 refactor 후)
+- `mcp/tools/alert-history.test.ts` — 필터 조합 검증 (prisma mock)
+
+## 완료 조건
+
+- [ ] Prisma migration 생성 + 적용
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] MCP tool 텔레그램 AI 에서 호출 성공 (배포 후 검증)
+
+## 제외 사항
+
+- 33-B 이력 페이지 UI — 별도 이슈 (#417)
+- 알림 자체 로직 변경 — 순수 관측/저장만 추가
+- 33-D 이전 발동은 복원 불가 (마이그레이션 시점부터 축적)

--- a/docs/specs/417-alert-history-page.md
+++ b/docs/specs/417-alert-history-page.md
@@ -1,0 +1,123 @@
+# [Phase 33-B] 알림 이력 페이지 (/alerts/history)
+
+- **이슈**: #417
+- **마스터**: #414
+- **선행**: #416 (AlertHistory 모델, 이미 머지됨)
+- **작성일**: 2026-07-08
+
+## 목표
+
+웹에서 알림 발동 이력을 필터·통계와 함께 조회. AI 자연어 질의 (`list_alert_history` MCP) 의 웹 UI 대응.
+
+## 사용자 흐름
+
+1. 텔레그램 알림을 받은 뒤 웹에서 "어떤 알림이 언제 왔나" 확인 → `/alerts/history` 진입
+2. 기본: 최근 7일 전체 kind
+3. 필요 시 기간(7/30/90일) / kind(칩 토글) / ticker 검색 조합 필터
+4. 상단 통계 카드로 발동 추이 요약, 하단 리스트로 개별 이벤트 상세
+
+## API 설계
+
+### `GET /api/alerts/history`
+
+Query params:
+- `kind` (optional): kind 필터 (단일)
+- `ticker` (optional): 대문자 정규화 후 exact match
+- `from`, `to` (optional): ISO 8601. 미지정 시 최근 7일
+- `limit` (optional): 기본 50, 최대 200
+- `offset` (optional): 기본 0
+
+Response (envelope):
+```
+{
+  success: true,
+  data: [ AlertHistoryRow, ... ],
+  meta: { total: number, limit: number, offset: number },
+}
+```
+
+### `GET /api/alerts/history/stats`
+
+Query params: 동일 (kind/ticker/from/to)
+
+Response:
+```
+{
+  success: true,
+  data: {
+    total: number,
+    byStatus: { sent: number, partial: number, failed: number },
+    byKind: [ { kind, count }, ... ],
+    byDay: [ { date: 'YYYY-MM-DD', count: number }, ... ],
+  }
+}
+```
+
+## 페이지 (`src/app/alerts/history/page.tsx` + `AlertHistoryClient.tsx`)
+
+### 레이아웃 (기존 site 패턴 재사용 — 별도 프로토타입 없이 dashboard-prototype 톤 그대로)
+
+```
+┌ Header(title, sub) ────────────────────────────────┐
+│                                                    │
+│ [필터 바] 기간 · kind 칩 · ticker 검색            │
+│                                                    │
+│ [Stat 4개]  총건수  성공률  종류수  티커수         │
+│                                                    │
+│ [Chart 2개] 일별 발동 라인 (Recharts)              │
+│             종류별 파이 (또는 스택 바)             │
+│                                                    │
+│ [리스트]  시각 · kind 뱃지 · ticker · 메시지 · 상태│
+│ [페이지네이션] Prev / N / M / Next                 │
+└────────────────────────────────────────────────────┘
+```
+
+### 색상/스타일
+
+- 기존 다크 톤 + `sejin=#34d399` 강조
+- kind 뱃지 컬러:
+  - surge → emerald (성공)
+  - drop → red
+  - fx → sky
+  - target_hit / watch_buy → sejin (green)
+  - stop_loss → red
+  - watch_zone → amber
+  - ta_signal → violet
+  - custom_strategy → orange
+- 상태 뱃지:
+  - sent → sejin
+  - partial → amber
+  - failed → red
+
+### 반응형
+
+- 모바일: 필터 세로 스택, 차트 1열, 리스트 카드 형태
+- 데스크톱: 필터 가로, 차트 2열 (라인/파이 병렬), 리스트 테이블
+
+## 파일 변경
+
+- `src/app/api/alerts/history/route.ts` (신규) — GET list
+- `src/app/api/alerts/history/stats/route.ts` (신규) — GET stats
+- `src/app/alerts/history/page.tsx` (신규)
+- `src/app/alerts/history/AlertHistoryClient.tsx` (신규)
+- 네비게이션 링크 (설정 페이지 등에서 접근 가능하도록) — 위치는 착수 시 결정
+
+## 테스트
+
+- API route: 필터 조합 검증 (envelope + pagination)
+- Stats: kind/status 집계 + byDay bucket 정합성
+- Client 유닛: 기간 프리셋 로직 pure, kind toggle set
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] 로컬 실행 후 필터/차트/리스트 정상 렌더링 확인 (verify skill)
+- [ ] 모바일 뷰포트 검증
+
+## 제외 사항
+
+- 알림 상세 모달 (kind 별 컨텍스트 표시) — v2
+- 이력 export (CSV) — v2
+- 알림 재발송 / 재시도 — 별도 스코프
+- 접근 제한 (관리자 전용) — 개인 서비스라 인증 미적용 상태 유지

--- a/docs/specs/418-mcp-log-dashboard.md
+++ b/docs/specs/418-mcp-log-dashboard.md
@@ -1,0 +1,84 @@
+# [Phase 33-C] MCP 로그 대시보드 + #409 흡수
+
+- **이슈**: #418 (부속 #409 흡수)
+- **마스터**: #414
+- **작성일**: 2026-07-08
+
+## 목표
+
+32-C 에서 만든 pino JSON 로그 파일 (`logs/mcp-YYYY-MM-DD.log`) 을 웹에서 조회 + 통계. 부속으로 #409 (crash 별도 파일 + 스키마 문서화) 흡수.
+
+## 산출물
+
+### A. Crash 별도 파일 (#409 A)
+`logs/mcp-crash-YYYY-MM-DD.log` — fatal + uncaughtException / unhandledRejection 만 tee. 일반 로그와 분리해 pm2 상태 진단 시 fatal 만 빠르게 스캔 가능.
+
+- pino `multistream` 에 `level: 'fatal'` entry 추가
+- KST rotation + retention 정책은 기본 파일과 동일 (14일)
+
+### B. 스키마 문서 (#409 B)
+`docs/mcp-log-schema.md` — 각 msg 별 (`tool_call`, `sdk_error`, `transport_ready`, `http_server_error`, `http_request_error`, `session_initialized`, `session_closed`, `session_sweep`, `shutdown_started`, `http_server_closed`, `force_exit_timeout`, `server_fatal`, `uncaught_exception`, `unhandled_rejection`, `transport_close_error`) 필드 목록 + 예시.
+
+### C. 대시보드 UI
+
+**API**:
+- `GET /api/admin/mcp-logs?date=&level=&msg=&tool=&traceId=&limit=&offset=`
+  - `date`: YYYY-MM-DD (기본 = 오늘 KST). `logs/mcp-<date>.log` 파일에서 파싱.
+  - `level`: info/warn/error/fatal (whitelist)
+  - `msg`: 정확 매치 (whitelist 는 12개 msg 상수)
+  - `tool`: tool 이름 (contains)
+  - `traceId`: 8자 hex
+  - `limit`: 기본 100, 최대 500
+  - `offset`: 페이지네이션
+  - 응답: envelope + paginated
+  - 대용량 방어: 파일 사이즈 확인 후 tail-N 파싱 (최근 항목 우선), max 50k 라인 스캔.
+
+- `GET /api/admin/mcp-logs/stats?date=&level=&msg=&tool=`
+  - `total`, `byLevel`, `byMsg`, `byTool` (top 20), `latencyStats` (tool 별 avg/p95/p99 for tool_call)
+
+**페이지** `/admin/mcp-logs`:
+- Header (title / sub)
+- Filter bar: 날짜 (달력 or 최근 7일 chip), level chip, msg chip, tool 검색, traceId 검색
+- Stat cards: 총 이벤트, 에러율, 유니크 tool 수, 평균 latency
+- Charts: level 별 파이 + tool 별 호출량 bar
+- List: 시각 / level 뱃지 / msg / tool 파란 뱃지 / 요약 (traceId + args preview)
+- Pagination
+
+### 접근 제한
+개인 서비스라 별도 role 없음. 기존 middleware auth 통과만.
+
+## 파일 변경
+
+**크래시 분리 (#409 A)**:
+- `src/mcp/logger.ts` — `openCrashFileStream` 신설, buildStreams 에 crash entry 추가, rotation 도 crash 별도로 스케줄
+
+**스키마 문서 (#409 B)**:
+- `docs/mcp-log-schema.md` (신규)
+
+**대시보드**:
+- `src/lib/mcp-logs/parser.ts` (신규) — JSON line 파서, tail-N, 필터 pure
+- `src/lib/mcp-logs/constants.ts` (신규) — MSG_LABELS, LEVEL_ORDER 등
+- `src/app/api/admin/mcp-logs/route.ts` (신규)
+- `src/app/api/admin/mcp-logs/stats/route.ts` (신규)
+- `src/app/admin/mcp-logs/page.tsx` (신규)
+- `src/app/admin/mcp-logs/McpLogsClient.tsx` (신규)
+- `src/components/layout/nav-config.ts` (수정) — `/admin/mcp-logs` 링크 추가
+
+**테스트**:
+- `src/mcp/__tests__/logger-crash-tee.test.ts` — 크래시 파일이 fatal 만 받는지
+- `src/lib/mcp-logs/__tests__/parser.test.ts` — JSON line 파서, 필터, tail-N
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P1/P2 = 0
+- [ ] verify skill 로 API + 페이지 렌더 확인
+- [ ] `docs/mcp-log-schema.md` 커밋
+- [ ] #409 CLOSE (같이 처리)
+
+## 제외 사항
+
+- 실시간 tail (WebSocket) — v2
+- 로그 다운로드 (CSV) — v2
+- 여러 파일 합쳐서 검색 (crash + 일반) — 우선 개별 파일별 검색만
+- Prometheus / Grafana 연동 — 스코프 밖

--- a/docs/specs/419-earnings-condition.md
+++ b/docs/specs/419-earnings-condition.md
@@ -1,0 +1,93 @@
+# [Phase 34-A] 커스텀 전략 v3 — 어닝 캘린더 조건
+
+- **이슈**: #419
+- **마스터**: #414
+- **작성일**: 2026-07-08
+
+## 목표
+
+커스텀 전략 v2 조건에 **`earnings_within_days`** 추가. 어닝 임박 종목에 대한 진입 회피 (D-3 이내 skip) / 어닝 안전 지대 확인 (D+7 이상 진입) 자동화.
+
+## 데이터 소스
+
+`yahoo-finance2.quoteSummary(ticker, { modules: ['calendarEvents'] })` — 무료.
+- 응답: `calendarEvents.earnings.earningsDate: Date[]` (다음 예정 어닝 배열, 보통 1~2개)
+- 실패 시 (미국 외 일부 종목 지원 X) — 캐시 유지, false-safe.
+
+## 스키마
+
+### Prisma 신규 모델
+```prisma
+model EarningsCache {
+  ticker             String    @id
+  nextEarningsDate   DateTime?
+  lastFetchedAt      DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+}
+```
+
+### Condition 확장
+```ts
+type ConditionType =
+  ... // 기존
+  | 'earnings_within_days'   // 다음 어닝까지 남은 일수
+```
+- operator: `<` / `<=` / `>` / `>=` / `==` (numeric)
+- value: 정수 (일)
+- timeframe: 미사용
+
+**의미**: `earnings_within_days <= 3` = 다음 어닝까지 3일 이하 (오늘 = 0). 데이터 없거나 이미 지난 어닝만 있으면 조건 **false** (안전측 — 진입 회피 스타일 조건이라 매치 안 됨이 안전).
+
+## 파일 변경
+
+- `prisma/schema.prisma` + migration — `EarningsCache`
+- `src/lib/earnings/fetcher.ts` (신규) — yahoo-finance2 호출, 단일 티커
+- `src/lib/earnings/cache.ts` (신규) — upsert / getByTicker
+- `src/lib/earnings/cron.ts` (신규 또는 `src/lib/cron.ts` 확장) — 일 1회 스캔, 대상 = 활성 전략 티커 ∪ 관심종목 ∪ 보유종목
+- `src/lib/custom-strategy/types.ts` — `earnings_within_days` 추가 (NUMERIC_TYPES 확장)
+- `src/lib/custom-strategy/evaluator.ts` — 조건 평가 (EarningsCache 조회 + 일수 계산)
+- `src/lib/ai/system-prompt.ts` — AI 프롬프트에 예시 추가 (자연어 → 조건 변환용)
+- `src/app/strategies/*` — 편집 폼 조건 옵션 추가
+
+## Evaluator 로직
+
+```ts
+if (condition.type === 'earnings_within_days') {
+  const cache = snapshot.earnings  // cron 이 미리 로드한 { nextEarningsDate }
+  if (!cache?.nextEarningsDate) return false
+  const days = Math.ceil((cache.nextEarningsDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000))
+  if (days < 0) return false  // 이미 지난 어닝
+  return numericCompare(days, condition.operator, condition.value)
+}
+```
+
+## Cron
+
+- 매일 KST 06:00 (미국 장 마감 후, 한국 장 시작 전)
+- 대상 티커 수집:
+  - `SELECT ticker FROM CustomStrategy WHERE isActive = true`
+  - `SELECT ticker FROM Watchlist`
+  - `SELECT DISTINCT ticker FROM Holding WHERE shares > 0`
+- 병렬 fetch (concurrency 5)
+- fetch 실패 → `lastFetchedAt` 만 업데이트, `nextEarningsDate` 유지
+- 로그: `msg='earnings_scan'`, 성공/실패 카운트
+
+## 테스트
+
+- `validateCondition` — `earnings_within_days` 통과, 잘못된 value 거부
+- `evaluator` — null cache / 과거 어닝 / 미래 D-0/D-3/D-30 시나리오
+- `fetcher` — yahoo-finance2 mock 으로 성공/실패
+- `cron` — 티커 수집 로직 (mock prisma)
+
+## 완료 조건
+
+- [ ] Prisma migration 적용
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] verify: 실제 티커 (예: AAPL) 로 fetcher → cache 반영 → evaluator 통과 확인
+
+## 제외 (34-A 이후 후속 이슈)
+
+- **Post-earnings drift** — 어닝 직후 진입 조건 (`days_since_earnings`) 별도 조건 타입 필요. 34-A 는 pre-earnings 만.
+- **어닝 EPS 실적 조건** — surprise% 기반 조건
+- **한국주 어닝** — Yahoo 는 미국 종목 위주. KRX 어닝은 별도 소스 필요.

--- a/docs/specs/420-cross-ticker-condition.md
+++ b/docs/specs/420-cross-ticker-condition.md
@@ -1,0 +1,124 @@
+# [Phase 34-B] 커스텀 전략 v3 — 크로스-티커 조건
+
+- **이슈**: #420
+- **마스터**: #414
+- **선행**: #419 (34-A) — 어닝 조건. 34-B 는 다른 조건 프레임워크 활용.
+- **작성일**: 2026-07-09
+
+## 목표
+
+전략 대상 티커와 다른 티커의 상태 (예: SPY 하락, VIX 급등) 를 진입 조건으로 사용. 시장 컨텍스트 게이트 자동화.
+
+**대표 사용례**:
+- "SPY 가 -2% 하락한 날엔 개별 종목 매수 회피"
+- "VIX > 25 일 때만 콜/풋 스캘핑"
+- "QQQ 200SMA 위에 있을 때만 성장주 진입"
+
+## 조건 스키마
+
+```ts
+type ConditionType =
+  ... // 기존
+  | 'cross_ticker'   // 다른 티커의 price / changePercent 조건
+```
+
+### 구조
+```ts
+{
+  type: 'cross_ticker',
+  operator: '<' | '<=' | '>' | '>=' | '==',
+  value: number,
+  crossTicker: string,          // 참조 티커 (대문자 정규화)
+  metric: 'price' | 'change_percent',  // 어떤 값과 비교
+}
+```
+
+- `crossTicker` **신규 필수 필드** (기존 `timeframe` 처럼 조건별 오버라이드).
+- `metric='price'`: PriceCache 의 `price` 필드
+- `metric='change_percent'`: PriceCache 의 `changePercent` 필드 (일일)
+
+### 유효성 검증
+- crossTicker 는 비어 있지 않은 문자열 (자동 대문자 정규화)
+- metric 은 화이트리스트
+- operator 는 numeric (< / <= / > / >= / ==)
+- value 는 finite number
+- **자기 자신 참조 금지** — validateCondition 은 통과 (전략 편집 시점엔 strategy.ticker 알 수 없음), 대신 **evaluator 가 `crossTicker === context.strategyTicker` 이면 false 안전 판정**
+
+### 예시
+```json
+{"type":"cross_ticker","operator":"<=","value":-2,"crossTicker":"SPY","metric":"change_percent"}
+```
+
+## 평가 로직 (evaluator)
+
+```ts
+case 'cross_ticker': {
+  if (typeof cond.value !== 'number') return false
+  if (!cond.crossTicker || !cond.metric) return false
+  const normalized = cond.crossTicker.trim().toUpperCase()
+  if (normalized === context.strategyTicker) return false  // 자기 자신 회피
+  const cross = context.crossTickers?.get(normalized)
+  if (!cross) return false  // 데이터 없음 → false 안전
+  const actual = cond.metric === 'price' ? cross.price : cross.changePercent
+  if (actual == null) return false
+  return compareNumeric(actual, cond.operator, cond.value)
+}
+```
+
+## Context 확장
+
+```ts
+interface EvaluationContext {
+  ...
+  crossTickers?: Map<string, { price: number; changePercent: number | null }>
+}
+```
+
+`custom-strategy-alert.ts` 가 evaluate 전에 **전략들의 모든 crossTicker 를 수집** → 별도 PriceCache 조회 → context 에 주입.
+
+## Ticker 수집 헬퍼
+
+```ts
+// pure
+function collectCrossTickers(strategies: CustomStrategy[]): Set<string>
+```
+
+- 각 전략의 conditions 순회 → `type === 'cross_ticker'` 인 것들의 `crossTicker` 추출 (정규화).
+
+## PriceCache 조회
+
+기존 `priceCache.findMany` 를 확장 — 전략 티커 + 크로스 티커 합집합으로 한 번에 조회.
+
+## Cron 필요 여부
+
+새 fetch 불필요. `refreshPrices` cron 이 이미 관심종목 + 보유 종목 대상. 사용자는 크로스 티커도 관심종목에 등록하면 자연스럽게 커버. **spec 은 크로스 티커 자동 등록은 하지 않음** (사용자가 SPY/VIX 을 스스로 관심종목에 추가).
+
+## AI 파서 프롬프트
+
+- v3 섹션에 예시 추가 ("SPY -2% 이하 때만" / "VIX 25 초과 때 진입")
+- 미지원 리스트에서 "크로스-티커" 제거
+
+## 파일 변경
+
+- `src/lib/custom-strategy/types.ts` — `cross_ticker` 타입, crossTicker/metric 필드, validateCondition 확장, conditionToString 지원
+- `src/lib/custom-strategy/evaluator.ts` — `crossTickers` context 필드, `cross_ticker` case, `collectCrossTickers` pure
+- `src/lib/custom-strategy/parser.ts` — 프롬프트 v3 확장
+- `src/bot/notifications/custom-strategy-alert.ts` — crossTicker 수집 + PriceCache 확장 조회 + context 주입
+
+## 테스트
+
+- `types.test.ts` — cross_ticker 검증 (필수 필드, metric whitelist, 잘못된 operator)
+- `evaluator.test.ts` — 데이터 없음 / 자기 참조 / price 비교 / change_percent 비교 / 여러 시나리오
+- `custom-strategy-alert` 흐름 (option: e2e 하기 어려우면 pure `collectCrossTickers` 만 확실히 검증)
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] verify: 실제 running 서버에서 SPY 크로스 조건 전략 → 만족 시 발동
+
+## 제외 (후속)
+
+- 크로스 티커의 TA 지표 (RSI/MACD 등) — 조건 스키마 확장 필요
+- 여러 크로스 티커 AND 조건 (예: SPY 하락 AND VIX 급등) — 현재 스키마에서도 `cross_ticker` 조건 2개로 표현 가능 (자연스러움)
+- 크로스 티커 자동 관심종목 등록

--- a/prisma/migrations/20260708022825_add_alert_history/migration.sql
+++ b/prisma/migrations/20260708022825_add_alert_history/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "AlertHistory" (
+    "id" TEXT NOT NULL,
+    "firedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "kind" TEXT NOT NULL,
+    "ticker" TEXT,
+    "price" DOUBLE PRECISION,
+    "changePercent" DOUBLE PRECISION,
+    "message" TEXT NOT NULL,
+    "deliveryStatus" TEXT NOT NULL,
+    "recipientCount" INTEGER NOT NULL DEFAULT 0,
+    "errorMessage" TEXT,
+
+    CONSTRAINT "AlertHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AlertHistory_firedAt_idx" ON "AlertHistory"("firedAt");
+
+-- CreateIndex
+CREATE INDEX "AlertHistory_kind_firedAt_idx" ON "AlertHistory"("kind", "firedAt");
+
+-- CreateIndex
+CREATE INDEX "AlertHistory_ticker_firedAt_idx" ON "AlertHistory"("ticker", "firedAt");

--- a/prisma/migrations/20260708085511_add_earnings_cache/migration.sql
+++ b/prisma/migrations/20260708085511_add_earnings_cache/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "EarningsCache" (
+    "ticker" TEXT NOT NULL,
+    "nextEarningsDate" TIMESTAMP(3),
+    "lastFetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EarningsCache_pkey" PRIMARY KEY ("ticker")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -437,3 +437,12 @@ model CustomStrategy {
 
   @@index([ticker, isActive])
 }
+
+// Phase 34-A (#419): 어닝 캘린더 캐시. cron 이 일 1회 yahoo-finance2 로 갱신하고
+// evaluator 의 `earnings_within_days` 조건이 참조.
+model EarningsCache {
+  ticker           String    @id
+  nextEarningsDate DateTime?
+  lastFetchedAt    DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -327,6 +327,25 @@ model AlertConfig {
   updatedAt DateTime @updatedAt
 }
 
+// Phase 33-A (#416): 알림 발동 이력. 33-B 이력 페이지 + 사후 진단 데이터 소스.
+// 1 행 = 1 이벤트. 한 번의 텔레그램 배치 발송에 여러 알림이 포함되면 여러 행 저장.
+model AlertHistory {
+  id             String   @id @default(cuid())
+  firedAt        DateTime @default(now())
+  kind           String   // surge / drop / fx / target_hit / stop_loss / watch_buy / watch_zone / ta_signal / custom_strategy
+  ticker         String?  // 환율 등 티커 없는 알림은 null
+  price          Float?
+  changePercent  Float?
+  message        String   // per-event HTML 본문
+  deliveryStatus String   // 'sent' | 'partial' | 'failed'
+  recipientCount Int      @default(0)
+  errorMessage   String?
+
+  @@index([firedAt])
+  @@index([kind, firedAt])
+  @@index([ticker, firedAt])
+}
+
 model Asset {
   id           String    @id @default(cuid())
   name         String                         // "신한 적금", "전세 보증금"

--- a/src/app/admin/mcp-logs/McpLogsClient.tsx
+++ b/src/app/admin/mcp-logs/McpLogsClient.tsx
@@ -1,0 +1,420 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates } from '@/lib/mcp-logs/constants'
+
+interface LogRow {
+  level: string
+  time?: string
+  msg?: string
+  tool?: string
+  args?: unknown
+  latency_ms?: number
+  traceId?: string
+  status?: string
+  err?: unknown
+  raw?: string
+  parseError?: boolean
+  lineNo?: number
+}
+
+interface ListResponse {
+  items: LogRow[]
+  date: string
+  crash: boolean
+  fileExists: boolean
+  fileSize: number
+  truncatedHead: boolean
+  totalLines: number
+  scannedLines: number
+  tailStartLineNo: number
+}
+
+interface Stats {
+  total: number
+  byLevel: Array<{ level: string; count: number }>
+  byMsg: Array<{ msg: string; count: number }>
+  byTool: Array<{ tool: string; count: number; errors: number }>
+  latencyByTool: Array<{ tool: string; avg_ms: number; p95_ms: number; p99_ms: number; count: number }>
+  errorRate: number
+  date: string
+  crash: boolean
+  fileExists: boolean
+  totalLines: number
+  scannedLines: number
+}
+
+const PAGE_SIZE = 50
+
+const LEVEL_CLASS: Record<string, string> = {
+  fatal: 'bg-red-500/20 text-red-400 border-red-500/40',
+  error: 'bg-red-500/15 text-red-400 border-red-500/30',
+  warn:  'bg-amber-500/15 text-amber-400 border-amber-500/30',
+  info:  'bg-sky-500/15 text-sky-400 border-sky-500/30',
+  debug: 'bg-sub/15 text-sub border-sub/30',
+  trace: 'bg-sub/10 text-dim border-sub/20',
+  unknown: 'bg-surface text-sub border-border',
+}
+
+function formatDuration(ms?: number): string {
+  if (typeof ms !== 'number') return ''
+  if (ms < 1000) return `${ms} ms`
+  return `${(ms / 1000).toFixed(2)} s`
+}
+
+function shortJson(v: unknown, max = 160): string {
+  if (v == null) return ''
+  try {
+    const s = JSON.stringify(v)
+    return s.length > max ? s.slice(0, max) + '…' : s
+  } catch {
+    return String(v).slice(0, max)
+  }
+}
+
+export default function McpLogsClient() {
+  const dateOptions = useMemo(() => recentLogDates(7), [])
+  const [date, setDate] = useState(dateOptions[0])
+  const [crash, setCrash] = useState(false)
+  const [level, setLevel] = useState<string>('')
+  const [msg, setMsg] = useState<string>('')
+  const [toolInput, setToolInput] = useState('')
+  const [toolFilter, setToolFilter] = useState('')
+  const [traceInput, setTraceInput] = useState('')
+  const [traceFilter, setTraceFilter] = useState('')
+  const [offset, setOffset] = useState(0)
+  const [rows, setRows] = useState<LogRow[]>([])
+  const [meta, setMeta] = useState<Omit<ListResponse, 'items'> | null>(null)
+  const [total, setTotal] = useState(0)
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const p = new URLSearchParams()
+        p.set('date', date)
+        if (crash) p.set('crash', '1')
+        if (level) p.set('level', level)
+        if (msg) p.set('msg', msg)
+        if (toolFilter) p.set('tool', toolFilter)
+        if (traceFilter) p.set('traceId', traceFilter)
+
+        const listP = new URLSearchParams(p)
+        listP.set('limit', String(PAGE_SIZE))
+        listP.set('offset', String(offset))
+
+        const [listRes, statsRes] = await Promise.all([
+          fetch(`/api/admin/mcp-logs?${listP.toString()}`),
+          fetch(`/api/admin/mcp-logs/stats?${p.toString()}`),
+        ])
+        const listJson = await listRes.json()
+        const statsJson = await statsRes.json()
+        if (cancelled) return
+        if (!listRes.ok) throw new Error(listJson?.error ?? '로그 조회 실패')
+        if (!statsRes.ok) throw new Error(statsJson?.error ?? '통계 조회 실패')
+
+        const listData = listJson?.data as ListResponse | undefined
+        setRows(listData?.items ?? [])
+        setTotal(listJson?.meta?.total ?? 0)
+        setMeta(listData ? { ...listData, items: [] as never } as never : null)
+        setStats(statsJson?.data ?? null)
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : '로그 조회 중 오류')
+          // self-review P1 (#418): meta 도 함께 초기화. 남겨두면 새 필터에 대해
+          // 이전 파일의 totalLines/scannedLines 헤더가 stale 하게 노출됨.
+          setRows([])
+          setTotal(0)
+          setStats(null)
+          setMeta(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [date, crash, level, msg, toolFilter, traceFilter, offset])
+
+  const applyTool = () => { setOffset(0); setToolFilter(toolInput.trim()) }
+  const applyTrace = () => { setOffset(0); setTraceFilter(traceInput.trim()) }
+  const clearAll = () => {
+    setLevel(''); setMsg('')
+    setToolInput(''); setToolFilter('')
+    setTraceInput(''); setTraceFilter('')
+    setOffset(0)
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
+  return (
+    <div className="space-y-5">
+      {/* Filter bar */}
+      <section className="rounded-[14px] border border-border bg-card p-4 sm:p-5 space-y-4">
+        <div className="flex flex-wrap gap-2 items-center">
+          <label className="text-[12px] text-sub mr-1">파일</label>
+          <select
+            value={date}
+            onChange={(e) => { setDate(e.target.value); setOffset(0) }}
+            className="bg-surface-dim border border-border rounded-md px-2.5 py-1.5 text-[12px] text-bright"
+          >
+            {dateOptions.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
+          <button
+            onClick={() => { setCrash(false); setOffset(0) }}
+            className={`px-3 py-1.5 text-[12px] font-semibold rounded-md border ${
+              !crash ? 'bg-sejin/25 text-sejin border-sejin/40' : 'bg-surface border-border text-sub hover:text-bright'
+            }`}
+          >
+            일반
+          </button>
+          <button
+            onClick={() => { setCrash(true); setOffset(0) }}
+            className={`px-3 py-1.5 text-[12px] font-semibold rounded-md border ${
+              crash ? 'bg-red-500/25 text-red-400 border-red-500/40' : 'bg-surface border-border text-sub hover:text-bright'
+            }`}
+          >
+            💀 크래시
+          </button>
+
+          <div className="ml-auto flex items-center gap-2">
+            <input
+              value={traceInput}
+              onChange={(e) => setTraceInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') applyTrace() }}
+              placeholder="traceId"
+              className="bg-surface-dim border border-border rounded-md px-3 py-1.5 text-[12px] font-mono text-bright w-32"
+            />
+            <input
+              value={toolInput}
+              onChange={(e) => setToolInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') applyTool() }}
+              placeholder="tool 이름"
+              className="bg-surface-dim border border-border rounded-md px-3 py-1.5 text-[12px] font-mono text-bright w-32"
+            />
+            <button
+              onClick={() => { applyTool(); applyTrace() }}
+              className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+            >
+              적용
+            </button>
+            {(level || msg || toolFilter || traceFilter) && (
+              <button
+                onClick={clearAll}
+                className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+              >
+                초기화
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <span className="text-[11px] text-dim self-center mr-1">Level:</span>
+          {['', ...LEVEL_ORDER].map((l) => {
+            const active = level === l
+            const cls = active
+              ? (l ? LEVEL_CLASS[l] : 'bg-sejin/25 text-sejin border-sejin/40')
+              : 'bg-surface border-border text-sub hover:text-bright'
+            return (
+              <button
+                key={l || 'all'}
+                onClick={() => { setLevel(l); setOffset(0) }}
+                className={`px-2.5 py-1 text-[11px] font-semibold rounded-md border transition-colors ${cls}`}
+              >
+                {l || '전체'}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <span className="text-[11px] text-dim self-center mr-1">Msg:</span>
+          {['', ...KNOWN_MSGS].map((m) => {
+            const active = msg === m
+            return (
+              <button
+                key={m || 'all'}
+                onClick={() => { setMsg(m); setOffset(0) }}
+                className={`px-2.5 py-1 text-[11px] font-semibold rounded-md border transition-colors ${
+                  active
+                    ? 'bg-sodam/25 text-sodam border-sodam/40'
+                    : 'bg-surface border-border text-sub hover:text-bright'
+                }`}
+                title={m}
+              >
+                {m ? (MSG_LABELS[m] ?? m) : '전체'}
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="총 이벤트" value={stats?.total ?? 0} />
+        <StatCard
+          label="에러율"
+          value={stats && stats.total > 0 ? `${(stats.errorRate * 100).toFixed(1)}%` : '—'}
+          tone={(stats?.errorRate ?? 0) > 0.05 ? 'dasom' : 'sejin'}
+        />
+        <StatCard label="유니크 tool" value={stats?.byTool.length ?? 0} tone="sodam" />
+        <StatCard
+          label="fatal"
+          value={stats?.byLevel.find((b) => b.level === 'fatal')?.count ?? 0}
+          tone={(stats?.byLevel.find((b) => b.level === 'fatal')?.count ?? 0) > 0 ? 'dasom' : 'sub'}
+        />
+      </section>
+
+      {/* Tool latency top 5 */}
+      {stats && stats.latencyByTool.length > 0 && (
+        <section className="rounded-[14px] border border-border bg-card p-4">
+          <div className="text-[12px] text-sub mb-3">Tool latency (tool_call 기준, ms)</div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-[12px]">
+            {stats.latencyByTool.slice(0, 8).map((t) => (
+              <div key={t.tool} className="flex items-center justify-between border border-border rounded-md px-3 py-2 bg-surface-dim">
+                <div className="font-mono text-bright truncate max-w-[180px]" title={t.tool}>{t.tool}</div>
+                <div className="text-sub text-[11px] tabular-nums whitespace-nowrap">
+                  n={t.count} · avg {t.avg_ms} · p95 {t.p95_ms} · p99 {t.p99_ms}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* List */}
+      <section className="rounded-[14px] border border-border bg-card overflow-hidden">
+        <div className="px-5 py-3 border-b border-border bg-surface-dim flex items-center gap-3 flex-wrap">
+          <div className="text-[13px] font-bold text-bright">
+            {crash ? '크래시 로그' : '전체 로그'}
+          </div>
+          <div className="text-[11px] text-sub">
+            {total.toLocaleString()} / {meta?.truncatedHead ? '창' : '파일'} {meta?.totalLines?.toLocaleString() ?? '?'} 라인
+            {meta && meta.scannedLines < meta.totalLines && (
+              <span className="ml-2 text-amber-400">(최근 {meta.scannedLines.toLocaleString()} 만 스캔)</span>
+            )}
+            {meta?.truncatedHead && (
+              <span className="ml-2 text-amber-400">
+                (파일 {(meta.fileSize / (1024 * 1024)).toFixed(1)}MB — EOF 8MB 창만 로드)
+              </span>
+            )}
+          </div>
+          <div className="ml-auto text-[11px] text-sub">
+            {total > 0 && `페이지 ${currentPage}/${totalPages}`}
+            {loading && <span className="ml-2">불러오는 중…</span>}
+          </div>
+        </div>
+        {error && <div className="px-5 py-4 text-[13px] text-red-400">{error}</div>}
+        {!error && !meta?.fileExists && !loading && (
+          <div className="px-5 py-8 text-center text-dim text-[13px]">
+            {date} 로그 파일이 없습니다 (MCP_LOG_TEE_FILE=1 필요).
+          </div>
+        )}
+        {!error && meta?.fileExists && rows.length === 0 && !loading && (
+          <div className="px-5 py-8 text-center text-dim text-[13px]">
+            해당 필터에 매칭되는 라인이 없습니다.
+          </div>
+        )}
+        {rows.length > 0 && (
+          <ul className="divide-y divide-border">
+            {rows.map((r, idx) => {
+              const levelCls = LEVEL_CLASS[r.level] ?? LEVEL_CLASS.unknown
+              return (
+                <li key={`${r.lineNo ?? idx}`} className="px-5 py-3 hover:bg-surface-dim transition-colors">
+                  <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                    <span className="text-dim font-mono">L{r.lineNo}</span>
+                    <span className="text-sub tabular-nums">{r.time?.slice(11, 19)}</span>
+                    <span className={`px-2 py-0.5 rounded border font-semibold ${levelCls}`}>{r.level}</span>
+                    {r.msg && (
+                      <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
+                        {r.msg}
+                      </span>
+                    )}
+                    {r.tool && (
+                      <span className="px-2 py-0.5 rounded bg-sky-500/10 border border-sky-500/25 text-sky-400 font-mono">
+                        {r.tool}
+                      </span>
+                    )}
+                    {typeof r.latency_ms === 'number' && (
+                      <span className="text-sub text-[11px] tabular-nums">{formatDuration(r.latency_ms)}</span>
+                    )}
+                    {r.traceId && (
+                      <span className="text-dim text-[11px] font-mono ml-auto">t:{r.traceId}</span>
+                    )}
+                  </div>
+                  {r.err != null && (
+                    <div className="mt-1.5 text-[12px] text-red-400 font-mono">
+                      err: {shortJson(r.err)}
+                    </div>
+                  )}
+                  {r.args != null && (
+                    <div className="mt-1 text-[11px] text-sub font-mono">
+                      args: {shortJson(r.args)}
+                    </div>
+                  )}
+                  {r.parseError && r.raw && (
+                    <div className="mt-1 text-[11px] text-amber-400 font-mono">raw: {r.raw.slice(0, 200)}</div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        {total > PAGE_SIZE && (
+          <div className="px-5 py-3 border-t border-border flex items-center justify-between text-[12px]">
+            <button
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0}
+              className="px-3 py-1.5 rounded-md border border-border text-sub hover:text-bright disabled:opacity-40 disabled:hover:text-sub"
+            >
+              이전
+            </button>
+            <span className="text-sub">{currentPage}/{totalPages}</span>
+            <button
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= total}
+              className="px-3 py-1.5 rounded-md border border-border text-sub hover:text-bright disabled:opacity-40 disabled:hover:text-sub"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function StatCard({
+  label, value, tone = 'bright',
+}: {
+  label: string
+  value: number | string
+  tone?: 'bright' | 'sejin' | 'sodam' | 'dasom' | 'sub'
+}) {
+  const toneClass = {
+    bright: 'text-bright',
+    sejin: 'text-sejin',
+    sodam: 'text-sodam',
+    dasom: 'text-dasom',
+    sub: 'text-dim',
+  }[tone]
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className={`text-[22px] font-extrabold tabular-nums ${toneClass}`}>
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </div>
+      <div className="text-[11px] text-sub mt-0.5">{label}</div>
+    </div>
+  )
+}

--- a/src/app/admin/mcp-logs/page.tsx
+++ b/src/app/admin/mcp-logs/page.tsx
@@ -1,0 +1,18 @@
+import Header from '@/components/layout/Header'
+import McpLogsClient from './McpLogsClient'
+
+export const dynamic = 'force-dynamic'
+
+export default function McpLogsPage() {
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[1200px]">
+      <Header
+        title="MCP 로그"
+        sub="myFinance MCP 서버 pino 로그 뷰어 (일반/크래시 파일별, level·msg·tool·traceId 필터)"
+      />
+      <div className="mt-5">
+        <McpLogsClient />
+      </div>
+    </div>
+  )
+}

--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -1,0 +1,379 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ResponsiveContainer,
+  LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip as RTooltip,
+  PieChart, Pie, Cell, Legend,
+} from 'recharts'
+import { KIND_META, kindMetaOf, STATUS_META, type AlertKind } from './kinds'
+import { formatFiredAt, stripHtml, periodFromISO } from './client-utils'
+
+interface HistoryRow {
+  id: string
+  firedAt: string
+  kind: string
+  ticker: string | null
+  price: number | null
+  changePercent: number | null
+  message: string
+  deliveryStatus: string
+  recipientCount: number
+  errorMessage: string | null
+}
+
+interface Stats {
+  total: number
+  byStatus: { sent: number; partial: number; failed: number }
+  byKind: Array<{ kind: string; count: number }>
+  byDay: Array<{ date: string; count: number }>
+}
+
+const PERIOD_OPTIONS = [
+  { key: 7, label: '7일' },
+  { key: 30, label: '30일' },
+  { key: 90, label: '90일' },
+] as const
+
+const PAGE_SIZE = 30
+
+export default function AlertHistoryClient() {
+  const [days, setDays] = useState<number>(7)
+  const [selectedKinds, setSelectedKinds] = useState<Set<AlertKind>>(new Set())
+  const [tickerInput, setTickerInput] = useState('')
+  const [tickerFilter, setTickerFilter] = useState('')
+  const [rows, setRows] = useState<HistoryRow[]>([])
+  const [total, setTotal] = useState(0)
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Codex P2 (#417 PR #424): 다중 kind 를 서버 쿼리로 전달 (`?kind=a&kind=b`) →
+  // API 가 `in` 절로 필터 + 페이지네이션·집계가 정합. 클라 사이드 후처리 제거.
+  const kindsKey = useMemo(() => Array.from(selectedKinds).sort().join(','), [selectedKinds])
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const from = periodFromISO(days)
+        const kinds = kindsKey ? kindsKey.split(',') : []
+
+        const listParams = new URLSearchParams()
+        listParams.set('from', from)
+        listParams.set('limit', String(PAGE_SIZE))
+        listParams.set('offset', String(offset))
+        for (const k of kinds) listParams.append('kind', k)
+        if (tickerFilter) listParams.set('ticker', tickerFilter)
+
+        const statsParams = new URLSearchParams()
+        statsParams.set('from', from)
+        for (const k of kinds) statsParams.append('kind', k)
+        if (tickerFilter) statsParams.set('ticker', tickerFilter)
+
+        const [listRes, statsRes] = await Promise.all([
+          fetch(`/api/alerts/history?${listParams.toString()}`),
+          fetch(`/api/alerts/history/stats?${statsParams.toString()}`),
+        ])
+        const listJson = await listRes.json()
+        const statsJson = await statsRes.json()
+        if (cancelled) return
+        if (!listRes.ok) throw new Error(listJson?.error ?? '이력 조회 실패')
+        if (!statsRes.ok) throw new Error(statsJson?.error ?? '통계 조회 실패')
+
+        setRows(listJson?.data ?? [])
+        setTotal(listJson?.meta?.total ?? 0)
+        setStats(statsJson?.data ?? null)
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : '알림 이력 조회 중 오류')
+          // Codex #424 P2 (2회차): 필터/페이지 refresh 실패 시 이전 rows/total/stats 를
+          // 그대로 두면 새 필터에 대해 stale 한 데이터 + 에러가 동시에 보임 → 초기화.
+          setRows([])
+          setTotal(0)
+          setStats(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [days, kindsKey, tickerFilter, offset])
+
+  const toggleKind = (k: AlertKind) => {
+    setOffset(0)
+    setSelectedKinds((prev) => {
+      const next = new Set(prev)
+      if (next.has(k)) next.delete(k)
+      else next.add(k)
+      return next
+    })
+  }
+
+  const applyTicker = () => {
+    setOffset(0)
+    setTickerFilter(tickerInput.trim().toUpperCase())
+  }
+
+  const clearFilters = () => {
+    setSelectedKinds(new Set())
+    setTickerInput('')
+    setTickerFilter('')
+    setOffset(0)
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
+  const successRate = useMemo(() => {
+    if (!stats || stats.total === 0) return null
+    const success = stats.byStatus.sent + stats.byStatus.partial * 0.5
+    return (success / stats.total) * 100
+  }, [stats])
+
+  return (
+    <div className="space-y-5">
+      {/* Filter bar */}
+      <section className="rounded-[14px] border border-border bg-card p-4 sm:p-5 space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {PERIOD_OPTIONS.map((p) => (
+            <button
+              key={p.key}
+              onClick={() => { setDays(p.key); setOffset(0) }}
+              className={`px-3 py-1.5 text-[12px] font-semibold rounded-md border transition-colors ${
+                days === p.key
+                  ? 'bg-sejin/25 text-sejin border-sejin/40'
+                  : 'bg-surface border-border text-sub hover:text-bright'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+          <div className="ml-auto flex items-center gap-2">
+            <input
+              value={tickerInput}
+              onChange={(e) => setTickerInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') applyTicker() }}
+              placeholder="티커 검색"
+              className="bg-surface-dim border border-border rounded-md px-3 py-1.5 text-[13px] text-bright placeholder:text-dim focus:outline-none focus:border-sejin w-32"
+            />
+            <button
+              onClick={applyTicker}
+              className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+            >
+              적용
+            </button>
+            {(selectedKinds.size > 0 || tickerFilter) && (
+              <button
+                onClick={clearFilters}
+                className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+              >
+                초기화
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {KIND_META.map((m) => {
+            const active = selectedKinds.has(m.key)
+            return (
+              <button
+                key={m.key}
+                onClick={() => toggleKind(m.key)}
+                className={`px-2.5 py-1 text-[11px] font-semibold rounded-md border transition-colors ${
+                  active ? m.colorClass : 'bg-surface border-border text-sub hover:text-bright'
+                }`}
+              >
+                {m.icon} {m.label}
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard label="총 발동" value={stats?.total ?? 0} tone="bright" />
+        <StatCard
+          label="전송 성공률"
+          value={successRate == null ? '—' : `${successRate.toFixed(0)}%`}
+          tone="sejin"
+        />
+        <StatCard label="종류" value={stats?.byKind.length ?? 0} tone="sodam" />
+        <StatCard
+          label="실패"
+          value={stats?.byStatus.failed ?? 0}
+          tone={stats?.byStatus.failed ? 'dasom' : 'sub'}
+        />
+      </section>
+
+      {/* Charts */}
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <div className="rounded-[14px] border border-border bg-card p-4">
+          <div className="text-[12px] text-sub mb-2">일별 발동 건수</div>
+          <div className="h-[220px]">
+            {stats && stats.byDay.length > 0 ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={stats.byDay} margin={{ top: 8, right: 12, left: -20, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.15)" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fill: '#94a3b8', fontSize: 11 }}
+                    tickFormatter={(s: string) => s.slice(5)}
+                  />
+                  <YAxis
+                    tick={{ fill: '#94a3b8', fontSize: 11 }}
+                    allowDecimals={false}
+                  />
+                  <RTooltip
+                    contentStyle={{ background: '#0f172a', border: '1px solid #334155', color: '#e2e8f0' }}
+                  />
+                  <Line type="monotone" dataKey="count" stroke="#34d399" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-full text-dim text-[13px]">데이터 없음</div>
+            )}
+          </div>
+        </div>
+        <div className="rounded-[14px] border border-border bg-card p-4">
+          <div className="text-[12px] text-sub mb-2">종류별 발동</div>
+          <div className="h-[220px]">
+            {stats && stats.byKind.length > 0 ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={stats.byKind}
+                    dataKey="count"
+                    nameKey="kind"
+                    innerRadius={45}
+                    outerRadius={80}
+                    paddingAngle={2}
+                  >
+                    {stats.byKind.map((entry, idx) => (
+                      <Cell key={idx} fill={kindMetaOf(entry.kind)?.hex ?? '#94a3b8'} />
+                    ))}
+                  </Pie>
+                  <RTooltip
+                    contentStyle={{ background: '#0f172a', border: '1px solid #334155', color: '#e2e8f0' }}
+                    formatter={(value, name) => [value as number, kindMetaOf(String(name))?.label ?? String(name)]}
+                  />
+                  <Legend
+                    formatter={(value: string) => kindMetaOf(value)?.label ?? value}
+                    wrapperStyle={{ fontSize: '11px' }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex items-center justify-center h-full text-dim text-[13px]">데이터 없음</div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* List */}
+      <section className="rounded-[14px] border border-border bg-card overflow-hidden">
+        <div className="px-5 py-3 border-b border-border bg-surface-dim flex items-center gap-2">
+          <div className="text-[13px] font-bold text-bright">이력</div>
+          <div className="text-[11px] text-sub">
+            {total.toLocaleString()}건 · 페이지 {currentPage}/{totalPages}
+          </div>
+          {loading && <div className="ml-auto text-[11px] text-sub">불러오는 중…</div>}
+        </div>
+        {error && (
+          <div className="px-5 py-4 text-[13px] text-red-400">{error}</div>
+        )}
+        {!error && rows.length === 0 && !loading && (
+          <div className="px-5 py-8 text-center text-dim text-[13px]">해당 조건의 알림 이력이 없습니다.</div>
+        )}
+        {rows.length > 0 && (
+          <ul>
+            {rows.map((r) => {
+              const meta = kindMetaOf(r.kind)
+              const status = STATUS_META[r.deliveryStatus] ?? { label: r.deliveryStatus, colorClass: 'bg-surface text-sub border-border' }
+              return (
+                <li
+                  key={r.id}
+                  className="px-5 py-3 border-b border-border last:border-b-0 hover:bg-surface-dim transition-colors"
+                >
+                  <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                    <span className="text-sub tabular-nums">{formatFiredAt(r.firedAt)}</span>
+                    <span className={`px-2 py-0.5 rounded border font-semibold ${meta?.colorClass ?? 'bg-surface text-sub border-border'}`}>
+                      {meta?.icon} {meta?.label ?? r.kind}
+                    </span>
+                    {r.ticker && (
+                      <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
+                        {r.ticker}
+                      </span>
+                    )}
+                    <span className={`ml-auto px-2 py-0.5 rounded border font-semibold ${status.colorClass}`}>
+                      {status.label} · {r.recipientCount}
+                    </span>
+                  </div>
+                  <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
+                    {stripHtml(r.message)}
+                  </div>
+                  {r.errorMessage && (
+                    <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        {total > PAGE_SIZE && (
+          <div className="px-5 py-3 border-t border-border flex items-center justify-between text-[12px]">
+            <button
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0}
+              className="px-3 py-1.5 rounded-md border border-border text-sub hover:text-bright disabled:opacity-40 disabled:hover:text-sub"
+            >
+              이전
+            </button>
+            <span className="text-sub">
+              {currentPage}/{totalPages}
+            </span>
+            <button
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= total}
+              className="px-3 py-1.5 rounded-md border border-border text-sub hover:text-bright disabled:opacity-40 disabled:hover:text-sub"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function StatCard({
+  label, value, tone,
+}: {
+  label: string
+  value: number | string
+  tone: 'bright' | 'sejin' | 'sodam' | 'dasom' | 'sub'
+}) {
+  const toneClass = {
+    bright: 'text-bright',
+    sejin:  'text-sejin',
+    sodam:  'text-sodam',
+    dasom:  'text-dasom',
+    sub:    'text-dim',
+  }[tone]
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className={`text-[22px] font-extrabold tabular-nums ${toneClass}`}>
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </div>
+      <div className="text-[11px] text-sub mt-0.5">{label}</div>
+    </div>
+  )
+}

--- a/src/app/alerts/history/__tests__/client-utils.test.ts
+++ b/src/app/alerts/history/__tests__/client-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { periodFromISO, formatFiredAt, stripHtml } from '../client-utils'
+
+describe('periodFromISO', () => {
+  it('N일 전 시각을 ISO 8601 로 반환 (now 주입)', () => {
+    const now = Date.parse('2026-07-08T00:00:00Z')
+    expect(periodFromISO(7, now)).toBe('2026-07-01T00:00:00.000Z')
+    expect(periodFromISO(30, now)).toBe('2026-06-08T00:00:00.000Z')
+    expect(periodFromISO(0, now)).toBe('2026-07-08T00:00:00.000Z')
+  })
+})
+
+describe('formatFiredAt', () => {
+  it('UTC ISO → KST MM-DD HH:mm', () => {
+    // UTC 00:00:00 = KST 09:00
+    expect(formatFiredAt('2026-07-08T00:00:00Z')).toBe('07-08 09:00')
+  })
+
+  it('자정 넘김 (UTC 15:30 → KST 다음날 00:30)', () => {
+    expect(formatFiredAt('2026-07-08T15:30:00Z')).toBe('07-09 00:30')
+  })
+})
+
+describe('stripHtml', () => {
+  it('<b> 태그 제거', () => {
+    expect(stripHtml('🔴 <b>AAPL</b> 급락')).toBe('🔴 AAPL 급락')
+  })
+
+  it('<br> 는 개행으로 변환', () => {
+    expect(stripHtml('a<br>b<br/>c')).toBe('a\nb\nc')
+  })
+
+  it('HTML 엔티티 역디코드 (escapeHtml 결과 원상복원)', () => {
+    expect(stripHtml('&amp; &lt;script&gt; &quot;x&quot; &#39;y&#39;')).toBe(`& <script> "x" 'y'`)
+  })
+
+  it('중첩 태그와 속성 모두 제거', () => {
+    expect(stripHtml('<b>hello <i class="x">world</i></b>')).toBe('hello world')
+  })
+
+  it('평문은 변경 없음', () => {
+    expect(stripHtml('안녕하세요')).toBe('안녕하세요')
+  })
+})

--- a/src/app/alerts/history/client-utils.ts
+++ b/src/app/alerts/history/client-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Phase 33-B (#417) — 알림 이력 클라이언트 유틸 (pure).
+ * `AlertHistoryClient.tsx` 로 분리해 테스트 편이.
+ */
+
+/** UTC now 로부터 N일 전 시각 반환 (ISO 8601) */
+export function periodFromISO(days: number, now: number = Date.now()): string {
+  const d = new Date(now - days * 24 * 60 * 60 * 1000)
+  return d.toISOString()
+}
+
+/** ISO 8601 → "MM-DD HH:mm" (KST 기준) */
+export function formatFiredAt(iso: string): string {
+  const d = new Date(iso)
+  const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  const s = kst.toISOString()
+  return `${s.slice(5, 10)} ${s.slice(11, 16)}`
+}
+
+/**
+ * message 는 텔레그램 발송용 HTML (자체 코드에서 escapeHtml + `<b>` 삽입).
+ * 웹에서는 XSS 방어와 시각 단순성을 위해 태그 제거 + HTML 엔티티 역디코드 후 plain text.
+ */
+export function stripHtml(s: string): string {
+  return s
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/?[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}

--- a/src/app/alerts/history/kinds.ts
+++ b/src/app/alerts/history/kinds.ts
@@ -1,0 +1,47 @@
+/**
+ * Phase 33-B (#417) — 알림 kind 메타 (라벨/색상).
+ * Server (`route.ts`) 와 UI 모두 참조 가능한 pure 상수. AlertConfig 카테고리와는 별도
+ * (kind 는 발동 종류, alert-config category 는 설정 그룹).
+ */
+
+export type AlertKind =
+  | 'surge' | 'drop' | 'fx'
+  | 'target_hit' | 'stop_loss'
+  | 'watch_buy' | 'watch_zone'
+  | 'ta_signal' | 'custom_strategy'
+
+export interface KindMeta {
+  key: AlertKind
+  label: string
+  icon: string
+  /** Tailwind 배경/텍스트 짝 (뱃지·차트 색상용) */
+  colorClass: string
+  /** Recharts 등 SVG 용 hex */
+  hex: string
+}
+
+export const KIND_META: KindMeta[] = [
+  { key: 'surge',           label: '급등',        icon: '🟢', colorClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30', hex: '#34d399' },
+  { key: 'drop',            label: '급락',        icon: '🔴', colorClass: 'bg-red-500/15 text-red-400 border-red-500/30',              hex: '#f87171' },
+  { key: 'fx',              label: '환율',        icon: '💱', colorClass: 'bg-sky-500/15 text-sky-400 border-sky-500/30',              hex: '#38bdf8' },
+  { key: 'target_hit',      label: '목표가',      icon: '🎯', colorClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30', hex: '#34d399' },
+  { key: 'stop_loss',       label: '손절가',      icon: '🛑', colorClass: 'bg-red-500/15 text-red-400 border-red-500/30',              hex: '#ef4444' },
+  { key: 'watch_buy',       label: '목표매수가',  icon: '💰', colorClass: 'bg-sejin/15 text-sejin border-sejin/30',                    hex: '#34d399' },
+  { key: 'watch_zone',      label: '매수구간',    icon: '🔔', colorClass: 'bg-amber-500/15 text-amber-400 border-amber-500/30',        hex: '#fbbf24' },
+  { key: 'ta_signal',       label: 'TA 시그널',   icon: '📊', colorClass: 'bg-violet-500/15 text-violet-400 border-violet-500/30',     hex: '#a78bfa' },
+  { key: 'custom_strategy', label: '커스텀 전략', icon: '🧠', colorClass: 'bg-dasom/15 text-dasom border-dasom/30',                    hex: '#fb923c' },
+]
+
+export const KIND_BY_KEY: Record<AlertKind, KindMeta> = Object.fromEntries(
+  KIND_META.map((m) => [m.key, m]),
+) as Record<AlertKind, KindMeta>
+
+export function kindMetaOf(key: string): KindMeta | undefined {
+  return KIND_BY_KEY[key as AlertKind]
+}
+
+export const STATUS_META: Record<string, { label: string; colorClass: string }> = {
+  sent:    { label: '전송',       colorClass: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30' },
+  partial: { label: '일부 전송',  colorClass: 'bg-amber-500/15 text-amber-400 border-amber-500/30' },
+  failed:  { label: '실패',       colorClass: 'bg-red-500/15 text-red-400 border-red-500/30' },
+}

--- a/src/app/alerts/history/page.tsx
+++ b/src/app/alerts/history/page.tsx
@@ -1,0 +1,18 @@
+import Header from '@/components/layout/Header'
+import AlertHistoryClient from './AlertHistoryClient'
+
+export const dynamic = 'force-dynamic'
+
+export default function AlertHistoryPage() {
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 py-5 sm:py-7 max-w-[1200px]">
+      <Header
+        title="알림 이력"
+        sub="텔레그램으로 발송된 알림 히스토리 (기간·종류·티커 필터)"
+      />
+      <div className="mt-5">
+        <AlertHistoryClient />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/mcp-logs/__tests__/shared.test.ts
+++ b/src/app/api/admin/mcp-logs/__tests__/shared.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { todayKst, isValidDateStr, logFilePath, stripLeadingPartialLine } from '../shared'
+
+describe('todayKst', () => {
+  it('UTC 00:00 → KST 09:00 → 같은 날짜', () => {
+    const now = Date.parse('2026-07-08T00:00:00Z')
+    expect(todayKst(now)).toBe('2026-07-08')
+  })
+
+  it('UTC 14:59 → KST 23:59 (같은 날)', () => {
+    const now = Date.parse('2026-07-08T14:59:00Z')
+    expect(todayKst(now)).toBe('2026-07-08')
+  })
+
+  it('UTC 15:00 → KST 00:00 (다음날)', () => {
+    const now = Date.parse('2026-07-08T15:00:00Z')
+    expect(todayKst(now)).toBe('2026-07-09')
+  })
+})
+
+describe('isValidDateStr', () => {
+  it('YYYY-MM-DD 형식 통과', () => {
+    expect(isValidDateStr('2026-07-08')).toBe(true)
+  })
+
+  it('잘못된 형식 → false', () => {
+    expect(isValidDateStr('2026/07/08')).toBe(false)
+    expect(isValidDateStr('26-7-8')).toBe(false)
+    expect(isValidDateStr('bogus')).toBe(false)
+    expect(isValidDateStr('')).toBe(false)
+  })
+
+  it('잘못된 날짜 값 → false', () => {
+    expect(isValidDateStr('2026-13-40')).toBe(false)
+  })
+
+  it('캘린더 무효 날짜는 false (Codex #425 P3 회귀 방지)', () => {
+    // JS Date 는 정규화해서 2026-03-03 으로 파싱 → isNaN 은 false. 명시적으로 거부해야 함.
+    expect(isValidDateStr('2026-02-31')).toBe(false)
+    expect(isValidDateStr('2026-04-31')).toBe(false)  // 4월은 30일까지
+    expect(isValidDateStr('2025-02-29')).toBe(false)  // 평년
+    expect(isValidDateStr('2024-02-29')).toBe(true)   // 윤년 OK
+    expect(isValidDateStr('2026-00-01')).toBe(false)  // 월 0
+    expect(isValidDateStr('2026-01-00')).toBe(false)  // 일 0
+  })
+})
+
+describe('logFilePath', () => {
+  it('기본 (일반 로그) → mcp-<date>.log', () => {
+    expect(logFilePath('2026-07-08')).toMatch(/mcp-2026-07-08\.log$/)
+  })
+
+  it('crash=true → mcp-crash-<date>.log', () => {
+    expect(logFilePath('2026-07-08', true)).toMatch(/mcp-crash-2026-07-08\.log$/)
+  })
+})
+
+describe('stripLeadingPartialLine (Codex #425 P2 회귀 방지)', () => {
+  it('첫 `\\n` 이전 partial 을 잘라내고 이후 라인만 반환', () => {
+    expect(stripLeadingPartialLine('partial-fragment\nfull1\nfull2\n')).toBe('full1\nfull2\n')
+  })
+
+  it('newline 이 하나도 없으면 빈 문자열 (전부 partial 로 간주 → 무시)', () => {
+    expect(stripLeadingPartialLine('no newline in here')).toBe('')
+  })
+
+  it('첫 문자가 newline 이면 그 뒤 전체 반환', () => {
+    expect(stripLeadingPartialLine('\nabc')).toBe('abc')
+  })
+
+  it('빈 입력 → 빈', () => {
+    expect(stripLeadingPartialLine('')).toBe('')
+  })
+})

--- a/src/app/api/admin/mcp-logs/route.ts
+++ b/src/app/api/admin/mcp-logs/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Phase 33-C (#418) — MCP 로그 리스트 조회.
+ * GET /api/admin/mcp-logs?date=&crash=&level=&msg=&tool=&traceId=&limit=&offset=
+ */
+
+import { NextRequest } from 'next/server'
+import { ok, fail } from '@/lib/api-response'
+import {
+  KNOWN_LEVELS, KNOWN_MSG_SET, isValidDateStr, loadEntries, todayKst,
+} from './shared'
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 500
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const dateRaw = url.searchParams.get('date')?.trim() || todayKst()
+    const crash = url.searchParams.get('crash') === '1' || url.searchParams.get('crash') === 'true'
+    const level = url.searchParams.get('level')?.trim() || undefined
+    const msg = url.searchParams.get('msg')?.trim() || undefined
+    const tool = url.searchParams.get('tool')?.trim() || undefined
+    const traceId = url.searchParams.get('traceId')?.trim() || undefined
+    const limitStr = url.searchParams.get('limit')
+    const offsetStr = url.searchParams.get('offset')
+
+    if (!isValidDateStr(dateRaw)) {
+      return fail('date 는 YYYY-MM-DD 형식이어야 합니다.', 400)
+    }
+    if (level && !KNOWN_LEVELS.has(level)) {
+      return fail(`알 수 없는 level: ${level}`, 400)
+    }
+    if (msg && !KNOWN_MSG_SET.has(msg)) {
+      return fail(`알 수 없는 msg: ${msg}`, 400)
+    }
+
+    let limit = limitStr ? parseInt(limitStr, 10) : DEFAULT_LIMIT
+    if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT
+    limit = Math.min(limit, MAX_LIMIT)
+
+    let offset = offsetStr ? parseInt(offsetStr, 10) : 0
+    if (!Number.isFinite(offset) || offset < 0) offset = 0
+
+    const result = loadEntries({
+      date: dateRaw,
+      crash,
+      filter: { level, msg, tool, traceId },
+    })
+
+    // 최신순 반환 (파일은 오래된 → 최신 순서, reverse 로 최신 → 오래된).
+    const reversed = result.entries.slice().reverse()
+    const page = reversed.slice(offset, offset + limit)
+
+    return ok(
+      {
+        items: page,
+        date: dateRaw,
+        crash,
+        fileExists: result.fileExists,
+        fileSize: result.fileSize,
+        truncatedHead: result.truncatedHead,
+        totalLines: result.totalLines,
+        scannedLines: result.scanned,
+        tailStartLineNo: result.startLineNo,
+      },
+      { meta: { total: reversed.length, limit, offset } },
+    )
+  } catch (error) {
+    console.error('GET /api/admin/mcp-logs error:', error)
+    return fail('로그 조회에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/admin/mcp-logs/shared.ts
+++ b/src/app/api/admin/mcp-logs/shared.ts
@@ -1,0 +1,137 @@
+/**
+ * Phase 33-C (#418) — MCP 로그 대시보드 API 공용.
+ */
+
+import path from 'node:path'
+import fs from 'node:fs'
+import { LEVEL_ORDER, KNOWN_MSGS } from '@/lib/mcp-logs/constants'
+import { parseLines, applyFilter, tailN, type Filter, type LogEntry } from '@/lib/mcp-logs/parser'
+
+/** KST 오늘 (YYYY-MM-DD) */
+export function todayKst(now: number = Date.now()): string {
+  const kst = new Date(now + 9 * 60 * 60 * 1000)
+  return kst.toISOString().slice(0, 10)
+}
+
+export const KNOWN_LEVELS = new Set<string>(LEVEL_ORDER)
+export const KNOWN_MSG_SET = new Set<string>(KNOWN_MSGS)
+
+const LOG_DIR = process.env.MCP_LOG_DIR ?? path.join(process.cwd(), 'logs')
+
+/** 대시보드가 한 요청당 파싱할 최대 라인 (대용량 파일 방어). */
+export const MAX_SCAN_LINES = 50_000
+
+/**
+ * 파일 EOF 부근에서 최대 이 바이트만 읽어들여 memory / event-loop 를 보호 (Codex #425 P2).
+ * `readFileSync` 로 전체를 읽으면 수백 MB 로그가 있을 때 Next.js 프로세스 전체가 블록됨.
+ * 50k 라인 × 평균 ~320B → 16MB 면 충분. 여유로 8MB → 대략 25k~40k 라인 커버.
+ * 8MB 초과분은 오래된 데이터라 대시보드 UX (최근 조회) 상 손실 무의미.
+ */
+export const MAX_TAIL_BYTES = 8 * 1024 * 1024
+
+/**
+ * `crash` true 이면 `logs/mcp-crash-YYYY-MM-DD.log`, 아니면 `logs/mcp-YYYY-MM-DD.log`.
+ */
+export function logFilePath(date: string, crash = false): string {
+  const name = crash ? `mcp-crash-${date}.log` : `mcp-${date}.log`
+  return path.join(LOG_DIR, name)
+}
+
+/**
+ * YYYY-MM-DD 형식 검증 (Codex #425 P3 반영).
+ * `new Date('2026-02-31...')` 은 `2026-03-03` 으로 정규화되어 `isNaN` 이 false → 통과됨.
+ * 파싱 결과 y/m/d 가 입력값과 동일한지 재확인해 캘린더 무효 날짜를 거부.
+ */
+export function isValidDateStr(s: string): boolean {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s)
+  if (!m) return false
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const day = Number(m[3])
+  const d = new Date(Date.UTC(year, month - 1, day))
+  if (Number.isNaN(d.getTime())) return false
+  return d.getUTCFullYear() === year
+    && d.getUTCMonth() + 1 === month
+    && d.getUTCDate() === day
+}
+
+export interface LoadOptions {
+  date: string
+  crash?: boolean
+  filter: Filter
+}
+
+export interface LoadResult {
+  entries: LogEntry[]
+  fileExists: boolean
+  fileSize: number
+  /** MAX_TAIL_BYTES 초과로 앞쪽이 잘렸는지 (총 라인 수 정확 카운트 불가) */
+  truncatedHead: boolean
+  /** 파일 전체 라인 수 (truncatedHead=true 이면 최소치, 실제 파일은 더 많음) */
+  totalLines: number
+  scanned: number
+  /** tail 이 적용됐다면 원본 대비 시작 라인 번호 (1-indexed). truncated 시 근사치. */
+  startLineNo: number
+}
+
+/**
+ * 첫 partial 라인 제거 — EOF 부근에서 raw 바이트를 읽으면 첫 라인이 잘린
+ * 상태일 가능성이 큼. 첫 `\n` 이전은 버림 (pure, 테스트 가능).
+ */
+export function stripLeadingPartialLine(text: string): string {
+  const idx = text.indexOf('\n')
+  return idx < 0 ? '' : text.slice(idx + 1)
+}
+
+/**
+ * 파일 EOF 에서 최대 `MAX_TAIL_BYTES` 만큼만 읽어 반환 (Codex #425 P2).
+ * 파일 사이즈가 그 이하면 그대로 전체 반환. 초과 시 첫 partial 라인 제거.
+ */
+function readTail(filePath: string): { text: string; size: number; truncated: boolean } {
+  const st = fs.statSync(filePath)
+  if (st.size <= MAX_TAIL_BYTES) {
+    return { text: fs.readFileSync(filePath, 'utf-8'), size: st.size, truncated: false }
+  }
+  const fd = fs.openSync(filePath, 'r')
+  try {
+    const buf = Buffer.alloc(MAX_TAIL_BYTES)
+    fs.readSync(fd, buf, 0, MAX_TAIL_BYTES, st.size - MAX_TAIL_BYTES)
+    const raw = buf.toString('utf-8')
+    return { text: stripLeadingPartialLine(raw), size: st.size, truncated: true }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
+/**
+ * 파일 로드 → tail-N → 파싱 → 필터. Entries 는 파일 순 (오래된 → 최신). UI 는 결과를
+ * reverse 해 최신순 노출.
+ * Codex #425 P2: 대용량 파일은 전체를 메모리에 로드하지 않고 EOF 부근 `MAX_TAIL_BYTES`
+ * 만 읽어 첫 partial 라인을 잘라낸 뒤 처리.
+ */
+export function loadEntries(opts: LoadOptions): LoadResult {
+  const filePath = logFilePath(opts.date, opts.crash)
+  if (!fs.existsSync(filePath)) {
+    return {
+      entries: [], fileExists: false, fileSize: 0, truncatedHead: false,
+      totalLines: 0, scanned: 0, startLineNo: 1,
+    }
+  }
+  const { text: raw, size, truncated } = readTail(filePath)
+  const rawLineCount = raw.split('\n').filter((l) => l.trim()).length
+  const { text, startLineNo } = tailN(raw, MAX_SCAN_LINES)
+  const parsed = parseLines(text)
+  // startLineNo 를 오프셋으로 반영. truncatedHead 이면 원본 line 번호는 알 수 없어
+  // 읽어들인 창 내부 line 번호 그대로 (사용자에게는 "L<number>" 로만 노출).
+  for (const e of parsed) e.lineNo = (e.lineNo ?? 1) + startLineNo - 1
+  const filtered = applyFilter(parsed, opts.filter)
+  return {
+    entries: filtered,
+    fileExists: true,
+    fileSize: size,
+    truncatedHead: truncated,
+    totalLines: rawLineCount,
+    scanned: parsed.length,
+    startLineNo,
+  }
+}

--- a/src/app/api/admin/mcp-logs/stats/route.ts
+++ b/src/app/api/admin/mcp-logs/stats/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Phase 33-C (#418) — MCP 로그 통계.
+ * GET /api/admin/mcp-logs/stats?date=&crash=&level=&msg=&tool=&traceId=
+ */
+
+import { NextRequest } from 'next/server'
+import { ok, fail } from '@/lib/api-response'
+import { computeStats } from '@/lib/mcp-logs/parser'
+import { KNOWN_LEVELS, KNOWN_MSG_SET, isValidDateStr, loadEntries, todayKst } from '../shared'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const dateRaw = url.searchParams.get('date')?.trim() || todayKst()
+    const crash = url.searchParams.get('crash') === '1' || url.searchParams.get('crash') === 'true'
+    const level = url.searchParams.get('level')?.trim() || undefined
+    const msg = url.searchParams.get('msg')?.trim() || undefined
+    const tool = url.searchParams.get('tool')?.trim() || undefined
+    const traceId = url.searchParams.get('traceId')?.trim() || undefined
+
+    if (!isValidDateStr(dateRaw)) return fail('date 는 YYYY-MM-DD 형식이어야 합니다.', 400)
+    if (level && !KNOWN_LEVELS.has(level)) return fail(`알 수 없는 level: ${level}`, 400)
+    if (msg && !KNOWN_MSG_SET.has(msg)) return fail(`알 수 없는 msg: ${msg}`, 400)
+
+    const result = loadEntries({
+      date: dateRaw,
+      crash,
+      filter: { level, msg, tool, traceId },
+    })
+
+    const stats = computeStats(result.entries)
+    return ok({
+      ...stats,
+      date: dateRaw,
+      crash,
+      fileExists: result.fileExists,
+      fileSize: result.fileSize,
+      truncatedHead: result.truncatedHead,
+      totalLines: result.totalLines,
+      scannedLines: result.scanned,
+    })
+  } catch (error) {
+    console.error('GET /api/admin/mcp-logs/stats error:', error)
+    return fail('로그 통계 조회에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/alerts/history/__tests__/shared.test.ts
+++ b/src/app/api/alerts/history/__tests__/shared.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets, parseKindsParam } from '../shared'
+import {
+  KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets, parseKindsParam,
+  resolveTimeWindow,
+} from '../shared'
 
 describe('KNOWN_KINDS', () => {
   it('9종 kind 를 모두 포함 (33-A AlertHistory 매핑과 동기화)', () => {
@@ -140,5 +143,40 @@ describe('buildKstDayBuckets (self-review P1 회귀 방지 #417)', () => {
     const d = new Date('2026-07-08T05:00:00Z')
     const buckets = buildKstDayBuckets(new Map([['2026-07-08', 2]]), d, d)
     expect(buckets).toEqual([{ date: '2026-07-08', count: 2 }])
+  })
+})
+
+describe('resolveTimeWindow (Codex #428 P2 회귀 방지)', () => {
+  const now = new Date('2026-07-09T00:00:00Z')
+  const DAY = 24 * 60 * 60 * 1000
+
+  it('both null → now anchored, from = now - N일', () => {
+    const r = resolveTimeWindow(null, null, 7, now)
+    expect(r.effectiveTo).toBe(now)
+    expect(r.effectiveFrom.getTime()).toBe(now.getTime() - 7 * DAY)
+  })
+
+  it('to 만 지정 (과거) → from = to - N일 (inverted range 방지)', () => {
+    const to = new Date('2026-06-01T00:00:00Z')
+    const r = resolveTimeWindow(null, to, 7, now)
+    expect(r.effectiveTo).toBe(to)
+    expect(r.effectiveFrom.getTime()).toBe(to.getTime() - 7 * DAY)
+    // 실제 위험 조건: from <= to (기존 버그 재현 방지)
+    expect(r.effectiveFrom.getTime()).toBeLessThanOrEqual(r.effectiveTo.getTime())
+  })
+
+  it('from 만 지정 → to = now', () => {
+    const from = new Date('2026-06-01T00:00:00Z')
+    const r = resolveTimeWindow(from, null, 7, now)
+    expect(r.effectiveFrom).toBe(from)
+    expect(r.effectiveTo).toBe(now)
+  })
+
+  it('both 지정 → 그대로', () => {
+    const from = new Date('2026-05-01T00:00:00Z')
+    const to = new Date('2026-06-01T00:00:00Z')
+    const r = resolveTimeWindow(from, to, 7, now)
+    expect(r.effectiveFrom).toBe(from)
+    expect(r.effectiveTo).toBe(to)
   })
 })

--- a/src/app/api/alerts/history/__tests__/shared.test.ts
+++ b/src/app/api/alerts/history/__tests__/shared.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets, parseKindsParam } from '../shared'
+
+describe('KNOWN_KINDS', () => {
+  it('9종 kind 를 모두 포함 (33-A AlertHistory 매핑과 동기화)', () => {
+    for (const k of [
+      'surge', 'drop', 'fx',
+      'target_hit', 'stop_loss',
+      'watch_buy', 'watch_zone',
+      'ta_signal', 'custom_strategy',
+    ]) {
+      expect(KNOWN_KINDS.has(k)).toBe(true)
+    }
+    expect(KNOWN_KINDS.size).toBe(9)
+  })
+
+  it('알려지지 않은 값은 false', () => {
+    expect(KNOWN_KINDS.has('unknown')).toBe(false)
+    expect(KNOWN_KINDS.has('')).toBe(false)
+  })
+})
+
+describe('parseISOOrNull', () => {
+  it('ISO 문자열 → Date', () => {
+    const d = parseISOOrNull('2026-07-08T00:00:00Z')
+    expect(d?.toISOString()).toBe('2026-07-08T00:00:00.000Z')
+  })
+
+  it('잘못된 형식 → null', () => {
+    expect(parseISOOrNull('not-a-date')).toBeNull()
+    expect(parseISOOrNull('2026-13-40')).toBeNull()
+  })
+
+  it('undefined/null/빈문자열 → null', () => {
+    expect(parseISOOrNull(undefined)).toBeNull()
+    expect(parseISOOrNull(null)).toBeNull()
+    expect(parseISOOrNull('')).toBeNull()
+  })
+})
+
+describe('parseKindsParam (Codex #424 P2 회귀 방지)', () => {
+  it('반복 파라미터 (`?kind=a&kind=b`) → kinds 배열', () => {
+    const p = new URLSearchParams('kind=drop&kind=surge')
+    const r = parseKindsParam(p)
+    expect(new Set(r.kinds)).toEqual(new Set(['drop', 'surge']))
+    expect(r.invalid).toEqual([])
+  })
+
+  it('CSV (`?kind=a,b`) 도 지원', () => {
+    const p = new URLSearchParams('kind=drop,surge')
+    const r = parseKindsParam(p)
+    expect(new Set(r.kinds)).toEqual(new Set(['drop', 'surge']))
+  })
+
+  it('반복 + CSV 혼합, 중복 제거', () => {
+    const p = new URLSearchParams('kind=drop,surge&kind=drop&kind=fx')
+    const r = parseKindsParam(p)
+    expect(new Set(r.kinds)).toEqual(new Set(['drop', 'surge', 'fx']))
+  })
+
+  it('알려지지 않은 kind → invalid 로 분리', () => {
+    const p = new URLSearchParams('kind=drop&kind=nope&kind=xyz')
+    const r = parseKindsParam(p)
+    expect(r.kinds).toEqual(['drop'])
+    expect(new Set(r.invalid)).toEqual(new Set(['nope', 'xyz']))
+  })
+
+  it('kind 파라미터 없음 → 빈 배열', () => {
+    const r = parseKindsParam(new URLSearchParams(''))
+    expect(r.kinds).toEqual([])
+    expect(r.invalid).toEqual([])
+  })
+
+  it('공백/빈 문자열 제거', () => {
+    const p = new URLSearchParams('kind=  ,,drop, ')
+    const r = parseKindsParam(p)
+    expect(r.kinds).toEqual(['drop'])
+  })
+})
+
+describe('kstDateKey', () => {
+  it('UTC 00:00 → KST 09:00 → 같은 날짜', () => {
+    expect(kstDateKey(new Date('2026-07-08T00:00:00Z'))).toBe('2026-07-08')
+  })
+  it('UTC 15:00 → KST 00:00 (다음날)', () => {
+    expect(kstDateKey(new Date('2026-07-07T15:00:00Z'))).toBe('2026-07-08')
+  })
+  it('UTC 14:59 → KST 23:59 (같은 날)', () => {
+    expect(kstDateKey(new Date('2026-07-07T14:59:00Z'))).toBe('2026-07-07')
+  })
+})
+
+describe('buildKstDayBuckets (self-review P1 회귀 방지 #417)', () => {
+  it('간단 3일 범위, 이벤트 없음 → 연속 버킷 3개', () => {
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-03T00:00:00Z')
+    const buckets = buildKstDayBuckets(new Map(), from, to)
+    expect(buckets.map((b) => b.date)).toEqual(['2026-07-01', '2026-07-02', '2026-07-03'])
+    expect(buckets.every((b) => b.count === 0)).toBe(true)
+  })
+
+  it('KST 자정 넘어가는 from/to (UTC 시각 불일치) 도 trailing 날짜 포함', () => {
+    // effectiveFrom = 07-01 14:59 UTC = 07-01 23:59 KST → key 07-01
+    // effectiveTo   = 07-08 15:00 UTC = 07-09 00:00 KST → key 07-09
+    // 이전 버그: cursor 가 UTC 14:59 고정으로 진행 → 07-08 14:59 UTC 에서 종료 → 07-09 누락.
+    const from = new Date('2026-07-01T14:59:00Z')
+    const to = new Date('2026-07-08T15:00:00Z')
+    const buckets = buildKstDayBuckets(new Map(), from, to)
+    const dates = buckets.map((b) => b.date)
+    expect(dates[0]).toBe('2026-07-01')
+    expect(dates[dates.length - 1]).toBe('2026-07-09')
+    expect(dates).toContain('2026-07-08')
+    expect(dates).toContain('2026-07-09')
+    // 중복/누락 없이 연속 KST 날짜 9개
+    expect(dates.length).toBe(9)
+  })
+
+  it('countsByKey 값이 있으면 해당 날짜 count 반영', () => {
+    const counts = new Map([['2026-07-02', 3], ['2026-07-03', 1]])
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-03T00:00:00Z')
+    const buckets = buildKstDayBuckets(counts, from, to)
+    expect(buckets).toEqual([
+      { date: '2026-07-01', count: 0 },
+      { date: '2026-07-02', count: 3 },
+      { date: '2026-07-03', count: 1 },
+    ])
+  })
+
+  it('to < from → 빈 배열', () => {
+    const buckets = buildKstDayBuckets(
+      new Map(),
+      new Date('2026-07-05T00:00:00Z'),
+      new Date('2026-07-01T00:00:00Z'),
+    )
+    expect(buckets).toEqual([])
+  })
+
+  it('같은 날 (from == to) → 1개 버킷', () => {
+    const d = new Date('2026-07-08T05:00:00Z')
+    const buckets = buildKstDayBuckets(new Map([['2026-07-08', 2]]), d, d)
+    expect(buckets).toEqual([{ date: '2026-07-08', count: 2 }])
+  })
+})

--- a/src/app/api/alerts/history/route.ts
+++ b/src/app/api/alerts/history/route.ts
@@ -1,0 +1,89 @@
+/**
+ * Phase 33-B (#417) — 알림 발동 이력 조회 API.
+ * GET /api/alerts/history?kind=&ticker=&from=&to=&limit=&offset=
+ * envelope: paginated({ items, meta })
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { paginated, fail } from '@/lib/api-response'
+import type { Prisma } from '@prisma/client'
+import { parseISOOrNull, parseKindsParam } from './shared'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+const DEFAULT_LOOKBACK_DAYS = 7
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const { kinds, invalid } = parseKindsParam(url.searchParams)
+    const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
+    const fromStr = url.searchParams.get('from')?.trim() || undefined
+    const toStr = url.searchParams.get('to')?.trim() || undefined
+    const limitStr = url.searchParams.get('limit')
+    const offsetStr = url.searchParams.get('offset')
+
+    if (invalid.length > 0) {
+      return fail(`알 수 없는 kind: ${invalid.join(', ')}`, 400)
+    }
+    const from = parseISOOrNull(fromStr)
+    const to = parseISOOrNull(toStr)
+    if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
+    if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
+
+    let limit = limitStr ? parseInt(limitStr, 10) : DEFAULT_LIMIT
+    if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT
+    limit = Math.min(limit, MAX_LIMIT)
+
+    let offset = offsetStr ? parseInt(offsetStr, 10) : 0
+    if (!Number.isFinite(offset) || offset < 0) offset = 0
+
+    // 기본 기간: 최근 N일 (from/to 미지정 시)
+    const now = new Date()
+    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+    const effectiveTo = to ?? now
+
+    const where: Prisma.AlertHistoryWhereInput = {
+      firedAt: { gte: effectiveFrom, lte: effectiveTo },
+    }
+    if (kinds.length === 1) where.kind = kinds[0]
+    else if (kinds.length > 1) where.kind = { in: kinds }
+    if (rawTicker) where.ticker = rawTicker.toUpperCase()
+
+    const [rows, total] = await Promise.all([
+      prisma.alertHistory.findMany({
+        where,
+        // Codex P2 (#417 PR #424): 동일 firedAt (배치 발송 시 다수 이벤트) 에서 page skip
+        // 순서가 비결정적 → 페이지 넘김 시 rows 누락/중복. id 로 tiebreak.
+        orderBy: [{ firedAt: 'desc' }, { id: 'desc' }],
+        skip: offset,
+        take: limit,
+      }),
+      prisma.alertHistory.count({ where }),
+    ])
+
+    return paginated(
+      rows.map((r) => ({
+        id: r.id,
+        firedAt: r.firedAt.toISOString(),
+        kind: r.kind,
+        ticker: r.ticker,
+        price: r.price,
+        changePercent: r.changePercent,
+        message: r.message,
+        deliveryStatus: r.deliveryStatus,
+        recipientCount: r.recipientCount,
+        errorMessage: r.errorMessage,
+      })),
+      total,
+      limit,
+      offset,
+    )
+  } catch (error) {
+    console.error('GET /api/alerts/history error:', error)
+    return fail('알림 이력 조회에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/alerts/history/route.ts
+++ b/src/app/api/alerts/history/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { paginated, fail } from '@/lib/api-response'
 import type { Prisma } from '@prisma/client'
-import { parseISOOrNull, parseKindsParam } from './shared'
+import { parseISOOrNull, parseKindsParam, resolveTimeWindow } from './shared'
 
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
@@ -41,10 +41,8 @@ export async function GET(req: NextRequest) {
     let offset = offsetStr ? parseInt(offsetStr, 10) : 0
     if (!Number.isFinite(offset) || offset < 0) offset = 0
 
-    // 기본 기간: 최근 N일 (from/to 미지정 시)
-    const now = new Date()
-    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
-    const effectiveTo = to ?? now
+    // 기본 기간: `to` anchored (Codex #428 P2 fix). from/to 조합별 규칙은 resolveTimeWindow 참고.
+    const { effectiveFrom, effectiveTo } = resolveTimeWindow(from, to, DEFAULT_LOOKBACK_DAYS)
 
     const where: Prisma.AlertHistoryWhereInput = {
       firedAt: { gte: effectiveFrom, lte: effectiveTo },

--- a/src/app/api/alerts/history/shared.ts
+++ b/src/app/api/alerts/history/shared.ts
@@ -1,0 +1,69 @@
+/**
+ * Phase 33-B (#417) — /api/alerts/history 및 stats 라우트 공용.
+ */
+
+export const KNOWN_KINDS = new Set([
+  'surge', 'drop', 'fx',
+  'target_hit', 'stop_loss',
+  'watch_buy', 'watch_zone',
+  'ta_signal', 'custom_strategy',
+])
+
+export function parseISOOrNull(s: string | undefined | null): Date | null {
+  if (!s) return null
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/**
+ * `kind` 쿼리 파라미터 정규화 — repeated (`?kind=a&kind=b`) 와 CSV (`?kind=a,b`) 모두 허용.
+ * Codex P2 (#417 PR #424): 다중 kind 를 서버에서 지원해야 페이지네이션/집계가
+ * 정합. 이전 구현은 클라 다중 선택 시 서버 필터를 skip 하고 페이지 후 클라 필터 →
+ * 페이지 넘어간 rows 누락, 총계/stats 는 전체 kind 반영 (부정확).
+ *
+ * 반환: `{ kinds, invalid }` — invalid 는 whitelist 에 없는 kind 리스트 (400 응답용).
+ */
+export function parseKindsParam(params: URLSearchParams): {
+  kinds: string[]
+  invalid: string[]
+} {
+  const raw = params.getAll('kind').flatMap((v) => v.split(',')).map((s) => s.trim()).filter(Boolean)
+  const unique = Array.from(new Set(raw))
+  const kinds = unique.filter((k) => KNOWN_KINDS.has(k))
+  const invalid = unique.filter((k) => !KNOWN_KINDS.has(k))
+  return { kinds, invalid }
+}
+
+/** UTC Date → KST YYYY-MM-DD (버킷 키) */
+export function kstDateKey(d: Date): string {
+  const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  return kst.toISOString().slice(0, 10)
+}
+
+/**
+ * KST 기준 [from, to] 범위의 모든 날짜 버킷을 반환 (라인 차트 X 축용).
+ *
+ * 이전 구현 (self-review P1, #417): effectiveFrom 의 UTC time-of-day 를 고정한 채
+ * `+24h` 씩 순회 → from/to 의 UTC 시각이 KST 자정을 사이에 두고 어긋나면 마지막
+ * KST 날짜 버킷이 loop 조건에서 누락되어 byDayMap 은 count 있지만 결과에서 사라짐.
+ *
+ * 대신 KST 달력 일을 직접 순회 — `${key}T00:00:00Z` 를 baseline 으로 하고 +24h UTC
+ * (=+1일 KST) 씩 진행하며 kstDateKey 를 다시 계산.
+ */
+export function buildKstDayBuckets(
+  countsByKey: Map<string, number>,
+  from: Date,
+  to: Date,
+): Array<{ date: string; count: number }> {
+  const startKey = kstDateKey(from)
+  const endKey = kstDateKey(to)
+  if (startKey > endKey) return []
+  const out: Array<{ date: string; count: number }> = []
+  let cursor = new Date(`${startKey}T00:00:00Z`)
+  while (kstDateKey(cursor) <= endKey) {
+    const key = kstDateKey(cursor)
+    out.push({ date: key, count: countsByKey.get(key) ?? 0 })
+    cursor = new Date(cursor.getTime() + 24 * 60 * 60 * 1000)
+  }
+  return out
+}

--- a/src/app/api/alerts/history/shared.ts
+++ b/src/app/api/alerts/history/shared.ts
@@ -16,6 +16,28 @@ export function parseISOOrNull(s: string | undefined | null): Date | null {
 }
 
 /**
+ * 조회 기간 계산 (Codex #428 P2 회귀 방지 — 이전에는 `from` 미지정 시 항상 서버 now 기준
+ * -N일 로 anchored → 사용자가 `to` 만 과거로 지정하면 inverted range → 0 rows).
+ *
+ * 규칙:
+ *   - both provided → 그대로 사용
+ *   - `to` 만 → `from = to - lookbackDays`
+ *   - `from` 만 → `to = now`
+ *   - both omitted → `to = now`, `from = now - lookbackDays`
+ */
+export function resolveTimeWindow(
+  from: Date | null,
+  to: Date | null,
+  lookbackDays: number,
+  now: Date = new Date(),
+): { effectiveFrom: Date; effectiveTo: Date } {
+  const DAY = 24 * 60 * 60 * 1000
+  const effectiveTo = to ?? now
+  const effectiveFrom = from ?? new Date(effectiveTo.getTime() - lookbackDays * DAY)
+  return { effectiveFrom, effectiveTo }
+}
+
+/**
  * `kind` 쿼리 파라미터 정규화 — repeated (`?kind=a&kind=b`) 와 CSV (`?kind=a,b`) 모두 허용.
  * Codex P2 (#417 PR #424): 다중 kind 를 서버에서 지원해야 페이지네이션/집계가
  * 정합. 이전 구현은 클라 다중 선택 시 서버 필터를 skip 하고 페이지 후 클라 필터 →

--- a/src/app/api/alerts/history/stats/route.ts
+++ b/src/app/api/alerts/history/stats/route.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase 33-B (#417) — 알림 이력 통계.
+ * GET /api/alerts/history/stats?kind=&ticker=&from=&to=
+ * 반환: total, byStatus, byKind, byDay (KST 기준 날짜 버킷).
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
+import type { Prisma } from '@prisma/client'
+import { parseISOOrNull, parseKindsParam, buildKstDayBuckets, kstDateKey } from '../shared'
+
+const DEFAULT_LOOKBACK_DAYS = 7
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const { kinds, invalid } = parseKindsParam(url.searchParams)
+    const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
+    const fromStr = url.searchParams.get('from')?.trim() || undefined
+    const toStr = url.searchParams.get('to')?.trim() || undefined
+
+    if (invalid.length > 0) {
+      return fail(`알 수 없는 kind: ${invalid.join(', ')}`, 400)
+    }
+    const from = parseISOOrNull(fromStr)
+    const to = parseISOOrNull(toStr)
+    if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
+    if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
+
+    const now = new Date()
+    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+    const effectiveTo = to ?? now
+
+    const where: Prisma.AlertHistoryWhereInput = {
+      firedAt: { gte: effectiveFrom, lte: effectiveTo },
+    }
+    if (kinds.length === 1) where.kind = kinds[0]
+    else if (kinds.length > 1) where.kind = { in: kinds }
+    if (rawTicker) where.ticker = rawTicker.toUpperCase()
+
+    const rows = await prisma.alertHistory.findMany({
+      where,
+      select: { firedAt: true, kind: true, deliveryStatus: true },
+    })
+
+    const byKindMap = new Map<string, number>()
+    const byStatusMap = new Map<string, number>()
+    const byDayMap = new Map<string, number>()
+
+    for (const r of rows) {
+      byKindMap.set(r.kind, (byKindMap.get(r.kind) ?? 0) + 1)
+      byStatusMap.set(r.deliveryStatus, (byStatusMap.get(r.deliveryStatus) ?? 0) + 1)
+      const day = kstDateKey(r.firedAt)
+      byDayMap.set(day, (byDayMap.get(day) ?? 0) + 1)
+    }
+
+    // 기간 내 모든 KST 날짜를 0 으로 채워 연속 버킷 반환 (라인 차트용).
+    // self-review P1 (#417): KST 자정을 사이에 둔 from/to 조합에서 trailing KST 날짜
+    // 누락 → shared.ts 의 buildKstDayBuckets 로 분리해 pure test 로 회귀 방지.
+    const byDay = buildKstDayBuckets(byDayMap, effectiveFrom, effectiveTo)
+
+    const byKind = Array.from(byKindMap.entries())
+      .map(([k, count]) => ({ kind: k, count }))
+      .sort((a, b) => b.count - a.count)
+
+    return ok({
+      total: rows.length,
+      byStatus: {
+        sent: byStatusMap.get('sent') ?? 0,
+        partial: byStatusMap.get('partial') ?? 0,
+        failed: byStatusMap.get('failed') ?? 0,
+      },
+      byKind,
+      byDay,
+    })
+  } catch (error) {
+    console.error('GET /api/alerts/history/stats error:', error)
+    return fail('알림 이력 통계 조회에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/alerts/history/stats/route.ts
+++ b/src/app/api/alerts/history/stats/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { ok, fail } from '@/lib/api-response'
 import type { Prisma } from '@prisma/client'
-import { parseISOOrNull, parseKindsParam, buildKstDayBuckets, kstDateKey } from '../shared'
+import { parseISOOrNull, parseKindsParam, buildKstDayBuckets, kstDateKey, resolveTimeWindow } from '../shared'
 
 const DEFAULT_LOOKBACK_DAYS = 7
 
@@ -30,9 +30,8 @@ export async function GET(req: NextRequest) {
     if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
     if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
 
-    const now = new Date()
-    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
-    const effectiveTo = to ?? now
+    // 기본 기간: `to` anchored (Codex #428 P2 fix). resolveTimeWindow 규칙 통일.
+    const { effectiveFrom, effectiveTo } = resolveTimeWindow(from, to, DEFAULT_LOOKBACK_DAYS)
 
     const where: Prisma.AlertHistoryWhereInput = {
       firedAt: { gte: effectiveFrom, lte: effectiveTo },

--- a/src/bot/commands/alert.ts
+++ b/src/bot/commands/alert.ts
@@ -1,5 +1,6 @@
 import { Bot, Context } from 'grammy'
 import { prisma } from '@/lib/prisma'
+import { isToggleKey } from '@/lib/alert-config/categories'
 import { replyHtml, escapeHtml, h } from '../utils/telegram'
 
 /** 키 → 사용자 친화적 별칭 매핑 */
@@ -12,14 +13,14 @@ const KEY_ALIASES: Record<string, string> = {
   '리포트일': 'monthly_report_day',
   '모니터링주기': 'ta_check_interval_min',
   '능동리뷰': 'active_review',
+  'TA가이드': 'ta_ai_guide',
+  '전략알림': 'custom_strategy_alerts',
+  '관심종목시간대': 'watchlist_market_hours_only',
 }
-
-/** on/off 문자열만 받는 키 (다른 키는 숫자) */
-const ON_OFF_KEYS = new Set(['active_review'])
 
 /** 값 형식 검증 — 키별로 허용 값 규칙이 다름 */
 function isValidValue(key: string, value: string): boolean {
-  if (ON_OFF_KEYS.has(key)) {
+  if (isToggleKey(key)) {
     const v = value.toLowerCase()
     return v === 'on' || v === 'off'
   }
@@ -87,12 +88,12 @@ async function handler(ctx: Context) {
       }
 
       if (!isValidValue(key, value)) {
-        const hint = ON_OFF_KEYS.has(key) ? 'on / off' : '숫자'
+        const hint = isToggleKey(key) ? 'on / off' : '숫자'
         await ctx.reply(`⚠️ 값 형식 오류 — ${hint} 만 허용됩니다: ${value}`)
         return
       }
-      // ON_OFF 는 소문자 정규화
-      const normalizedValue = ON_OFF_KEYS.has(key) ? value.toLowerCase() : value
+      // 토글은 소문자 정규화
+      const normalizedValue = isToggleKey(key) ? value.toLowerCase() : value
 
       const existing = await prisma.alertConfig.findUnique({ where: { key } })
       if (!existing) {

--- a/src/bot/notifications/__tests__/alert-history.test.ts
+++ b/src/bot/notifications/__tests__/alert-history.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { computeDeliveryStatus, recordAlertHistory } from '../alert-history'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      createMany: vi.fn(),
+    },
+  },
+}))
+
+describe('computeDeliveryStatus', () => {
+  it('total <= 0 → failed (수신자 없는 이벤트는 실질 미발송)', () => {
+    expect(computeDeliveryStatus(0, 0)).toBe('failed')
+    expect(computeDeliveryStatus(0, -1)).toBe('failed')
+  })
+
+  it('전원 성공 → sent', () => {
+    expect(computeDeliveryStatus(3, 3)).toBe('sent')
+  })
+
+  it('전원 실패 → failed', () => {
+    expect(computeDeliveryStatus(0, 3)).toBe('failed')
+  })
+
+  it('일부 성공 → partial', () => {
+    expect(computeDeliveryStatus(1, 3)).toBe('partial')
+    expect(computeDeliveryStatus(2, 3)).toBe('partial')
+  })
+
+  it('successCount > total 도 sent (방어)', () => {
+    // 상위 로직이 잘못 세어도 최소 sent 판정 유지
+    expect(computeDeliveryStatus(5, 3)).toBe('sent')
+  })
+})
+
+describe('recordAlertHistory', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockReset()
+  })
+
+  it('빈 events 는 no-op (createMany 호출 없음)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    await recordAlertHistory([], 'sent', 0)
+    expect(prisma.alertHistory.createMany).not.toHaveBeenCalled()
+  })
+
+  it('event 들을 kind/ticker/message 그대로 매핑하여 createMany 호출', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 2 } as never)
+
+    await recordAlertHistory(
+      [
+        { kind: 'drop', ticker: 'AAPL', price: 150, changePercent: -6.2, message: '🔴 AAPL 급락' },
+        { kind: 'fx', ticker: 'USDKRW=X', price: 1330, message: '💱 환율 상승' },
+      ],
+      'sent',
+      2,
+    )
+
+    expect(prisma.alertHistory.createMany).toHaveBeenCalledTimes(1)
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data).toHaveLength(2)
+    expect(data[0]).toMatchObject({
+      kind: 'drop', ticker: 'AAPL', price: 150, changePercent: -6.2,
+      message: '🔴 AAPL 급락', deliveryStatus: 'sent', recipientCount: 2,
+    })
+    expect(data[1]).toMatchObject({
+      kind: 'fx', ticker: 'USDKRW=X', price: 1330,
+      message: '💱 환율 상승', deliveryStatus: 'sent', recipientCount: 2,
+    })
+  })
+
+  it('선택 필드 미지정 시 null 로 저장', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    await recordAlertHistory(
+      [{ kind: 'ta_signal', message: '📊 시그널' }],
+      'partial',
+      3,
+      '네트워크 오류',
+    )
+
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0]).toMatchObject({
+      kind: 'ta_signal', ticker: null, price: null, changePercent: null,
+      deliveryStatus: 'partial', recipientCount: 3, errorMessage: '네트워크 오류',
+    })
+  })
+
+  it('Prisma 실패는 삼키고 예외 전파 X (알림 흐름 유지)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockRejectedValueOnce(new Error('DB down'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      recordAlertHistory([{ kind: 'surge', message: 'x' }], 'sent', 1),
+    ).resolves.toBeUndefined()
+
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+})

--- a/src/bot/notifications/__tests__/price-alert-watchlist.test.ts
+++ b/src/bot/notifications/__tests__/price-alert-watchlist.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { shouldSkipWatchlistAlert } from '../price-alert'
+
+describe('shouldSkipWatchlistAlert (Phase 33-D / #415)', () => {
+  const OPEN = () => true
+  const CLOSED = () => false
+
+  it('marketHoursOnly=off + 장중 → skip 안 함 (24h 동작)', () => {
+    expect(shouldSkipWatchlistAlert(false, 'US', 'AAPL', OPEN)).toBe(false)
+  })
+
+  it('marketHoursOnly=off + 장외 → skip 안 함 (하위호환: 24h 동작 유지)', () => {
+    expect(shouldSkipWatchlistAlert(false, 'US', 'AAPL', CLOSED)).toBe(false)
+  })
+
+  it('marketHoursOnly=on + 장중 → skip 안 함 (발동)', () => {
+    expect(shouldSkipWatchlistAlert(true, 'KR', '005930.KS', OPEN)).toBe(false)
+  })
+
+  it('marketHoursOnly=on + 장외 → skip (알림 차단)', () => {
+    expect(shouldSkipWatchlistAlert(true, 'KR', '005930.KS', CLOSED)).toBe(true)
+  })
+
+  it('marketOpen 판정 함수 인자로 market/ticker 를 그대로 전달', () => {
+    const seen: Array<[string, string]> = []
+    const spy = (m: string, t: string) => {
+      seen.push([m, t])
+      return true
+    }
+    shouldSkipWatchlistAlert(true, 'KR', '005930.KS', spy)
+    expect(seen).toEqual([['KR', '005930.KS']])
+  })
+})

--- a/src/bot/notifications/alert-history.ts
+++ b/src/bot/notifications/alert-history.ts
@@ -1,0 +1,73 @@
+/**
+ * Phase 33-A (#416) — 알림 발동 이력 저장.
+ *
+ * 각 알림 스캐너 (price-alert / ta-signal-alert / custom-strategy-alert) 에서
+ * 이벤트 수집 후 배치 발송 → 결과와 함께 이 헬퍼로 저장.
+ * 저장 실패는 로그만 (알림 자체 흐름에 영향 X).
+ */
+
+import { prisma } from '@/lib/prisma'
+
+export type AlertKind =
+  | 'surge'
+  | 'drop'
+  | 'fx'
+  | 'target_hit'
+  | 'stop_loss'
+  | 'watch_buy'
+  | 'watch_zone'
+  | 'ta_signal'
+  | 'custom_strategy'
+
+export type DeliveryStatus = 'sent' | 'partial' | 'failed'
+
+export interface AlertEventInput {
+  kind: AlertKind
+  ticker?: string | null
+  price?: number | null
+  changePercent?: number | null
+  message: string
+}
+
+/**
+ * 배치 발송 성공 카운트로부터 deliveryStatus 산출 (pure).
+ *   total=0  → failed (수신자 없는 이벤트는 실질 미발송)
+ *   all      → sent
+ *   none     → failed
+ *   partial  → partial
+ */
+export function computeDeliveryStatus(successCount: number, total: number): DeliveryStatus {
+  if (total <= 0) return 'failed'
+  if (successCount >= total) return 'sent'
+  if (successCount <= 0) return 'failed'
+  return 'partial'
+}
+
+/**
+ * events 를 AlertHistory 로 일괄 저장. 빈 배열이면 no-op.
+ * Prisma 실패는 삼키고 로그만 — 알림 흐름 유지 우선.
+ */
+export async function recordAlertHistory(
+  events: AlertEventInput[],
+  deliveryStatus: DeliveryStatus,
+  recipientCount: number,
+  errorMessage?: string,
+): Promise<void> {
+  if (events.length === 0) return
+  try {
+    await prisma.alertHistory.createMany({
+      data: events.map((e) => ({
+        kind: e.kind,
+        ticker: e.ticker ?? null,
+        price: e.price ?? null,
+        changePercent: e.changePercent ?? null,
+        message: e.message,
+        deliveryStatus,
+        recipientCount,
+        errorMessage: errorMessage ?? null,
+      })),
+    })
+  } catch (error) {
+    console.error('[alert-history] 저장 실패:', error)
+  }
+}

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -15,6 +15,7 @@ import { getBot } from '@/bot/index'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { generateTAReport } from '@/lib/ta/engine'
 import type { TAReport } from '@/lib/ta/types'
+import { getEarningsMany } from '@/lib/earnings/cache'
 import {
   computeDeliveryStatus,
   recordAlertHistory,
@@ -147,6 +148,10 @@ async function runScan(chatIds: number[]): Promise<void> {
   })
   const holdings = new Set(holdingRows.map((h) => h.ticker))
 
+  // Phase 34-A (#419): 어닝 캐시 (전략 전체 티커 대상 미리 조회).
+  // 캐시 없으면 evaluator 가 자동으로 false 처리 → 안전.
+  const earningsMap = await getEarningsMany(tickers)
+
   // TA 필요한 ticker 만 리포트 생성 (병렬 + 실패 허용)
   const taByTicker = new Map<string, TAReport | null>()
 
@@ -189,11 +194,13 @@ async function runScan(chatIds: number[]): Promise<void> {
     if (!shouldFire(s.frequency, s.lastTriggeredAt, now)) continue
 
     const priceRow = priceMap.get(s.ticker)
+    const earningsRow = earningsMap.get(s.ticker)
     const snapshot: MarketSnapshot = {
       price: priceRow
         ? { price: priceRow.price, changePercent: priceRow.changePercent }
         : null,
       ta: taByTicker.get(s.ticker) ?? null,
+      earnings: earningsRow ? { nextEarningsDate: earningsRow.nextEarningsDate } : null,
     }
 
     const { satisfied, perCondition } = evaluateStrategy(

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -24,6 +24,7 @@ import {
 import {
   evaluateStrategy,
   requiresTA,
+  collectCrossTickers,
   type MarketSnapshot,
 } from '@/lib/custom-strategy/evaluator'
 import {
@@ -133,12 +134,20 @@ async function runScan(chatIds: number[]): Promise<void> {
   })
   if (strategies.length === 0) return
 
-  // ticker 단위로 PriceCache 미리 조회
-  const tickers = Array.from(new Set(strategies.map((s) => s.ticker)))
+  // Phase 34-B (#420): 전략들이 참조하는 크로스 티커도 함께 조회 (같은 쿼리에 병합).
+  const strategyTickers = Array.from(new Set(strategies.map((s) => s.ticker)))
+  const crossSet = collectCrossTickers(strategies)
+  const tickers = strategyTickers
+  const allPriceTickers = Array.from(new Set([...strategyTickers, ...crossSet]))
   const prices = await prisma.priceCache.findMany({
-    where: { ticker: { in: tickers } },
+    where: { ticker: { in: allPriceTickers } },
   })
   const priceMap = new Map(prices.map((p) => [p.ticker, p]))
+  const crossTickersMap = new Map<string, { price: number; changePercent: number | null }>()
+  for (const t of crossSet) {
+    const p = priceMap.get(t)
+    if (p) crossTickersMap.set(t, { price: p.price, changePercent: p.changePercent })
+  }
 
   // 보유 티커 조회 — holding_status 조건 평가용 (Phase 31-A v2).
   // shares > 0 만 홀딩으로 간주. 여러 계좌에서 같은 티커 보유해도 Set 이므로 중복 무관.
@@ -207,7 +216,7 @@ async function runScan(chatIds: number[]): Promise<void> {
       conds,
       s.logic === 'OR' ? 'OR' : 'AND',
       snapshot,
-      { now, holdings, strategyTicker: s.ticker },
+      { now, holdings, strategyTicker: s.ticker, crossTickers: crossTickersMap },
     )
 
     if (!satisfied) continue

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -16,6 +16,11 @@ import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { generateTAReport } from '@/lib/ta/engine'
 import type { TAReport } from '@/lib/ta/types'
 import {
+  computeDeliveryStatus,
+  recordAlertHistory,
+  type AlertEventInput,
+} from './alert-history'
+import {
   evaluateStrategy,
   requiresTA,
   type MarketSnapshot,
@@ -168,6 +173,7 @@ async function runScan(chatIds: number[]): Promise<void> {
 
   const now = new Date()
   const alerts: string[] = []
+  const historyEvents: AlertEventInput[] = []
   const firedIds: string[] = []
   const disableIds: string[] = [] // frequency=once + 발동 → 자동 비활성화
 
@@ -210,11 +216,19 @@ async function runScan(chatIds: number[]): Promise<void> {
       ? `${priceRow.price.toLocaleString('ko-KR')} ${priceRow.currency}`
       : '(가격 미확인)'
 
-    alerts.push(
+    const alertBlock =
       `🎯 <b>${escapeHtml(s.name)}</b> (${escapeHtml(s.ticker)})\n` +
-        `현재가: ${escapeHtml(priceLabel)}\n` +
-        `${escapeHtml('조건 (' + s.logic + ') 만족:')}\n${escapeHtml(condLines)}`,
-    )
+      `현재가: ${escapeHtml(priceLabel)}\n` +
+      `${escapeHtml('조건 (' + s.logic + ') 만족:')}\n${escapeHtml(condLines)}`
+    alerts.push(alertBlock)
+
+    // 이력용 — HTML 태그 없이 이력 페이지에서 보기 편한 요약.
+    historyEvents.push({
+      kind: 'custom_strategy',
+      ticker: s.ticker,
+      price: priceRow?.price ?? null,
+      message: `${s.name} (${s.ticker}) — ${s.logic} 조건 만족`,
+    })
   }
 
   if (alerts.length === 0) return
@@ -222,14 +236,20 @@ async function runScan(chatIds: number[]): Promise<void> {
   // 최소 1개 chatId 에 발송 성공한 뒤에만 DB 상태 갱신 — 실패 시 다음 tick 에서 재시도.
   const message = `🧠 <b>커스텀 전략 발동</b> (${todayKST()})\n\n${alerts.join('\n\n')}`
   let sentCount = 0
+  let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
       await sendHtml(bot, chatId, message)
       sentCount++
     } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
       console.error(`[custom-strategy] 알림 발송 실패 (chatId: ${chatId}):`, error)
     }
   }
+
+  // Phase 33-A (#416): 발동 이력 저장 (발송 성공 여부와 무관 — 실패도 partial/failed 로 기록).
+  const status = computeDeliveryStatus(sentCount, chatIds.length)
+  await recordAlertHistory(historyEvents, status, chatIds.length, status === 'sent' ? undefined : lastError)
 
   if (sentCount === 0) {
     console.warn('[custom-strategy] 전체 chatId 발송 실패 — DB 상태 갱신 보류 (다음 tick 재시도)')

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -11,6 +11,11 @@ import { getBot } from '@/bot/index'
 import { formatPercent } from '@/bot/utils/formatter'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { isMarketOpenFor } from '@/lib/market-hours'
+import {
+  computeDeliveryStatus,
+  recordAlertHistory,
+  type AlertEventInput,
+} from './alert-history'
 
 const WATCHLIST_MHO_KEY = 'watchlist_market_hours_only'
 const WATCHLIST_MHO_LABEL = '관심종목 매수 알림 — 장중에만'
@@ -117,7 +122,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   })
 
   const priceMap = new Map(prices.map((p) => [p.ticker, p]))
-  const alerts: string[] = []
+  const events: AlertEventInput[] = []
 
   for (const p of prices) {
     // 환율은 별도 처리
@@ -128,9 +133,13 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
         sentToday.set(key, today)
 
         const direction = p.change > 0 ? '📈 상승' : '📉 하락'
-        alerts.push(
-          `💱 환율 ${direction}: ${p.price.toLocaleString('ko-KR')}원 (${p.change > 0 ? '+' : ''}${p.change.toFixed(0)}원)`
-        )
+        events.push({
+          kind: 'fx',
+          ticker: p.ticker,
+          price: p.price,
+          changePercent: p.changePercent,
+          message: `💱 환율 ${direction}: ${p.price.toLocaleString('ko-KR')}원 (${p.change > 0 ? '+' : ''}${p.change.toFixed(0)}원)`,
+        })
       }
       continue
     }
@@ -148,15 +157,23 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
     if (p.changePercent <= dropThreshold) {
       sentToday.set(key, today)
       const name = nameMap.get(p.ticker) ?? p.ticker
-      alerts.push(
-        `🔴 ${name} (${p.ticker}) 급락: ${formatPercent(p.changePercent)}`
-      )
+      events.push({
+        kind: 'drop',
+        ticker: p.ticker,
+        price: p.price,
+        changePercent: p.changePercent,
+        message: `🔴 ${name} (${p.ticker}) 급락: ${formatPercent(p.changePercent)}`,
+      })
     } else if (p.changePercent >= surgeThreshold) {
       sentToday.set(key, today)
       const name = nameMap.get(p.ticker) ?? p.ticker
-      alerts.push(
-        `🟢 ${name} (${p.ticker}) 급등: ${formatPercent(p.changePercent)}`
-      )
+      events.push({
+        kind: 'surge',
+        ticker: p.ticker,
+        price: p.price,
+        changePercent: p.changePercent,
+        message: `🟢 ${name} (${p.ticker}) 급등: ${formatPercent(p.changePercent)}`,
+      })
     }
   }
 
@@ -185,9 +202,12 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `target:${s.holding.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'target_hit',
+          ticker: s.holding.ticker,
+          price: currentPrice,
+          message: `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`,
+        })
       }
     }
 
@@ -195,9 +215,12 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `stoploss:${s.holding.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'stop_loss',
+          ticker: s.holding.ticker,
+          price: currentPrice,
+          message: `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`,
+        })
       }
     }
   }
@@ -227,9 +250,12 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `wbuy:${w.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'watch_buy',
+          ticker: w.ticker,
+          price: price.price,
+          message: `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`,
+        })
       }
     }
 
@@ -237,25 +263,36 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
       const key = `wzone:${w.ticker}`
       if (sentToday.get(key) !== today) {
         sentToday.set(key, today)
-        alerts.push(
-          `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`
-        )
+        events.push({
+          kind: 'watch_zone',
+          ticker: w.ticker,
+          price: price.price,
+          message: `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`,
+        })
       }
     }
   }
 
-  if (alerts.length === 0) return
+  if (events.length === 0) return
 
   const bot = getBot()
-  const message = `⚡ <b>변동 알림</b>\n\n${alerts.join('\n')}`
+  const combined = `⚡ <b>변동 알림</b>\n\n${events.map((e) => e.message).join('\n')}`
 
+  let sendSuccess = 0
+  let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
-      await sendHtml(bot, chatId, message)
+      await sendHtml(bot, chatId, combined)
+      sendSuccess++
     } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
       console.error(`[notification] 변동 알림 발송 실패 (chatId: ${chatId}):`, error)
     }
   }
 
-  console.log(`[notification] 변동 알림 발송: ${alerts.length}건`)
+  // Phase 33-A (#416): 각 이벤트 이력 저장 (배송 상태 요약)
+  const status = computeDeliveryStatus(sendSuccess, chatIds.length)
+  await recordAlertHistory(events, status, chatIds.length, status === 'sent' ? undefined : lastError)
+
+  console.log(`[notification] 변동 알림 발송: ${events.length}건 → ${sendSuccess}/${chatIds.length} chats`)
 }

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -12,6 +12,41 @@ import { formatPercent } from '@/bot/utils/formatter'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { isMarketOpenFor } from '@/lib/market-hours'
 
+const WATCHLIST_MHO_KEY = 'watchlist_market_hours_only'
+const WATCHLIST_MHO_LABEL = '관심종목 매수 알림 — 장중에만'
+
+/**
+ * 관심종목 목표매수가/매수구간 알림의 시간대 제한 설정 초기화 (Phase 33-D / #415).
+ * `off` (기본) = 24h 발송, `on` = 각 시장 거래시간에만 발송.
+ * 봇 시작 시 upsert 로 row 존재 보장 → 설정 페이지에 자동 노출.
+ */
+export async function ensureWatchlistMarketHoursOnlySetting(): Promise<void> {
+  try {
+    await prisma.alertConfig.upsert({
+      where: { key: WATCHLIST_MHO_KEY },
+      update: {},
+      create: { key: WATCHLIST_MHO_KEY, value: 'off', label: WATCHLIST_MHO_LABEL },
+    })
+  } catch (error) {
+    console.error('[notification] watchlist_market_hours_only 설정 초기화 실패:', error)
+  }
+}
+
+/**
+ * Pure — 관심종목 매수 알림 발동을 시간대 제한 규칙으로 건너뛸지 판단.
+ * marketHoursOnly=false 이면 항상 발동 (24h). true 이면 해당 시장 장중에만 발동.
+ * `marketOpen` 은 실제 판정 함수 주입 (테스트 용이).
+ */
+export function shouldSkipWatchlistAlert(
+  marketHoursOnly: boolean,
+  market: string,
+  ticker: string,
+  marketOpen: (market: string, ticker: string) => boolean = isMarketOpenFor,
+): boolean {
+  if (!marketHoursOnly) return false
+  return !marketOpen(market, ticker)
+}
+
 /** 당일 알림 발송 기록 (ticker → date string) */
 const sentToday = new Map<string, string>()
 
@@ -44,7 +79,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   // AlertConfig에서 임계값 조회
   const configs = await prisma.alertConfig.findMany({
     where: {
-      key: { in: ['price_drop_pct', 'price_surge_pct', 'fx_change_krw'] },
+      key: { in: ['price_drop_pct', 'price_surge_pct', 'fx_change_krw', WATCHLIST_MHO_KEY] },
     },
   })
   const configMap = new Map(configs.map((c) => [c.key, c.value]))
@@ -57,6 +92,7 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   const dropThreshold = parseOrDefault('price_drop_pct', -5)
   const surgeThreshold = parseOrDefault('price_surge_pct', 5)
   const fxThreshold = parseOrDefault('fx_change_krw', 50)
+  const watchlistMarketHoursOnly = (configMap.get(WATCHLIST_MHO_KEY) ?? 'off').toLowerCase() === 'on'
 
   // 보유 종목만 조회 (전체 PriceCache가 아니라)
   const holdings = await prisma.holding.findMany({
@@ -179,6 +215,10 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
   for (const w of watchlist) {
     const price = priceMap.get(w.ticker)
     if (!price) continue
+
+    // 관심종목 알림 시간대 토글 (Phase 33-D / #415)
+    // — on 이면 매수구간/목표매수가 알림을 각 시장 거래시간에만 발송 (기본 off = 24h).
+    if (shouldSkipWatchlistAlert(watchlistMarketHoursOnly, price.market, w.ticker)) continue
 
     const name = escapeHtml(w.displayName)
     const ticker = escapeHtml(w.ticker)

--- a/src/bot/notifications/scheduler.ts
+++ b/src/bot/notifications/scheduler.ts
@@ -10,6 +10,7 @@ import { sendRSUReminders, sendRSUVestConfirmations } from './rsu'
 import { sendClosingReview, sendWeeklyReview, ensureActiveReviewSetting } from './active-review'
 import { ensureCustomStrategyAlertsSetting } from './custom-strategy-alert'
 import { ensureTaAiGuideSetting } from './ta-signal-alert'
+import { ensureWatchlistMarketHoursOnlySetting } from './price-alert'
 import { sendMonthlyReminder } from './monthly'
 import { sendDailySummary } from './daily'
 import { sendMonthlyReport } from './monthly-report'
@@ -55,6 +56,11 @@ export function scheduleNotifications(): void {
   // ta_ai_guide 키 upsert — TA 시그널 AI 가이드 on/off
   ensureTaAiGuideSetting().catch((error) => {
     console.error('[notification] ensureTaAiGuideSetting 실패:', error)
+  })
+  // watchlist_market_hours_only 키 upsert (Phase 33-D / #415) —
+  // 관심종목 매수 알림을 각 시장 거래시간에만 발송할지 사용자 토글.
+  ensureWatchlistMarketHoursOnlySetting().catch((error) => {
+    console.error('[notification] ensureWatchlistMarketHoursOnlySetting 실패:', error)
   })
 
   try {

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -12,6 +12,11 @@ import { getBot } from '@/bot/index'
 import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
 import { isMarketOpenFor } from '@/lib/market-hours'
+import {
+  computeDeliveryStatus,
+  recordAlertHistory,
+  type AlertEventInput,
+} from './alert-history'
 import type { TAReport } from '@/lib/ta/types'
 
 /** 당일 시그널 발송 기록 (키 → date string) */
@@ -213,12 +218,16 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
   if (tickerStrategies.size === 0) return
 
   // PriceCache.market을 결정적 소스로 사용 (Holding/Watchlist 간 market 불일치 방지)
-  // price-alert.ts와 동일한 패턴 (#261)
+  // price-alert.ts와 동일한 패턴 (#261). Phase 33-A: price/changePercent 도 함께 조회하여
+  // AlertHistory 에 시세 스냅샷 캡처 (사후 진단 유용).
   const priceCaches = await prisma.priceCache.findMany({
     where: { ticker: { in: Array.from(tickerStrategies.keys()) } },
-    select: { ticker: true, market: true },
+    select: { ticker: true, market: true, price: true, changePercent: true },
   })
   const marketByTicker = new Map(priceCaches.map((p) => [p.ticker, p.market]))
+  const snapshotByTicker = new Map(
+    priceCaches.map((p) => [p.ticker, { price: p.price, changePercent: p.changePercent }]),
+  )
 
   const results: SignalResult[] = []
 
@@ -314,19 +323,21 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
   const bot = getBot()
   const message = lines.join('\n')
 
-  let sendSuccess = false
+  let sendSuccess = 0
+  let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
       await sendHtml(bot, chatId, message)
-      sendSuccess = true
+      sendSuccess++
     } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
       console.error(`[ta-signal] 알림 발송 실패 (chatId: ${chatId}):`, error)
     }
   }
 
   // 발송 성공 시에만 dedupe + AI 쿨다운 기록 (실패 시 다음 주기 재시도).
   // AI 가이드가 붙었던 티커만 쿨다운 기록 → skip 된 티커는 다음 주기 재시도.
-  if (sendSuccess) {
+  if (sendSuccess > 0) {
     for (const r of results) {
       for (const sigId of r.signalIds) {
         sentToday.set(`ta:${r.ticker}:${sigId}`, today)
@@ -338,5 +349,20 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     }
   }
 
-  console.log(`[ta-signal] TA 시그널 알림: ${results.length}종목`)
+  // Phase 33-A (#416): 티커 단위 이력 저장 — 각 종목의 시그널을 한 이벤트로 통합.
+  // 시세 스냅샷 (price / changePercent) 을 함께 캡처하여 사후 진단시 참고.
+  const historyEvents: AlertEventInput[] = results.map((r) => {
+    const snap = snapshotByTicker.get(r.ticker)
+    return {
+      kind: 'ta_signal',
+      ticker: r.ticker,
+      price: snap?.price ?? null,
+      changePercent: snap?.changePercent ?? null,
+      message: `${r.displayName} (${r.ticker}) — ${r.strategy}: ${r.signals.join(', ')}`,
+    }
+  })
+  const status = computeDeliveryStatus(sendSuccess, chatIds.length)
+  await recordAlertHistory(historyEvents, status, chatIds.length, status === 'sent' ? undefined : lastError)
+
+  console.log(`[ta-signal] TA 시그널 알림: ${results.length}종목 → ${sendSuccess}/${chatIds.length} chats`)
 }

--- a/src/bot/standalone.ts
+++ b/src/bot/standalone.ts
@@ -9,7 +9,7 @@
 
 import 'dotenv/config'
 import { getBot } from './index'
-import { schedulePriceUpdates, scheduleSnapshots, scheduleKrxSync, scheduleRecurring, scheduleVestingStatusUpdate } from '@/lib/cron'
+import { schedulePriceUpdates, scheduleSnapshots, scheduleKrxSync, scheduleRecurring, scheduleVestingStatusUpdate, scheduleEarningsScan } from '@/lib/cron'
 import { scheduleNotifications } from './notifications/scheduler'
 import { sanitizeError } from './utils/error'
 
@@ -31,6 +31,7 @@ async function main(): Promise<void> {
   scheduleKrxSync()
   scheduleRecurring()
   scheduleVestingStatusUpdate()
+  scheduleEarningsScan()
   scheduleNotifications()
   console.log('[bot] cron + 알림 스케줄러 등록 완료')
 

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -56,6 +56,7 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     title: '설정',
     items: [
+      { href: '/alerts/history', icon: '🔔', label: '알림 이력' },
       { href: '/settings', icon: '⚙️', label: '설정', hiddenOnMobile: true },
     ],
   },

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -57,6 +57,7 @@ export const NAV_GROUPS: NavGroup[] = [
     title: '설정',
     items: [
       { href: '/alerts/history', icon: '🔔', label: '알림 이력' },
+      { href: '/admin/mcp-logs', icon: '🪵', label: 'MCP 로그', hiddenOnMobile: true },
       { href: '/settings', icon: '⚙️', label: '설정', hiddenOnMobile: true },
     ],
   },

--- a/src/lib/__tests__/kst-date.test.ts
+++ b/src/lib/__tests__/kst-date.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { kstMidnightUtc, isSameOrFutureKstDay, kstDayDiff } from '../kst-date'
+
+describe('kstMidnightUtc', () => {
+  it('KST 자정 (UTC 15:00 전날) 을 그 UTC 값으로 반환', () => {
+    // 2026-07-30 00:00 KST = 2026-07-29 15:00 UTC
+    const d = new Date('2026-07-30T05:00:00Z')  // KST 14:00
+    expect(new Date(kstMidnightUtc(d)).toISOString()).toBe('2026-07-29T15:00:00.000Z')
+  })
+
+  it('UTC 자정도 KST 09:00 → 같은 KST 캘린더 일', () => {
+    const d = new Date('2026-07-30T00:00:00Z')  // KST 09:00
+    const midnight = new Date('2026-07-30T05:00:00Z')  // KST 14:00 (같은 KST 날짜)
+    expect(kstMidnightUtc(d)).toBe(kstMidnightUtc(midnight))
+  })
+})
+
+describe('isSameOrFutureKstDay (Codex #426 P2 회귀 방지)', () => {
+  it('yahoo earnings 값이 UTC 자정 (=KST 09:00) 인데 스캔이 KST 오후 → 같은 KST 날 → true', () => {
+    const earnings = new Date('2026-07-30T00:00:00Z')  // KST 07-30 09:00
+    const scanNow = new Date('2026-07-30T05:00:00Z')   // KST 07-30 14:00
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(true)
+  })
+
+  it('어닝이 KST 어제 자정 → false', () => {
+    const earnings = new Date('2026-07-29T20:00:00Z')  // KST 07-30 05:00 (같은 KST 날)
+    const scanNow = new Date('2026-07-31T05:00:00Z')   // KST 07-31 14:00
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(false)
+  })
+
+  it('어닝이 KST 내일 → true', () => {
+    const earnings = new Date('2026-07-31T00:00:00Z')  // KST 07-31 09:00
+    const scanNow = new Date('2026-07-30T05:00:00Z')   // KST 07-30
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(true)
+  })
+
+  it('KST 자정 경계 정확도: now 가 KST 23:59, 어닝이 KST 다음날 00:00 → future', () => {
+    const scanNow = new Date('2026-07-30T14:59:00Z')   // KST 07-30 23:59
+    const earnings = new Date('2026-07-30T15:00:00Z')  // KST 07-31 00:00
+    expect(isSameOrFutureKstDay(earnings, scanNow)).toBe(true)
+  })
+})
+
+describe('kstDayDiff', () => {
+  it('같은 KST 날 → 0 (시각 무관)', () => {
+    const a = new Date('2026-07-30T00:00:00Z')  // KST 09:00
+    const b = new Date('2026-07-30T14:00:00Z')  // KST 23:00
+    expect(kstDayDiff(a, b)).toBe(0)
+    expect(kstDayDiff(b, a)).toBe(0)
+  })
+
+  it('내일 vs 오늘 → +1 / -1', () => {
+    const today = new Date('2026-07-30T00:00:00Z')
+    const tomorrow = new Date('2026-07-31T00:00:00Z')
+    expect(kstDayDiff(tomorrow, today)).toBe(1)
+    expect(kstDayDiff(today, tomorrow)).toBe(-1)
+  })
+
+  it('3일 뒤 → 3', () => {
+    const today = new Date('2026-07-30T00:00:00Z')
+    const d3 = new Date('2026-08-02T20:00:00Z')  // KST 08-03 05:00 → 4일 뒤 아님, 3일 뒤 KST 8-2
+    // 실제로 2026-07-30 (KST 07-30 09:00) → 2026-08-02T20:00Z (KST 08-03 05:00): 4일 뒤
+    // 다른 예시 사용
+    const d3proper = new Date('2026-08-01T20:00:00Z')  // KST 08-02 05:00 → 3일 뒤
+    expect(kstDayDiff(d3proper, today)).toBe(3)
+    // sanity
+    expect(kstDayDiff(d3, today)).toBe(4)
+  })
+})

--- a/src/lib/__tests__/price-fetcher-utils.test.ts
+++ b/src/lib/__tests__/price-fetcher-utils.test.ts
@@ -2,20 +2,43 @@ import { describe, expect, it } from 'vitest'
 // price-fetcher 본체 (Prisma / yahoo top-level 로드) 대신 순수 유틸 모듈에서 직접 import →
 // Prisma generate / DATABASE_URL 없이도 테스트 가능 (Codex #429 P2).
 import { mergeCrossTickersIntoMeta } from '../price-fetcher-utils'
+import { normalizeMarket } from '../market-hours'
 
 describe('mergeCrossTickersIntoMeta (Codex #428 P2 회귀 방지)', () => {
-  it('신규 크로스 티커를 placeholder 로 삽입', () => {
+  it('신규 US 벤치마크는 market="US" / currency="USD" 로 삽입', () => {
     const meta = new Map()
     mergeCrossTickersIntoMeta(meta, ['SPY', 'VIX'])
-    expect(meta.get('SPY')).toEqual({ displayName: 'SPY', market: '?', currency: 'USD' })
-    expect(meta.get('VIX')).toEqual({ displayName: 'VIX', market: '?', currency: 'USD' })
+    expect(meta.get('SPY')).toEqual({ displayName: 'SPY', market: 'US', currency: 'USD' })
+    expect(meta.get('VIX')).toEqual({ displayName: 'VIX', market: 'US', currency: 'USD' })
   })
 
-  it('KRX suffix (.KS/.KQ) 는 KRW 통화 부여', () => {
+  it('KRX suffix (.KS/.KQ) 는 market="KR" / currency="KRW"', () => {
     const meta = new Map()
     mergeCrossTickersIntoMeta(meta, ['005930.KS', '035720.KS', '091990.KQ'])
-    expect(meta.get('005930.KS')?.currency).toBe('KRW')
+    expect(meta.get('005930.KS')).toEqual({ displayName: '005930.KS', market: 'KR', currency: 'KRW' })
+    expect(meta.get('091990.KQ')?.market).toBe('KR')
     expect(meta.get('091990.KQ')?.currency).toBe('KRW')
+  })
+
+  it('FX 티커 (`=X`) 는 market="FX" (Codex #428 재재리뷰 P2 회귀 방지)', () => {
+    // market='US' 로 두면 normalizeMarket 이 US 매치 먼저 반환 → `=X` suffix 체크 skip →
+    // FX 티커가 US-hours-only 로 굳어짐. 명시 'FX' 로 방지.
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, ['EURUSD=X', 'GBPJPY=X'])
+    expect(meta.get('EURUSD=X')?.market).toBe('FX')
+    expect(meta.get('GBPJPY=X')?.market).toBe('FX')
+  })
+
+  it('doRefreshPrices 흐름과 정합: normalizeMarket 이 US/KR/FX 로 판정 (Codex #428 P2 회귀 방지)', () => {
+    // doRefreshPrices 는 `normalizeMarket(meta.market, ticker)` 를 호출해 PriceCache.market 저장.
+    // 이전 구현 (`market: '?'`) 은 SPY 를 'OTHER' 로 판정 → 개선 후 'US'/'KR'/'FX' 정확 반환.
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, ['SPY', 'VIX', 'QQQ', '005930.KS', 'EURUSD=X'])
+    expect(normalizeMarket(meta.get('SPY')!.market, 'SPY')).toBe('US')
+    expect(normalizeMarket(meta.get('VIX')!.market, 'VIX')).toBe('US')
+    expect(normalizeMarket(meta.get('QQQ')!.market, 'QQQ')).toBe('US')
+    expect(normalizeMarket(meta.get('005930.KS')!.market, '005930.KS')).toBe('KR')
+    expect(normalizeMarket(meta.get('EURUSD=X')!.market, 'EURUSD=X')).toBe('FX')
   })
 
   it('이미 등록된 티커는 덮어쓰지 않음 (holdings/watchlist 메타 우선)', () => {

--- a/src/lib/__tests__/price-fetcher-utils.test.ts
+++ b/src/lib/__tests__/price-fetcher-utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+// price-fetcher 본체 (Prisma / yahoo top-level 로드) 대신 순수 유틸 모듈에서 직접 import →
+// Prisma generate / DATABASE_URL 없이도 테스트 가능 (Codex #429 P2).
+import { mergeCrossTickersIntoMeta } from '../price-fetcher-utils'
+
+describe('mergeCrossTickersIntoMeta (Codex #428 P2 회귀 방지)', () => {
+  it('신규 크로스 티커를 placeholder 로 삽입', () => {
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, ['SPY', 'VIX'])
+    expect(meta.get('SPY')).toEqual({ displayName: 'SPY', market: '?', currency: 'USD' })
+    expect(meta.get('VIX')).toEqual({ displayName: 'VIX', market: '?', currency: 'USD' })
+  })
+
+  it('KRX suffix (.KS/.KQ) 는 KRW 통화 부여', () => {
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, ['005930.KS', '035720.KS', '091990.KQ'])
+    expect(meta.get('005930.KS')?.currency).toBe('KRW')
+    expect(meta.get('091990.KQ')?.currency).toBe('KRW')
+  })
+
+  it('이미 등록된 티커는 덮어쓰지 않음 (holdings/watchlist 메타 우선)', () => {
+    const meta = new Map([['SPY', { displayName: 'S&P 500 ETF', market: 'US', currency: 'USD' }]])
+    mergeCrossTickersIntoMeta(meta, ['SPY', 'VIX'])
+    expect(meta.get('SPY')).toEqual({ displayName: 'S&P 500 ETF', market: 'US', currency: 'USD' })
+    expect(meta.get('VIX')?.displayName).toBe('VIX')
+  })
+
+  it('빈 crossTickers → 원본 그대로', () => {
+    const meta = new Map([['AAPL', { displayName: 'Apple', market: 'US', currency: 'USD' }]])
+    const before = new Map(meta)
+    mergeCrossTickersIntoMeta(meta, [])
+    expect(meta).toEqual(before)
+  })
+
+  it('Set 타입도 수용 (Iterable 인터페이스)', () => {
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, new Set(['SPY', 'QQQ']))
+    expect(meta.has('SPY')).toBe(true)
+    expect(meta.has('QQQ')).toBe(true)
+  })
+})

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -85,6 +85,7 @@ const ALLOWED_TOOLS = [
   'mcp__myfinance__delete_recurring_transaction',
   'mcp__myfinance__list_alert_configs',
   'mcp__myfinance__update_alert_config',
+  'mcp__myfinance__list_alert_history',
   'mcp__myfinance__create_rsu_schedule',
   'mcp__myfinance__update_rsu_schedule',
   'mcp__myfinance__delete_rsu_schedule',

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -102,6 +102,7 @@ export const SYSTEM_PROMPT = `당신은 myFinance의 가족 자산관리 AI 어�
 - list_budgets / set_budget / delete_budget: 카테고리별 월 예산 관리 (set은 upsert). **쓰기는 사용자 확인 후**
 - list_recurring_transactions / create_recurring_transaction / update_recurring_transaction / delete_recurring_transaction: 반복 거래 CRUD. **쓰기는 사용자 확인 후**
 - list_alert_configs / update_alert_config: 알림 임계값 설정 (기존 키만). **변경은 사용자 확인 후**
+- list_alert_history: 알림 발동 이력 조회. 필터: kind (surge/drop/fx/target_hit/stop_loss/watch_buy/watch_zone/ta_signal/custom_strategy), ticker, from~to (ISO 8601), limit (기본 50, 최대 200)
 - create_rsu_schedule / update_rsu_schedule / delete_rsu_schedule: RSU 베스팅 일정 CRUD (update/delete는 pending만). **쓰기는 사용자 확인 후**
 - vest_rsu: RSU 베스팅 처리 — 종가 자동 조회 후 BUY/SELL Trade + Holding 자동 반영. **사용자의 명시적 동의 후에만 호출**
 - create_stock_option / update_stock_option / delete_stock_option: 스톡옵션 CRUD (update 시 remainingShares 자동 재계산). **쓰기는 사용자 확인 후**

--- a/src/lib/alert-config/__tests__/categories.test.ts
+++ b/src/lib/alert-config/__tests__/categories.test.ts
@@ -5,6 +5,7 @@ import {
   categoryOf,
   inputTypeOf,
   groupByCategory,
+  isToggleKey,
 } from '../categories'
 
 describe('categoryOf', () => {
@@ -83,7 +84,7 @@ describe('groupByCategory', () => {
 })
 
 describe('ALERT_KEY_CATEGORY 완전성', () => {
-  it('실제 사용 중인 10개 키가 모두 매핑됨', () => {
+  it('실제 사용 중인 키들이 모두 매핑됨', () => {
     const knownKeys = [
       'price_drop_pct',
       'price_surge_pct',
@@ -95,10 +96,46 @@ describe('ALERT_KEY_CATEGORY 완전성', () => {
       'ta_ai_guide',
       'active_review',
       'custom_strategy_alerts',
+      'watchlist_market_hours_only',
     ]
     for (const key of knownKeys) {
       expect(ALERT_KEY_CATEGORY[key]).toBeDefined()
     }
+  })
+})
+
+describe('isToggleKey (bot 커맨드 / MCP 툴 단일 진실)', () => {
+  it('토글 매핑된 키는 true (활성/비활성 알림 정책)', () => {
+    // Codex #422 P2: 이 목록이 곧 텔레그램 봇 커맨드 / MCP updateAlertConfig 에서
+    // on/off 허용 여부를 결정. 새 토글 추가 시 반드시 여기 포함되어야 회귀 방지.
+    expect(isToggleKey('active_review')).toBe(true)
+    expect(isToggleKey('ta_ai_guide')).toBe(true)
+    expect(isToggleKey('custom_strategy_alerts')).toBe(true)
+    expect(isToggleKey('watchlist_market_hours_only')).toBe(true)
+  })
+
+  it('숫자/문자 키는 false', () => {
+    expect(isToggleKey('price_drop_pct')).toBe(false)
+    expect(isToggleKey('daily_summary_hour')).toBe(false)
+    expect(isToggleKey('fx_change_krw')).toBe(false)
+  })
+
+  it('알려지지 않은 키는 false', () => {
+    expect(isToggleKey('unknown_key_xyz')).toBe(false)
+    expect(isToggleKey('')).toBe(false)
+  })
+})
+
+describe('watchlist_market_hours_only (Phase 33-D / #415)', () => {
+  it('price 카테고리로 분류', () => {
+    expect(categoryOf('watchlist_market_hours_only')).toBe('price')
+  })
+
+  it('toggle 입력 타입 (off 기본값과 무관하게 매핑 override 적용)', () => {
+    // value 가 아직 upsert 되지 않아 빈 문자열이더라도 override 로 toggle 반환.
+    expect(inputTypeOf('watchlist_market_hours_only', '')).toBe('toggle')
+    expect(inputTypeOf('watchlist_market_hours_only', 'off')).toBe('toggle')
+    expect(inputTypeOf('watchlist_market_hours_only', 'on')).toBe('toggle')
   })
 })
 

--- a/src/lib/alert-config/categories.ts
+++ b/src/lib/alert-config/categories.ts
@@ -66,6 +66,7 @@ export const ALERT_KEY_CATEGORY: Record<string, AlertCategoryKey> = {
   price_drop_pct: 'price',
   price_surge_pct: 'price',
   fx_change_krw: 'price',
+  watchlist_market_hours_only: 'price',
   budget_warn_pct: 'expense',
   daily_summary_hour: 'schedule',
   monthly_report_day: 'schedule',
@@ -89,6 +90,7 @@ export const ALERT_KEY_INPUT_TYPE: Record<string, AlertInputType> = {
   ta_ai_guide: 'toggle',
   active_review: 'toggle',
   custom_strategy_alerts: 'toggle',
+  watchlist_market_hours_only: 'toggle',
 }
 
 /** 키별 사용자 향 설명 (label 은 DB label, 이건 부가 설명) */
@@ -103,11 +105,22 @@ export const ALERT_KEY_DESCRIPTION: Record<string, string> = {
   ta_ai_guide: 'TA 시그널 알림에 AI 짧은 조언 첨부 (티커별 6h 쿨다운)',
   active_review: 'KR 15:40 / US 07:15 클로징 리뷰 + 주간 리뷰 자동 발송',
   custom_strategy_alerts: '/strategies 에 등록한 조건 발동 시 텔레그램 알림',
+  watchlist_market_hours_only: '관심종목 목표매수가/매수구간 알림을 각 시장 거래시간에만 발송 (기본 off = 24h)',
 }
 
 /** 카테고리 조회 — 알려지지 않은 키는 general */
 export function categoryOf(key: string): AlertCategoryKey {
   return ALERT_KEY_CATEGORY[key] ?? 'general'
+}
+
+/**
+ * 토글 (on/off) 키 여부.
+ * `ALERT_KEY_INPUT_TYPE` 를 단일 진실로 삼아 텔레그램 봇 커맨드 / MCP 도구 / 웹 UI
+ * 세 곳이 일관되게 on/off 검증 하도록. 신규 토글 키 추가 시 `ALERT_KEY_INPUT_TYPE`
+ * 에 `'toggle'` 로만 매핑하면 세 경로 모두 자동 반영.
+ */
+export function isToggleKey(key: string): boolean {
+  return ALERT_KEY_INPUT_TYPE[key] === 'toggle'
 }
 
 /**

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -138,6 +138,42 @@ export function scheduleSnapshots(): void {
 }
 
 /**
+ * Phase 34-A (#419) — 어닝 캘린더 갱신 스케줄러.
+ * 매일 06:00 KST — 스냅샷과 겹치지 않는 5분 앞 슬롯. 미국장 마감 후 신선.
+ * 부팅 후 첫 실행은 다음 06:00 을 기다림 (부팅 즉시 실행하면 rate limit 부담).
+ */
+export function scheduleEarningsScan(): void {
+  const guard = createCronGuard('어닝 스캔', 5 * 60 * 1000)
+
+  async function runOnce(): Promise<void> {
+    await guard(async () => {
+      const { runEarningsScan } = await import('./earnings/cron')
+      const result = await runEarningsScan()
+      console.log(`[cron] 어닝 스캔 완료: attempted=${result.attempted} ok=${result.ok} failed=${result.failed}`)
+    })
+  }
+
+  cron.schedule('0 6 * * *', () => { void runOnce() }, { timezone: 'Asia/Seoul' })
+
+  // 부팅 즉시 초기 시드 — cache 가 비어 있으면 다음 06:00 KST 까지 대기하는 대신 채움.
+  // 신규 배포 후 최대 24h dead window (모든 earnings_within_days 조건 false) 회피
+  // (self-review P1, #419). scheduleKrxSync 와 동일 패턴 (cron.ts scheduleKrxSync 참고).
+  void (async () => {
+    try {
+      const count = await prisma.earningsCache.count()
+      if (count === 0) {
+        console.log('[cron] EarningsCache empty → 초기 시드 실행')
+        await runOnce()
+      }
+    } catch (error) {
+      console.error('[cron] 어닝 초기 시드 실패:', error)
+    }
+  })()
+
+  console.log('[cron] 어닝 스캔 스케줄러 등록 (매일 06:00 KST)')
+}
+
+/**
  * KRX 종목 리스트 동기화 스케줄러.
  * 매주 월요일 07:00 KST 실행.
  */

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -3,6 +3,7 @@ import {
   evaluateCondition,
   evaluateStrategy,
   requiresTA,
+  daysUntilEarnings,
   type MarketSnapshot,
   type EvaluationContext,
 } from '../evaluator'
@@ -250,6 +251,90 @@ describe('evaluateCondition — v2 holding_status', () => {
   })
 })
 
+describe('daysUntilEarnings (v3 pure, #419) — KST 캘린더 일수', () => {
+  // KST 자정 기준. 2026-01-05 00:00 KST = 2026-01-04 15:00 UTC.
+  const now = new Date('2026-01-04T15:00:00Z')  // KST 2026-01-05 00:00
+
+  it('null / undefined → null', () => {
+    expect(daysUntilEarnings(null, now)).toBeNull()
+    expect(daysUntilEarnings(undefined, now)).toBeNull()
+  })
+
+  it('과거 어닝 (KST 어제) → null', () => {
+    // KST 2026-01-04 12:00 = UTC 2026-01-04 03:00 (now 보다 12h 이전)
+    expect(daysUntilEarnings(new Date('2026-01-04T03:00:00Z'), now)).toBeNull()
+  })
+
+  it('같은 KST 날짜 어닝 → 0', () => {
+    // KST 2026-01-05 15:00 = UTC 2026-01-05 06:00
+    expect(daysUntilEarnings(new Date('2026-01-05T06:00:00Z'), now)).toBe(0)
+  })
+
+  it('내일 (KST 2026-01-06 아무 시각) → 1', () => {
+    // KST 2026-01-06 00:30 = UTC 2026-01-05 15:30
+    expect(daysUntilEarnings(new Date('2026-01-05T15:30:00Z'), now)).toBe(1)
+    // KST 2026-01-06 23:59 = UTC 2026-01-06 14:59
+    expect(daysUntilEarnings(new Date('2026-01-06T14:59:00Z'), now)).toBe(1)
+  })
+
+  it('KST 3일 뒤 어닝 → 3', () => {
+    // KST 2026-01-08 09:00 = UTC 2026-01-08 00:00
+    expect(daysUntilEarnings(new Date('2026-01-08T00:00:00Z'), now)).toBe(3)
+  })
+
+  it('now 가 KST 23:59, 어닝이 다음 KST 00:00 → D-1 (자정 경계)', () => {
+    // now KST 2026-01-05 23:59 = UTC 2026-01-05 14:59
+    const late = new Date('2026-01-05T14:59:00Z')
+    // 어닝 KST 2026-01-06 00:00 = UTC 2026-01-05 15:00
+    expect(daysUntilEarnings(new Date('2026-01-05T15:00:00Z'), late)).toBe(1)
+  })
+})
+
+describe('evaluateCondition — v3 earnings_within_days (#419)', () => {
+  // now = KST 2026-01-05 00:00 = UTC 2026-01-04 15:00
+  const now = new Date('2026-01-04T15:00:00Z')
+  const ctx = makeContext({ now })
+  // KST 날짜 → UTC 00:00 shift (KST 는 UTC-9h). 편의 헬퍼.
+  const kstDate = (y: number, m: number, d: number) => new Date(Date.UTC(y, m - 1, d - 1, 15, 0, 0))
+
+  it('데이터 없음 → false (안전측)', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    expect(evaluateCondition(cond, makeSnapshot({ earnings: null }), ctx)).toBe(false)
+    // earnings undefined 도 같은 처리
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('과거 어닝 → false', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 3) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(false)
+  })
+
+  it('KST 3일 뒤 어닝 (D-3), <=3 → true', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 8) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(true)
+  })
+
+  it('KST 7일 뒤 어닝, <=3 → false', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '<=', value: 3 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 12) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(false)
+  })
+
+  it('KST 7일 뒤 어닝, >=5 → true', () => {
+    const cond: Condition = { type: 'earnings_within_days', operator: '>=', value: 5 }
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 12) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(true)
+  })
+
+  it('value 문자열 → false (validate 통과했더라도 evaluator 방어)', () => {
+    const cond = { type: 'earnings_within_days', operator: '<=', value: '3' } as unknown as Condition
+    const snap = makeSnapshot({ earnings: { nextEarningsDate: kstDate(2026, 1, 8) } })
+    expect(evaluateCondition(cond, snap, ctx)).toBe(false)
+  })
+})
+
 describe('evaluateStrategy', () => {
   const c1: Condition = { type: 'price', operator: '<=', value: 200 }
   const c2: Condition = { type: 'price', operator: '>=', value: 50 }
@@ -306,5 +391,9 @@ describe('requiresTA', () => {
     expect(requiresTA([{ type: 'time_window', operator: 'is', value: '09:00~15:30' }])).toBe(false)
     expect(requiresTA([{ type: 'weekday', operator: 'is', value: ['MON'] }])).toBe(false)
     expect(requiresTA([{ type: 'holding_status', operator: 'is', value: 'HELD' }])).toBe(false)
+  })
+
+  it('v3 earnings_within_days → TA 불필요 (EarningsCache 만 참조)', () => {
+    expect(requiresTA([{ type: 'earnings_within_days', operator: '<=', value: 3 }])).toBe(false)
   })
 })

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateStrategy,
   requiresTA,
   daysUntilEarnings,
+  collectCrossTickers,
   type MarketSnapshot,
   type EvaluationContext,
 } from '../evaluator'
@@ -335,6 +336,141 @@ describe('evaluateCondition — v3 earnings_within_days (#419)', () => {
   })
 })
 
+describe('evaluateCondition — v3 cross_ticker (Phase 34-B / #420)', () => {
+  const ctx = makeContext({ strategyTicker: 'SOXL' })
+
+  it('crossTickers 미주입 → false', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('참조 티커 데이터 없음 → false', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    const c = makeContext({ strategyTicker: 'SOXL', crossTickers: new Map() })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(false)
+  })
+
+  it('SPY change_percent -3 이 -2 이하 → true', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SPY', { price: 400, changePercent: -3 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(true)
+  })
+
+  it('VIX price > 25 (가격 지표) 통과', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    }
+    const c = makeContext({
+      strategyTicker: 'QQQ',
+      crossTickers: new Map([['VIX', { price: 30, changePercent: 10 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(true)
+  })
+
+  it('changePercent 이 null 이면 false', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SPY', { price: 400, changePercent: null }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(false)
+  })
+
+  it('자기 자신 참조 → false (tautology 방지)', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '<=', value: 200,
+      crossTicker: 'SOXL', metric: 'price',
+    }
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SOXL', { price: 100, changePercent: 0 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(false)
+  })
+
+  it('소문자 crossTicker 도 대문자로 정규화하여 조회', () => {
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'vix', metric: 'price',
+    }
+    const c = makeContext({
+      strategyTicker: 'QQQ',
+      crossTickers: new Map([['VIX', { price: 30, changePercent: 10 }]]),
+    })
+    expect(evaluateCondition(cond, makeSnapshot(), c)).toBe(true)
+  })
+
+  it('crossTicker/metric 누락 → false (evaluator 방어)', () => {
+    const c = makeContext({
+      strategyTicker: 'SOXL',
+      crossTickers: new Map([['SPY', { price: 400, changePercent: -3 }]]),
+    })
+    expect(evaluateCondition(
+      { type: 'cross_ticker', operator: '<=', value: 0 } as unknown as Condition,
+      makeSnapshot(), c,
+    )).toBe(false)
+  })
+})
+
+describe('collectCrossTickers (pure, Phase 34-B / #420)', () => {
+  it('여러 전략의 cross_ticker 참조 통합 + 대문자 정규화 + 중복 제거', () => {
+    const strategies = [
+      { ticker: 'SOXL', conditions: [
+        { type: 'cross_ticker', crossTicker: 'spy', metric: 'change_percent' },
+        { type: 'price', value: 50 },
+      ] },
+      { ticker: 'QQQ', conditions: [
+        { type: 'cross_ticker', crossTicker: 'VIX', metric: 'price' },
+        { type: 'cross_ticker', crossTicker: 'SPY', metric: 'change_percent' }, // 중복 (다른 전략)
+      ] },
+    ]
+    expect(collectCrossTickers(strategies)).toEqual(new Set(['SPY', 'VIX']))
+  })
+
+  it('자기 자신 참조는 제외', () => {
+    const strategies = [
+      { ticker: 'SPY', conditions: [
+        { type: 'cross_ticker', crossTicker: 'SPY', metric: 'price' },
+        { type: 'cross_ticker', crossTicker: 'VIX', metric: 'price' },
+      ] },
+    ]
+    expect(collectCrossTickers(strategies)).toEqual(new Set(['VIX']))
+  })
+
+  it('conditions 배열이 아니거나 손상된 조건은 무시', () => {
+    const strategies = [
+      { ticker: 'SOXL', conditions: 'not-an-array' },
+      { ticker: 'QQQ', conditions: [
+        { type: 'cross_ticker' }, // crossTicker 누락
+        { type: 'cross_ticker', crossTicker: '' },
+        null,
+        { type: 'cross_ticker', crossTicker: 'SPY', metric: 'price' },
+      ] },
+    ]
+    expect(collectCrossTickers(strategies)).toEqual(new Set(['SPY']))
+  })
+
+  it('빈 입력 → 빈 Set', () => {
+    expect(collectCrossTickers([])).toEqual(new Set())
+  })
+})
+
 describe('evaluateStrategy', () => {
   const c1: Condition = { type: 'price', operator: '<=', value: 200 }
   const c2: Condition = { type: 'price', operator: '>=', value: 50 }
@@ -395,5 +531,12 @@ describe('requiresTA', () => {
 
   it('v3 earnings_within_days → TA 불필요 (EarningsCache 만 참조)', () => {
     expect(requiresTA([{ type: 'earnings_within_days', operator: '<=', value: 3 }])).toBe(false)
+  })
+
+  it('v3 cross_ticker → TA 불필요 (PriceCache 만 참조)', () => {
+    expect(requiresTA([{
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    }])).toBe(false)
   })
 })

--- a/src/lib/custom-strategy/__tests__/types.test.ts
+++ b/src/lib/custom-strategy/__tests__/types.test.ts
@@ -201,4 +201,50 @@ describe('conditionToString', () => {
       conditionToString({ type: 'holding_status', operator: 'is', value: 'HELD' }),
     ).toBe('holding_status is HELD')
   })
+
+  it('earnings_within_days 정수 (v3)', () => {
+    expect(
+      conditionToString({ type: 'earnings_within_days', operator: '<=', value: 3 }),
+    ).toBe('earnings_within_days <= 3')
+  })
+})
+
+describe('earnings_within_days (v3, Phase 34-A / #419)', () => {
+  it('숫자 연산자 5개 모두 허용, 정수 값', () => {
+    for (const op of ['<', '<=', '>', '>=', '==']) {
+      expect(
+        validateCondition({ type: 'earnings_within_days', operator: op, value: 3 }),
+      ).toBe(true)
+    }
+  })
+
+  it('음수 값 거부 (미래 카운트다운 의미상)', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '>=', value: -1 }),
+    ).toBe(false)
+  })
+
+  it('소수 값 거부 (일 단위 정수만)', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '<=', value: 1.5 }),
+    ).toBe(false)
+  })
+
+  it('is 연산자 거부 (numeric 타입)', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: 'is', value: 3 }),
+    ).toBe(false)
+  })
+
+  it('value 문자열 거부', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '<=', value: '3' }),
+    ).toBe(false)
+  })
+
+  it('0 (오늘 어닝) 허용', () => {
+    expect(
+      validateCondition({ type: 'earnings_within_days', operator: '==', value: 0 }),
+    ).toBe(true)
+  })
 })

--- a/src/lib/custom-strategy/__tests__/types.test.ts
+++ b/src/lib/custom-strategy/__tests__/types.test.ts
@@ -248,3 +248,54 @@ describe('earnings_within_days (v3, Phase 34-A / #419)', () => {
     ).toBe(true)
   })
 })
+
+describe('cross_ticker (v3, Phase 34-B / #420)', () => {
+  it('필수 필드 (crossTicker + metric + operator + value) 모두 있으면 통과', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    })).toBe(true)
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    })).toBe(true)
+  })
+
+  it('crossTicker 누락 → false', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0, metric: 'price',
+    })).toBe(false)
+  })
+
+  it('crossTicker 빈 문자열 → false', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0, crossTicker: '   ', metric: 'price',
+    })).toBe(false)
+  })
+
+  it('metric 화이트리스트 외 → false', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0,
+      crossTicker: 'SPY', metric: 'rsi',
+    })).toBe(false)
+    expect(validateCondition({
+      type: 'cross_ticker', operator: '<=', value: 0, crossTicker: 'SPY',
+    })).toBe(false)
+  })
+
+  it('is 연산자 거부 (numeric 타입)', () => {
+    expect(validateCondition({
+      type: 'cross_ticker', operator: 'is', value: 0,
+      crossTicker: 'SPY', metric: 'price',
+    })).toBe(false)
+  })
+})
+
+describe('conditionToString — cross_ticker', () => {
+  it('SPY.change_percent <= -2 형태', () => {
+    expect(conditionToString({
+      type: 'cross_ticker', operator: '<=', value: -2,
+      crossTicker: 'SPY', metric: 'change_percent',
+    })).toBe('SPY.change_percent <= -2')
+  })
+})

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -15,6 +15,7 @@
 import type { Condition, WeekdayCode } from './types'
 import { TIME_WINDOW_RE } from './types'
 import type { TAReport } from '@/lib/ta/types'
+import { kstDayDiff } from '@/lib/kst-date'
 
 export interface PriceSnapshot {
   price: number
@@ -24,6 +25,11 @@ export interface PriceSnapshot {
 export interface MarketSnapshot {
   price: PriceSnapshot | null
   ta: TAReport | null
+  /**
+   * Phase 34-A (#419): 어닝 캘린더 스냅샷. `earnings_within_days` 조건 평가용.
+   * cron 이 upsert 한 EarningsCache 를 호출자가 주입.
+   */
+  earnings?: { nextEarningsDate: Date | null } | null
 }
 
 /**
@@ -74,6 +80,24 @@ function kstWeekday(now: Date): WeekdayCode {
   const dow = kst.getUTCDay() // 0=Sun, 1=Mon, ...
   const codes: WeekdayCode[] = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
   return codes[dow]
+}
+
+/**
+ * Pure — 다음 어닝까지 남은 KST 캘린더 일수.
+ * 양쪽을 KST 자정으로 정규화한 뒤 계산 → 사용자 인식 ("D-3") 과 정합.
+ *
+ * 예시 (KST):
+ *   - now 07-08 15:00, earnings 07-08 20:00 → 0  (오늘)
+ *   - now 07-08 15:00, earnings 07-09 00:30 → 1  (내일)
+ *   - now 07-08 00:01, earnings 07-11 23:59 → 3  (D-3)
+ *   - now 07-08 23:59, earnings 07-09 00:00 → 1  (자정 넘어감 → D-1)
+ * 이미 지난 어닝 (KST 어제 이전) → `null` → evaluator false.
+ */
+export function daysUntilEarnings(nextEarningsDate: Date | null | undefined, now: Date): number | null {
+  if (!nextEarningsDate) return null
+  const diffDays = kstDayDiff(nextEarningsDate, now)
+  if (diffDays < 0) return null
+  return diffDays
 }
 
 /** "HH:MM~HH:MM" 파싱 → 분 단위 [start, end]. wraparound (end < start) 도 허용. */
@@ -162,6 +186,14 @@ export function evaluateCondition(
       if (cond.value === 'HELD') return isHeld
       if (cond.value === 'NOT_HELD') return !isHeld
       return false
+    }
+    // ── v3 (Phase 34-A #419) —
+    case 'earnings_within_days': {
+      if (typeof cond.value !== 'number') return false
+      const days = daysUntilEarnings(snapshot.earnings?.nextEarningsDate ?? null, context.now)
+      // 데이터 없음 or 과거 어닝만 있음 → false (안전측 — pre-earnings 회피 조건 사용 흐름 상)
+      if (days == null) return false
+      return compareNumeric(days, cond.operator, cond.value)
     }
     default:
       return false

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -43,6 +43,12 @@ export interface EvaluationContext {
   holdings: Set<string>
   /** 평가 대상 티커 — holding_status 판정용 (Strategy.ticker 주입) */
   strategyTicker: string
+  /**
+   * Phase 34-B (#420): 크로스-티커 조건 참조용 스냅샷 맵.
+   * key = 대문자 정규화된 티커. 호출자가 전략들의 모든 crossTicker 를 미리 조회해 주입.
+   * 미주입 or 특정 티커 없음 → cross_ticker 조건 false (안전측).
+   */
+  crossTickers?: Map<string, { price: number; changePercent: number | null }>
 }
 
 /** 지원 조건 타입 중 TA 필요 여부 판단 — 평가 전에 TAReport fetch 여부 결정 */
@@ -195,9 +201,48 @@ export function evaluateCondition(
       if (days == null) return false
       return compareNumeric(days, cond.operator, cond.value)
     }
+    // ── v3 (Phase 34-B #420) —
+    case 'cross_ticker': {
+      if (typeof cond.value !== 'number') return false
+      if (typeof cond.crossTicker !== 'string' || !cond.crossTicker.trim()) return false
+      if (cond.metric !== 'price' && cond.metric !== 'change_percent') return false
+      const target = cond.crossTicker.trim().toUpperCase()
+      // 자기 자신 참조 방지 — 사용자가 실수로 등록해도 무의미한 tautology 회피.
+      if (target === context.strategyTicker) return false
+      const cross = context.crossTickers?.get(target)
+      if (!cross) return false
+      const actual = cond.metric === 'price' ? cross.price : cross.changePercent
+      if (actual == null || !Number.isFinite(actual)) return false
+      return compareNumeric(actual, cond.operator, cond.value)
+    }
     default:
       return false
   }
+}
+
+/**
+ * Pure — 전략 집합에서 참조되는 모든 크로스 티커를 대문자 정규화하여 수집.
+ * 자기 자신 참조 (strategyTicker == crossTicker) 는 evaluator 가 false 처리하지만
+ * 수집 단계에서도 제외해 PriceCache 조회 최적화.
+ */
+export function collectCrossTickers(
+  strategies: Array<{ ticker: string; conditions: unknown }>,
+): Set<string> {
+  const out = new Set<string>()
+  for (const s of strategies) {
+    const self = s.ticker.trim().toUpperCase()
+    const raw = Array.isArray(s.conditions) ? (s.conditions as unknown[]) : []
+    for (const c of raw) {
+      if (!c || typeof c !== 'object') continue
+      const cond = c as { type?: string; crossTicker?: string }
+      if (cond.type !== 'cross_ticker') continue
+      if (typeof cond.crossTicker !== 'string') continue
+      const t = cond.crossTicker.trim().toUpperCase()
+      if (!t || t === self) continue
+      out.add(t)
+    }
+  }
+  return out
 }
 
 export interface EvaluationResult {

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -26,6 +26,9 @@ const PROMPT_HEADER = `
 - weekday (배열, 요일 코드 ["MON","TUE","WED","THU","FRI","SAT","SUN"] 중 부분집합)
 - holding_status (문자열, "HELD" 또는 "NOT_HELD" — 사용자가 해당 ticker 보유 여부)
 
+## 지원 조건 타입 (v3 — 어닝 캘린더)
+- earnings_within_days (숫자 정수, 0 이상, 다음 어닝까지 남은 일수 — Yahoo Finance 캘린더)
+
 ## 연산자
 - 숫자 타입: < <= > >= ==
 - 문자열/배열 타입: is (전용)
@@ -62,9 +65,20 @@ const PROMPT_HEADER = `
     {"type":"holding_status","operator":"is","value":"HELD"}
   ], "logic":"AND"}
 
+## v3 예시 (어닝 캘린더)
+- "AAPL 어닝 3일 이내면 알림 (매수 회피용)" →
+  {"conditions": [
+    {"type":"earnings_within_days","operator":"<=","value":3}
+  ], "logic":"AND"}
+- "NVDA RSI 30 이하 + 어닝 7일 이상 남았을 때만 진입" →
+  {"conditions": [
+    {"type":"rsi","operator":"<=","value":30},
+    {"type":"earnings_within_days","operator":">=","value":7}
+  ], "logic":"AND"}
+
 ## 규칙
 - 지원 타입 외 조건 요구되면 { "error": "지원 안함: ..." } 로만 응답
-- 뉴스/펀더멘털/어닝/크로스-티커 조건은 미지원 (지원 타입 외 로 처리)
+- 뉴스/펀더멘털/크로스-티커 조건은 미지원 (지원 타입 외 로 처리). 어닝은 v3 로 지원 시작.
 - ticker 알 수 없으면 { "error": "ticker 를 명확히 지정해주세요" }
 - 사용자가 시간대를 "미국장" / "한국장" 등으로 지칭하면 KST 로 환산 (미국장 = 대략 22:30~05:00 KST DST 무관 단순화, 한국장 = 09:00~15:30)
 

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -26,8 +26,13 @@ const PROMPT_HEADER = `
 - weekday (배열, 요일 코드 ["MON","TUE","WED","THU","FRI","SAT","SUN"] 중 부분집합)
 - holding_status (문자열, "HELD" 또는 "NOT_HELD" — 사용자가 해당 ticker 보유 여부)
 
-## 지원 조건 타입 (v3 — 어닝 캘린더)
+## 지원 조건 타입 (v3 — 어닝 캘린더 / 크로스-티커)
 - earnings_within_days (숫자 정수, 0 이상, 다음 어닝까지 남은 일수 — Yahoo Finance 캘린더)
+- cross_ticker — 다른 티커의 price / change_percent 비교. 필수 필드:
+  - crossTicker: 참조 티커 (대문자 정규화). 자기 자신 참조 금지
+  - metric: "price" 또는 "change_percent"
+  - operator: 숫자 연산자 (< / <= / > / >= / ==)
+  - value: 숫자
 
 ## 연산자
 - 숫자 타입: < <= > >= ==
@@ -76,9 +81,18 @@ const PROMPT_HEADER = `
     {"type":"earnings_within_days","operator":">=","value":7}
   ], "logic":"AND"}
 
+## v3 예시 (크로스-티커)
+- "SPY -2% 이하 하락한 날에는 SOXL 진입 회피 → SOXL 매수 조건에 SPY 안 떨어진 조건 추가"
+  ticker: "SOXL", conditions: [
+    {"type":"cross_ticker","operator":">","value":-2,"crossTicker":"SPY","metric":"change_percent"}
+  ], "logic":"AND"
+- "VIX 25 초과 시 QQQ 콜 스캘핑" — ticker: "QQQ", conditions: [
+    {"type":"cross_ticker","operator":">","value":25,"crossTicker":"VIX","metric":"price"}
+  ]
+
 ## 규칙
 - 지원 타입 외 조건 요구되면 { "error": "지원 안함: ..." } 로만 응답
-- 뉴스/펀더멘털/크로스-티커 조건은 미지원 (지원 타입 외 로 처리). 어닝은 v3 로 지원 시작.
+- 뉴스/펀더멘털 조건은 미지원 (지원 타입 외 로 처리). 어닝 / 크로스-티커는 v3 로 지원 시작.
 - ticker 알 수 없으면 { "error": "ticker 를 명확히 지정해주세요" }
 - 사용자가 시간대를 "미국장" / "한국장" 등으로 지칭하면 KST 로 환산 (미국장 = 대략 22:30~05:00 KST DST 무관 단순화, 한국장 = 09:00~15:30)
 

--- a/src/lib/custom-strategy/types.ts
+++ b/src/lib/custom-strategy/types.ts
@@ -17,6 +17,8 @@ export type ConditionType =
   | 'time_window'     // KST 시각 범위 필터 (HH:MM~HH:MM)
   | 'weekday'         // KST 요일 필터 (MON/TUE/…)
   | 'holding_status'  // 사용자 보유 여부
+  // v3 additions (Phase 34) —
+  | 'earnings_within_days'  // 다음 어닝까지 남은 일수 (data 없거나 과거만 있으면 false)
 
 export type Operator = '<' | '<=' | '>' | '>=' | '==' | 'is'
 
@@ -60,7 +62,7 @@ const VALID_WEEKDAYS_SET = new Set<WeekdayCode>(VALID_WEEKDAYS)
 /** HH:MM~HH:MM 포맷 (00~23:00~59). 자정 wraparound 는 evaluator 가 판정. */
 export const TIME_WINDOW_RE = /^([01]\d|2[0-3]):([0-5]\d)~([01]\d|2[0-3]):([0-5]\d)$/
 
-const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct'])
+const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days'])
 const SINGLE_STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position', 'holding_status'])
 const NUMERIC_OPS = new Set<Operator>(['<', '<=', '>', '>=', '=='])
 const IS_OP: Operator = 'is'
@@ -71,6 +73,7 @@ const VALID_TIMEFRAMES = new Set<Timeframe>(['1d', '5d', '20d'])
 const VALID_TYPES = new Set<ConditionType>([
   'price', 'rsi', 'macd_signal', 'sma_cross', 'bb_position', 'change_pct',
   'time_window', 'weekday', 'holding_status',
+  'earnings_within_days',
 ])
 
 /** Condition 유효성 검증 — evaluator 진입 전 방어 */
@@ -87,6 +90,10 @@ export function validateCondition(c: unknown): c is Condition {
     if (type === 'change_pct') {
       // timeframe 필수 — evaluator 폴백을 방지해 조건 의도가 명확해지도록
       if (!VALID_TIMEFRAMES.has(cond.timeframe as Timeframe)) return false
+    }
+    if (type === 'earnings_within_days') {
+      // 어닝 일수는 정수 + 음수는 무의미 (미래 카운트다운). 소수/음수 거부.
+      if (!Number.isInteger(cond.value) || cond.value < 0) return false
     }
     return true
   }

--- a/src/lib/custom-strategy/types.ts
+++ b/src/lib/custom-strategy/types.ts
@@ -19,11 +19,15 @@ export type ConditionType =
   | 'holding_status'  // 사용자 보유 여부
   // v3 additions (Phase 34) —
   | 'earnings_within_days'  // 다음 어닝까지 남은 일수 (data 없거나 과거만 있으면 false)
+  | 'cross_ticker'          // 다른 티커의 price/changePercent 조건 (SPY, VIX 등 벤치마크 게이트)
 
 export type Operator = '<' | '<=' | '>' | '>=' | '==' | 'is'
 
 /** timeframe 지원 조건 타입 (change_pct 전용) */
 export type Timeframe = '1d' | '5d' | '20d'
+
+/** cross_ticker 조건에서 비교할 지표 */
+export type CrossTickerMetric = 'price' | 'change_percent'
 
 /** 요일 코드 (KST 기준) */
 export type WeekdayCode = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN'
@@ -34,6 +38,10 @@ export interface Condition {
   /** number (수치 조건) | string (단일 상태) | WeekdayCode[] (weekday 배열) */
   value: number | string | WeekdayCode[]
   timeframe?: Timeframe
+  /** cross_ticker 전용 — 참조할 티커 (대문자 정규화) */
+  crossTicker?: string
+  /** cross_ticker 전용 — 어떤 지표와 비교할지 */
+  metric?: CrossTickerMetric
 }
 
 export type LogicOp = 'AND' | 'OR'
@@ -62,7 +70,8 @@ const VALID_WEEKDAYS_SET = new Set<WeekdayCode>(VALID_WEEKDAYS)
 /** HH:MM~HH:MM 포맷 (00~23:00~59). 자정 wraparound 는 evaluator 가 판정. */
 export const TIME_WINDOW_RE = /^([01]\d|2[0-3]):([0-5]\d)~([01]\d|2[0-3]):([0-5]\d)$/
 
-const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days'])
+const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days', 'cross_ticker'])
+const VALID_CROSS_METRICS = new Set<CrossTickerMetric>(['price', 'change_percent'])
 const SINGLE_STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position', 'holding_status'])
 const NUMERIC_OPS = new Set<Operator>(['<', '<=', '>', '>=', '=='])
 const IS_OP: Operator = 'is'
@@ -73,7 +82,7 @@ const VALID_TIMEFRAMES = new Set<Timeframe>(['1d', '5d', '20d'])
 const VALID_TYPES = new Set<ConditionType>([
   'price', 'rsi', 'macd_signal', 'sma_cross', 'bb_position', 'change_pct',
   'time_window', 'weekday', 'holding_status',
-  'earnings_within_days',
+  'earnings_within_days', 'cross_ticker',
 ])
 
 /** Condition 유효성 검증 — evaluator 진입 전 방어 */
@@ -94,6 +103,12 @@ export function validateCondition(c: unknown): c is Condition {
     if (type === 'earnings_within_days') {
       // 어닝 일수는 정수 + 음수는 무의미 (미래 카운트다운). 소수/음수 거부.
       if (!Number.isInteger(cond.value) || cond.value < 0) return false
+    }
+    if (type === 'cross_ticker') {
+      // crossTicker: 비어있지 않은 문자열 (정규화는 evaluator 가 처리 — 원본 보존).
+      if (typeof cond.crossTicker !== 'string' || cond.crossTicker.trim() === '') return false
+      // metric: 화이트리스트
+      if (!VALID_CROSS_METRICS.has(cond.metric as CrossTickerMetric)) return false
     }
     return true
   }
@@ -143,6 +158,9 @@ export function conditionToString(c: Condition): string {
   const timeframe = c.timeframe ? `(${c.timeframe})` : ''
   if (c.type === 'weekday' && Array.isArray(c.value)) {
     return `weekday ${c.operator} [${c.value.join(',')}]`
+  }
+  if (c.type === 'cross_ticker') {
+    return `${c.crossTicker ?? '?'}.${c.metric ?? '?'} ${c.operator} ${c.value}`
   }
   return `${c.type}${timeframe} ${c.operator} ${c.value}`
 }

--- a/src/lib/earnings/__tests__/cache.test.ts
+++ b/src/lib/earnings/__tests__/cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    earningsCache: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}))
+
+import { getEarnings, getEarningsMany, upsertEarningsResults } from '../cache'
+
+describe('getEarnings', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.findUnique).mockReset()
+  })
+
+  it('row 있음 → snapshot 반환', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const date = new Date('2026-02-01T00:00:00Z')
+    vi.mocked(prisma.earningsCache.findUnique).mockResolvedValueOnce({
+      ticker: 'AAPL',
+      nextEarningsDate: date,
+      lastFetchedAt: new Date(),
+      updatedAt: new Date(),
+    } as never)
+
+    const r = await getEarnings('AAPL')
+    expect(r?.ticker).toBe('AAPL')
+    expect(r?.nextEarningsDate).toEqual(date)
+  })
+
+  it('row 없음 → null', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.findUnique).mockResolvedValueOnce(null)
+    expect(await getEarnings('UNKNOWN')).toBeNull()
+  })
+})
+
+describe('getEarningsMany', () => {
+  it('빈 배열 입력 → 빈 Map, findMany 호출 없음', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.findMany).mockReset()
+    const r = await getEarningsMany([])
+    expect(r.size).toBe(0)
+    expect(prisma.earningsCache.findMany).not.toHaveBeenCalled()
+  })
+
+  it('여러 티커 조회 → ticker 별 Map', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const d1 = new Date('2026-02-01T00:00:00Z')
+    const d2 = new Date('2026-03-01T00:00:00Z')
+    vi.mocked(prisma.earningsCache.findMany).mockResolvedValueOnce([
+      { ticker: 'AAPL', nextEarningsDate: d1, lastFetchedAt: new Date(), updatedAt: new Date() },
+      { ticker: 'MSFT', nextEarningsDate: d2, lastFetchedAt: new Date(), updatedAt: new Date() },
+    ] as never)
+
+    const r = await getEarningsMany(['AAPL', 'MSFT'])
+    expect(r.get('AAPL')?.nextEarningsDate).toEqual(d1)
+    expect(r.get('MSFT')?.nextEarningsDate).toEqual(d2)
+  })
+})
+
+describe('upsertEarningsResults', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.upsert).mockReset()
+    vi.mocked(prisma.earningsCache.updateMany).mockReset()
+  })
+
+  it('성공 결과 → upsert 호출, ok 카운트', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.upsert).mockResolvedValue({} as never)
+
+    const r = await upsertEarningsResults([
+      { ticker: 'AAPL', nextEarningsDate: new Date('2026-02-01T00:00:00Z') },
+      { ticker: 'MSFT', nextEarningsDate: null },
+    ])
+    expect(r).toEqual({ ok: 2, failed: 0 })
+    expect(prisma.earningsCache.upsert).toHaveBeenCalledTimes(2)
+  })
+
+  it('error 결과 → updateMany 로 lastFetchedAt 만 갱신, failed 카운트', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.updateMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    const r = await upsertEarningsResults([
+      { ticker: 'BAD', nextEarningsDate: null, error: '404' },
+    ])
+    expect(r).toEqual({ ok: 0, failed: 1 })
+    expect(prisma.earningsCache.upsert).not.toHaveBeenCalled()
+    expect(prisma.earningsCache.updateMany).toHaveBeenCalledWith({
+      where: { ticker: 'BAD' },
+      data: expect.objectContaining({ lastFetchedAt: expect.any(Date) }),
+    })
+  })
+
+  it('성공 + 실패 혼합', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.earningsCache.upsert).mockResolvedValue({} as never)
+    vi.mocked(prisma.earningsCache.updateMany).mockResolvedValue({ count: 0 } as never)
+
+    const r = await upsertEarningsResults([
+      { ticker: 'AAPL', nextEarningsDate: new Date() },
+      { ticker: 'BAD', nextEarningsDate: null, error: 'timeout' },
+    ])
+    expect(r).toEqual({ ok: 1, failed: 1 })
+  })
+})

--- a/src/lib/earnings/__tests__/cron.test.ts
+++ b/src/lib/earnings/__tests__/cron.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    customStrategy: { findMany: vi.fn() },
+    watchlist: { findMany: vi.fn() },
+    holding: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('../fetcher', () => ({
+  fetchEarningsMany: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  upsertEarningsResults: vi.fn(),
+}))
+
+import { gatherTargetTickers, runEarningsScan } from '../cron'
+
+describe('gatherTargetTickers', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockReset()
+    vi.mocked(prisma.watchlist.findMany).mockReset()
+    vi.mocked(prisma.holding.findMany).mockReset()
+  })
+
+  it('3소스 union, 중복 제거, 알파벳 정렬', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([
+      { ticker: 'AAPL' }, { ticker: 'MSFT' },
+    ] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([
+      { ticker: 'MSFT' }, { ticker: 'NVDA' },
+    ] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([
+      { ticker: 'AAPL' }, { ticker: 'TSLA' },
+    ] as never)
+
+    const result = await gatherTargetTickers()
+    expect(result).toEqual(['AAPL', 'MSFT', 'NVDA', 'TSLA'])
+  })
+
+  it('3소스 모두 비면 빈 배열', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([] as never)
+
+    expect(await gatherTargetTickers()).toEqual([])
+  })
+})
+
+describe('runEarningsScan', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockReset()
+    vi.mocked(prisma.watchlist.findMany).mockReset()
+    vi.mocked(prisma.holding.findMany).mockReset()
+    const { fetchEarningsMany } = await import('../fetcher')
+    const { upsertEarningsResults } = await import('../cache')
+    vi.mocked(fetchEarningsMany).mockReset()
+    vi.mocked(upsertEarningsResults).mockReset()
+  })
+
+  it('타깃 없으면 fetch/upsert 스킵', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([] as never)
+
+    const { fetchEarningsMany } = await import('../fetcher')
+    const { upsertEarningsResults } = await import('../cache')
+
+    const r = await runEarningsScan()
+    expect(r).toEqual({ attempted: 0, ok: 0, failed: 0 })
+    expect(fetchEarningsMany).not.toHaveBeenCalled()
+    expect(upsertEarningsResults).not.toHaveBeenCalled()
+  })
+
+  it('fetch 결과를 upsert 로 전달, 요약 반환', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.customStrategy.findMany).mockResolvedValueOnce([{ ticker: 'AAPL' }] as never)
+    vi.mocked(prisma.watchlist.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.holding.findMany).mockResolvedValueOnce([] as never)
+
+    const { fetchEarningsMany } = await import('../fetcher')
+    const { upsertEarningsResults } = await import('../cache')
+    vi.mocked(fetchEarningsMany).mockResolvedValueOnce([
+      { ticker: 'AAPL', nextEarningsDate: new Date('2026-02-01T00:00:00Z') },
+    ])
+    vi.mocked(upsertEarningsResults).mockResolvedValueOnce({ ok: 1, failed: 0 })
+
+    const r = await runEarningsScan()
+    expect(r).toEqual({ attempted: 1, ok: 1, failed: 0 })
+    expect(fetchEarningsMany).toHaveBeenCalledWith(['AAPL'], 5)
+  })
+})

--- a/src/lib/earnings/__tests__/fetcher.test.ts
+++ b/src/lib/earnings/__tests__/fetcher.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { quoteSummaryMock } = vi.hoisted(() => ({ quoteSummaryMock: vi.fn() }))
+
+vi.mock('yahoo-finance2', () => {
+  class YahooFinance {
+    quoteSummary = quoteSummaryMock
+  }
+  return { default: YahooFinance }
+})
+
+import { fetchEarnings, fetchEarningsMany } from '../fetcher'
+
+const FIXED_NOW = Date.parse('2026-07-08T00:00:00Z')
+
+beforeEach(() => {
+  quoteSummaryMock.mockReset()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(FIXED_NOW))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('fetchEarnings', () => {
+  it('array of ISO strings → 미래 중 가장 이른 date 반환', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2026-07-30T20:00:00.000Z', '2026-10-30T20:00:00.000Z'] },
+      },
+    })
+    const r = await fetchEarnings('AAPL')
+    expect(r.ticker).toBe('AAPL')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-07-30T20:00:00.000Z')
+    expect(r.error).toBeUndefined()
+  })
+
+  it('array of Date 인스턴스 도 파싱', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: [new Date('2026-08-01T20:00:00Z')] },
+      },
+    })
+    const r = await fetchEarnings('MSFT')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-08-01T20:00:00.000Z')
+  })
+
+  it('단일 Date (배열 아님) 도 정규화하여 파싱', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: new Date('2026-09-01T00:00:00Z') },
+      },
+    })
+    const r = await fetchEarnings('GOOG')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-09-01T00:00:00.000Z')
+  })
+
+  it('과거 date 만 있으면 nextEarningsDate = null (미래 없음)', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2025-01-01T00:00:00Z', '2026-06-01T00:00:00Z'] },
+      },
+    })
+    const r = await fetchEarnings('OLD')
+    expect(r.nextEarningsDate).toBeNull()
+    expect(r.error).toBeUndefined()
+  })
+
+  it('어닝 UTC 자정 (=KST 09:00) 이고 스캔이 같은 KST 날 오후 → 놓치지 않음 (Codex #426 P2)', async () => {
+    // FIXED_NOW = 2026-07-08T00:00:00Z (KST 07-08 09:00) — 오전. 어닝을 이후 시간대로.
+    // KST 07-08 스캔이 KST 07-08 오후에 실행되고, 어닝 timestamp 가 그 스캔 시각보다 이전이지만
+    // 같은 KST 날짜 이면 유지되어야 함.
+    vi.setSystemTime(new Date('2026-07-08T05:00:00Z')) // KST 14:00
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2026-07-08T00:00:00Z'] }, // KST 09:00 (5h 이전 raw)
+      },
+    })
+    const r = await fetchEarnings('AAPL')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-07-08T00:00:00.000Z')
+  })
+
+  it('KST 어제로 넘어간 어닝은 제외', async () => {
+    vi.setSystemTime(new Date('2026-07-09T05:00:00Z')) // KST 07-09 14:00
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['2026-07-07T15:00:00Z'] }, // KST 07-08 00:00 (어제)
+      },
+    })
+    const r = await fetchEarnings('AAPL')
+    expect(r.nextEarningsDate).toBeNull()
+  })
+
+  it('과거 + 미래 혼합 → 미래 중 가장 이른 것', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: [
+          '2026-06-01T00:00:00Z',            // 과거
+          '2026-10-01T00:00:00Z',            // 미래
+          '2026-07-30T20:00:00Z',            // 미래 (더 가까움)
+        ] },
+      },
+    })
+    const r = await fetchEarnings('MIX')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-07-30T20:00:00.000Z')
+  })
+
+  it('calendarEvents 자체가 없어도 crash X → null 반환', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({})
+    const r = await fetchEarnings('NONE')
+    expect(r.nextEarningsDate).toBeNull()
+    expect(r.error).toBeUndefined()
+  })
+
+  it('parseable date 가 아닌 문자열 skip', async () => {
+    quoteSummaryMock.mockResolvedValueOnce({
+      calendarEvents: {
+        earnings: { earningsDate: ['not-a-date', '2026-08-15T00:00:00Z'] },
+      },
+    })
+    const r = await fetchEarnings('BAD')
+    expect(r.nextEarningsDate?.toISOString()).toBe('2026-08-15T00:00:00.000Z')
+  })
+
+  it('quoteSummary 가 throw → error 필드로 반환 (예외 전파 X)', async () => {
+    quoteSummaryMock.mockRejectedValueOnce(new Error('rate limit'))
+    const r = await fetchEarnings('FAIL')
+    expect(r.ticker).toBe('FAIL')
+    expect(r.nextEarningsDate).toBeNull()
+    expect(r.error).toContain('rate limit')
+  })
+})
+
+describe('fetchEarningsMany', () => {
+  it('여러 티커 순회, 각 결과 반환 (실패 포함)', async () => {
+    quoteSummaryMock
+      .mockResolvedValueOnce({
+        calendarEvents: { earnings: { earningsDate: ['2026-08-01T00:00:00Z'] } },
+      })
+      .mockRejectedValueOnce(new Error('404'))
+      .mockResolvedValueOnce({
+        calendarEvents: { earnings: { earningsDate: ['2026-09-01T00:00:00Z'] } },
+      })
+
+    const results = await fetchEarningsMany(['A', 'B', 'C'], 2)
+    expect(results).toHaveLength(3)
+    const byTicker = Object.fromEntries(results.map((r) => [r.ticker, r]))
+    expect(byTicker.A.nextEarningsDate?.toISOString()).toBe('2026-08-01T00:00:00.000Z')
+    expect(byTicker.B.error).toContain('404')
+    expect(byTicker.C.nextEarningsDate?.toISOString()).toBe('2026-09-01T00:00:00.000Z')
+  })
+
+  it('빈 tickers → 빈 배열, quoteSummary 호출 없음', async () => {
+    const results = await fetchEarningsMany([], 5)
+    expect(results).toEqual([])
+    expect(quoteSummaryMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/earnings/cache.ts
+++ b/src/lib/earnings/cache.ts
@@ -1,0 +1,79 @@
+/**
+ * Phase 34-A (#419) — EarningsCache 접근 헬퍼.
+ */
+
+import { prisma } from '@/lib/prisma'
+import type { EarningsFetchResult } from './fetcher'
+
+export interface EarningsSnapshot {
+  ticker: string
+  nextEarningsDate: Date | null
+  lastFetchedAt: Date
+}
+
+export async function getEarnings(ticker: string): Promise<EarningsSnapshot | null> {
+  const row = await prisma.earningsCache.findUnique({ where: { ticker } })
+  if (!row) return null
+  return {
+    ticker: row.ticker,
+    nextEarningsDate: row.nextEarningsDate,
+    lastFetchedAt: row.lastFetchedAt,
+  }
+}
+
+export async function getEarningsMany(tickers: string[]): Promise<Map<string, EarningsSnapshot>> {
+  if (tickers.length === 0) return new Map()
+  const rows = await prisma.earningsCache.findMany({
+    where: { ticker: { in: tickers } },
+  })
+  return new Map(rows.map((r) => [
+    r.ticker,
+    { ticker: r.ticker, nextEarningsDate: r.nextEarningsDate, lastFetchedAt: r.lastFetchedAt },
+  ]))
+}
+
+/**
+ * fetcher 결과를 upsert. 실패한 티커 (error 있음) 는 nextEarningsDate 를
+ * 이전 값 유지 (best-effort — 일시적 네트워크 오류로 캐시 무효화 방지).
+ * 성공한 티커는 nextEarningsDate 를 새 값으로 갱신 (null 도 유효한 성공값).
+ */
+export async function upsertEarningsResults(results: EarningsFetchResult[]): Promise<{
+  ok: number
+  failed: number
+}> {
+  let ok = 0
+  let failed = 0
+  for (const r of results) {
+    if (r.error) {
+      failed++
+      // 실패 시엔 lastFetchedAt 만 업데이트 (row 없으면 새로 생성 X — noise 방지)
+      try {
+        await prisma.earningsCache.updateMany({
+          where: { ticker: r.ticker },
+          data: { lastFetchedAt: new Date() },
+        })
+      } catch {
+        // ignore
+      }
+      continue
+    }
+    ok++
+    try {
+      await prisma.earningsCache.upsert({
+        where: { ticker: r.ticker },
+        create: {
+          ticker: r.ticker,
+          nextEarningsDate: r.nextEarningsDate,
+          lastFetchedAt: new Date(),
+        },
+        update: {
+          nextEarningsDate: r.nextEarningsDate,
+          lastFetchedAt: new Date(),
+        },
+      })
+    } catch (error) {
+      console.error(`[earnings/cache] upsert 실패 (${r.ticker}):`, error)
+    }
+  }
+  return { ok, failed }
+}

--- a/src/lib/earnings/cron.ts
+++ b/src/lib/earnings/cron.ts
@@ -1,0 +1,50 @@
+/**
+ * Phase 34-A (#419) — 어닝 캘린더 갱신 cron.
+ * 매일 KST 06:00 (미국장 마감 후, 한국장 시작 전).
+ * 대상 = 활성 CustomStrategy 티커 ∪ Watchlist ∪ 보유 종목 (shares > 0).
+ */
+
+import { prisma } from '@/lib/prisma'
+import { fetchEarningsMany } from './fetcher'
+import { upsertEarningsResults } from './cache'
+
+/**
+ * DB 에서 대상 티커 3소스 조회 → 중복 제거된 정렬 배열 반환 (테스트 가능하도록 export).
+ * concurrency 를 유지하기 위해 안정된 순서 (알파벳순) 로 반환.
+ */
+export async function gatherTargetTickers(): Promise<string[]> {
+  const [strategies, watchlist, holdings] = await Promise.all([
+    prisma.customStrategy.findMany({
+      where: { isActive: true },
+      select: { ticker: true },
+    }),
+    prisma.watchlist.findMany({ select: { ticker: true } }),
+    prisma.holding.findMany({
+      where: { shares: { gt: 0 } },
+      select: { ticker: true },
+      distinct: ['ticker'],
+    }),
+  ])
+
+  const set = new Set<string>()
+  for (const row of strategies) set.add(row.ticker)
+  for (const row of watchlist) set.add(row.ticker)
+  for (const row of holdings) set.add(row.ticker)
+  return Array.from(set).sort()
+}
+
+/**
+ * 한 번의 어닝 스캔 실행 — 대상 티커 수집 → fetch → upsert.
+ * 결과 요약을 반환 (로그 및 테스트용).
+ */
+export async function runEarningsScan(): Promise<{
+  attempted: number
+  ok: number
+  failed: number
+}> {
+  const tickers = await gatherTargetTickers()
+  if (tickers.length === 0) return { attempted: 0, ok: 0, failed: 0 }
+  const results = await fetchEarningsMany(tickers, 5)
+  const { ok, failed } = await upsertEarningsResults(results)
+  return { attempted: tickers.length, ok, failed }
+}

--- a/src/lib/earnings/fetcher.ts
+++ b/src/lib/earnings/fetcher.ts
@@ -1,0 +1,70 @@
+/**
+ * Phase 34-A (#419) — 어닝 캘린더 fetcher.
+ * yahoo-finance2 `quoteSummary(ticker, { modules: ['calendarEvents'] })` 사용.
+ * 무료. 미국주 위주 — 한국 종목은 대부분 미지원 (nextEarningsDate=null 로 그레이스풀).
+ */
+
+import YahooFinance from 'yahoo-finance2'
+import { isSameOrFutureKstDay } from '@/lib/kst-date'
+
+const yahooFinance = new YahooFinance()
+
+export interface EarningsFetchResult {
+  ticker: string
+  nextEarningsDate: Date | null
+  error?: string
+}
+
+/**
+ * 단일 티커 어닝 조회. 실패해도 예외 던지지 않고 error 필드로 반환.
+ * 성공 시 다음 예정 어닝 중 가장 가까운 날짜를 반환.
+ */
+export async function fetchEarnings(ticker: string): Promise<EarningsFetchResult> {
+  try {
+    const result = await yahooFinance.quoteSummary(ticker, {
+      modules: ['calendarEvents'],
+    })
+    const raw = result?.calendarEvents?.earnings?.earningsDate
+    const dates = Array.isArray(raw) ? raw : raw ? [raw] : []
+    const parsed = dates
+      .map((d) => (d instanceof Date ? d : new Date(d as unknown as string)))
+      .filter((d) => !Number.isNaN(d.getTime()))
+      .sort((a, b) => a.getTime() - b.getTime())
+
+    // 다음 어닝 = KST 캘린더 기준 오늘 이후 중 가장 이른 것.
+    // Codex #426 P2: 원 코드가 raw timestamp (`>= Date.now()`) 로 비교 →
+    // "2026-07-30T00:00Z" (=KST 07-30 09:00) 어닝이 KST 07-30 오후 스캔에서 이미 지난 것으로
+    // 판정 → cache null → evaluator (KST 자정 정규화) 는 D-0 로 취급하려 하지만 nextEarningsDate 가
+    // 이미 null 이라 조건 false. KST 자정 기준으로 두면 evaluator 와 정합.
+    const nowDate = new Date()
+    const nextEarningsDate = parsed.find((d) => isSameOrFutureKstDay(d, nowDate)) ?? null
+
+    return { ticker, nextEarningsDate }
+  } catch (error) {
+    return {
+      ticker,
+      nextEarningsDate: null,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * 여러 티커 병렬 조회 (concurrency 제한). yahoo API 부담 방지.
+ */
+export async function fetchEarningsMany(
+  tickers: string[],
+  concurrency = 5,
+): Promise<EarningsFetchResult[]> {
+  const results: EarningsFetchResult[] = []
+  const queue = [...tickers]
+  const workers = Array.from({ length: Math.min(concurrency, tickers.length) }, async () => {
+    while (queue.length > 0) {
+      const t = queue.shift()
+      if (!t) return
+      results.push(await fetchEarnings(t))
+    }
+  })
+  await Promise.all(workers)
+  return results
+}

--- a/src/lib/kst-date.ts
+++ b/src/lib/kst-date.ts
@@ -1,0 +1,33 @@
+/**
+ * KST 캘린더 일수 유틸 (pure).
+ *
+ * MyFinance 는 여러 곳 (evaluator earnings, fetcher, cron 등) 에서 "KST 기준 오늘·같은 날"
+ * 판정을 하며 이들이 raw UTC 시각으로 나뉘어 있으면 경계 조건에서 불일치가 발생 (Codex #426 P2).
+ * → 이 파일 하나로 통일.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+
+/**
+ * `d` 가 속한 KST 캘린더 일의 자정 (KST 00:00) 을 UTC 타임스탬프 (ms) 로 반환.
+ * 두 날짜의 KST 캘린더 일수 차이는 `(kstMidnightUtc(a) - kstMidnightUtc(b)) / DAY_MS`.
+ */
+export function kstMidnightUtc(d: Date): number {
+  const shifted = d.getTime() + KST_OFFSET_MS
+  const day = Math.floor(shifted / DAY_MS)
+  // shift 공간의 자정을 다시 실제 UTC 로 되돌림 (KST 00:00 = UTC 전날 15:00).
+  return day * DAY_MS - KST_OFFSET_MS
+}
+
+/** `d` 가 속한 KST 캘린더 일이 `ref` 의 KST 캘린더 일 이후인지 (같은 날 포함). */
+export function isSameOrFutureKstDay(d: Date, ref: Date): boolean {
+  return kstMidnightUtc(d) >= kstMidnightUtc(ref)
+}
+
+/**
+ * 두 시각의 KST 캘린더 일수 차이 (`d - ref`). 정수. `d` 가 미래면 양수, 과거면 음수.
+ */
+export function kstDayDiff(d: Date, ref: Date): number {
+  return Math.round((kstMidnightUtc(d) - kstMidnightUtc(ref)) / DAY_MS)
+}

--- a/src/lib/mcp-logs/__tests__/constants.test.ts
+++ b/src/lib/mcp-logs/__tests__/constants.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates } from '../constants'
+
+describe('KNOWN_MSGS', () => {
+  it('실제 서버에서 emit 되는 모든 msg 를 포함 (Codex #425 P2 회귀 방지)', () => {
+    // src/mcp/server.ts + src/mcp/logger.ts 에서 logger.* (…, 'msg_name') 로 emit 되는 값.
+    // 여기 목록에서 빠지면 대시보드 필터가 400 을 던져 사용자가 해당 라인을 못 찾음.
+    const emitted = [
+      'tool_call',
+      'tool_call_reported_error',
+      'tool_call_sdk_error',
+      'tool_call_failed',
+      'sdk_error',
+      'transport_ready',
+      'http_request',
+      'http_request_error',
+      'http_server_error',
+      'session_initialized',
+      'session_closed',
+      'session_sweep',
+      'transport_close_error',
+      'shutdown_started',
+      'http_server_closed',
+      'force_exit_timeout',
+      'server_fatal',
+      'uncaught_exception',
+      'unhandled_rejection',
+    ]
+    const known = new Set<string>(KNOWN_MSGS)
+    for (const m of emitted) {
+      expect(known.has(m), `KNOWN_MSGS missing "${m}"`).toBe(true)
+    }
+  })
+
+  it('MSG_LABELS 가 KNOWN_MSGS 모두를 커버', () => {
+    for (const m of KNOWN_MSGS) {
+      expect(MSG_LABELS[m]).toBeDefined()
+    }
+  })
+
+  it('LEVEL_ORDER 는 fatal → trace 내림차순 (심각도)', () => {
+    expect(LEVEL_ORDER).toEqual(['fatal', 'error', 'warn', 'info', 'debug', 'trace'])
+  })
+})
+
+describe('recentLogDates', () => {
+  it('N=7 → 오늘부터 6일 전까지 7개 (KST 기준)', () => {
+    // now = 2026-07-08 UTC 00:00 → KST 09:00 → 2026-07-08 for day 0
+    const now = Date.parse('2026-07-08T00:00:00Z')
+    const dates = recentLogDates(7, now)
+    expect(dates).toEqual([
+      '2026-07-08', '2026-07-07', '2026-07-06', '2026-07-05',
+      '2026-07-04', '2026-07-03', '2026-07-02',
+    ])
+  })
+
+  it('N=1 → 오늘만', () => {
+    const now = Date.parse('2026-07-08T00:00:00Z')
+    expect(recentLogDates(1, now)).toEqual(['2026-07-08'])
+  })
+
+  it('N=0 → 빈 배열', () => {
+    expect(recentLogDates(0)).toEqual([])
+  })
+})

--- a/src/lib/mcp-logs/__tests__/parser.test.ts
+++ b/src/lib/mcp-logs/__tests__/parser.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { parseLines, applyFilter, tailN, computeStats } from '../parser'
+
+const SAMPLE = [
+  JSON.stringify({ level: 'info', time: '2026-07-08T01:00:00Z', pid: 1, service: 'mcp', msg: 'tool_call', tool: 'get_portfolio', args: { x: 1 }, latency_ms: 42, traceId: 'abcd1234', status: 'ok' }),
+  JSON.stringify({ level: 'info', time: '2026-07-08T01:00:01Z', pid: 1, service: 'mcp', msg: 'tool_call', tool: 'get_portfolio', latency_ms: 60, traceId: 'ffff0000', status: 'ok' }),
+  JSON.stringify({ level: 'warn', time: '2026-07-08T01:00:02Z', pid: 1, service: 'mcp', msg: 'tool_call_reported_error', tool: 'get_trades', status: 'error', err: { kind: 'reported', message: '보유수량 부족' }, traceId: 'aaaa0001' }),
+  JSON.stringify({ level: 'error', time: '2026-07-08T01:00:03Z', pid: 1, service: 'mcp', msg: 'http_request_error', err: { message: 'oops' } }),
+  JSON.stringify({ level: 'fatal', time: '2026-07-08T01:00:04Z', pid: 1, service: 'mcp', msg: 'http_server_error', err: { message: 'bind EADDRINUSE' } }),
+].join('\n')
+
+describe('parseLines', () => {
+  it('빈 라인 skip, 각 라인을 LogEntry 로 변환', () => {
+    const entries = parseLines(SAMPLE + '\n\n')
+    expect(entries).toHaveLength(5)
+    expect(entries[0].msg).toBe('tool_call')
+    expect(entries[0].tool).toBe('get_portfolio')
+    expect(entries[0].lineNo).toBe(1)
+  })
+
+  it('numeric level → 문자열 매핑', () => {
+    const entries = parseLines('{"level":30,"msg":"tool_call"}')
+    expect(entries[0].level).toBe('info')
+  })
+
+  it('파싱 실패는 raw + parseError=true', () => {
+    const entries = parseLines('not a json\n{"level":"info","msg":"ok"}')
+    expect(entries[0].parseError).toBe(true)
+    expect(entries[0].raw).toBe('not a json')
+    expect(entries[1].parseError).toBeUndefined()
+  })
+})
+
+describe('applyFilter', () => {
+  const entries = parseLines(SAMPLE)
+
+  it('필터 없음 → 전체 반환', () => {
+    expect(applyFilter(entries, {})).toHaveLength(5)
+  })
+
+  it('level=fatal → fatal 라인만', () => {
+    const r = applyFilter(entries, { level: 'fatal' })
+    expect(r).toHaveLength(1)
+    expect(r[0].msg).toBe('http_server_error')
+  })
+
+  it('msg=tool_call → 2건', () => {
+    expect(applyFilter(entries, { msg: 'tool_call' })).toHaveLength(2)
+  })
+
+  it('tool contains 대소문자 무관 부분 매치', () => {
+    expect(applyFilter(entries, { tool: 'PORT' })).toHaveLength(2)
+    expect(applyFilter(entries, { tool: 'trades' })).toHaveLength(1)
+  })
+
+  it('traceId 정확 매치', () => {
+    expect(applyFilter(entries, { traceId: 'abcd1234' })).toHaveLength(1)
+    expect(applyFilter(entries, { traceId: 'ffff0000' })).toHaveLength(1)
+    expect(applyFilter(entries, { traceId: 'nope' })).toHaveLength(0)
+  })
+
+  it('복합 필터 (AND)', () => {
+    expect(applyFilter(entries, { level: 'info', tool: 'get_portfolio' })).toHaveLength(2)
+    expect(applyFilter(entries, { level: 'warn', tool: 'get_portfolio' })).toHaveLength(0)
+  })
+})
+
+describe('tailN', () => {
+  it('전체 라인이 maxLines 이하 → 원본 반환', () => {
+    const r = tailN('a\nb\nc', 10)
+    expect(r.text).toBe('a\nb\nc')
+    expect(r.startLineNo).toBe(1)
+  })
+
+  it('초과 시 마지막 N 라인만, startLineNo 조정', () => {
+    const r = tailN('a\nb\nc\nd\ne', 2)
+    expect(r.text).toBe('d\ne')
+    expect(r.startLineNo).toBe(4)
+  })
+
+  it('후행 newline 이 있어도 실제 라인 수 기준으로 tail (Codex #425 P3 회귀 방지)', () => {
+    // pino 로그는 매 record 끝에 `\n` → split 결과 마지막 원소는 ''.
+    // 이전 구현은 이 empty 원소를 슬라이스에 포함해 실제 반환 라인이 1개 부족했음.
+    const r = tailN('a\nb\nc\n', 2)
+    expect(r.text).toBe('b\nc')
+    expect(r.startLineNo).toBe(2)
+  })
+
+  it('후행 newline + 정확히 maxLines → 원본 반환', () => {
+    const r = tailN('a\nb\n', 2)
+    expect(r.text).toBe('a\nb\n')
+    expect(r.startLineNo).toBe(1)
+  })
+
+  it('maxLines=0 → 빈', () => {
+    expect(tailN('a\nb', 0).text).toBe('')
+  })
+})
+
+describe('computeStats', () => {
+  const entries = parseLines(SAMPLE)
+  const stats = computeStats(entries)
+
+  it('total = 라인 수', () => {
+    expect(stats.total).toBe(5)
+  })
+
+  it('byLevel 내림차순', () => {
+    const counts = Object.fromEntries(stats.byLevel.map((b) => [b.level, b.count]))
+    expect(counts.info).toBe(2)
+    expect(counts.warn).toBe(1)
+    expect(counts.error).toBe(1)
+    expect(counts.fatal).toBe(1)
+  })
+
+  it('byMsg 는 msg 별 카운트', () => {
+    const map = Object.fromEntries(stats.byMsg.map((b) => [b.msg, b.count]))
+    expect(map.tool_call).toBe(2)
+    expect(map.tool_call_reported_error).toBe(1)
+  })
+
+  it('byTool 에러 카운트 (status=error 또는 error/fatal/warn level)', () => {
+    const portfolio = stats.byTool.find((b) => b.tool === 'get_portfolio')!
+    expect(portfolio.count).toBe(2)
+    expect(portfolio.errors).toBe(0)
+    const trades = stats.byTool.find((b) => b.tool === 'get_trades')!
+    expect(trades.count).toBe(1)
+    expect(trades.errors).toBe(1) // reported_error (warn + status=error)
+  })
+
+  it('latencyByTool 은 tool_call + latency_ms 있는 항목만', () => {
+    const portfolio = stats.latencyByTool.find((b) => b.tool === 'get_portfolio')!
+    expect(portfolio.count).toBe(2)
+    expect(portfolio.avg_ms).toBe(51) // (42 + 60) / 2 = 51
+    // percentile 2개 샘플 → p95/p99 는 max 값 근처
+    expect(portfolio.p95_ms).toBe(60)
+  })
+
+  it('errorRate = 에러 라인 / 총 라인 (warn+error+fatal 카운트)', () => {
+    // 3 error 이상 / 5 = 0.6
+    expect(stats.errorRate).toBeCloseTo(0.6)
+  })
+
+  it('빈 입력 → 0/0 반환, errorRate=0', () => {
+    const s = computeStats([])
+    expect(s.total).toBe(0)
+    expect(s.errorRate).toBe(0)
+    expect(s.byLevel).toEqual([])
+  })
+})

--- a/src/lib/mcp-logs/constants.ts
+++ b/src/lib/mcp-logs/constants.ts
@@ -1,0 +1,68 @@
+/**
+ * Phase 33-C (#418) — MCP 로그 대시보드 상수.
+ * `docs/mcp-log-schema.md` 와 동기화 유지.
+ */
+
+export const LEVEL_ORDER = ['fatal', 'error', 'warn', 'info', 'debug', 'trace'] as const
+export type LogLevel = (typeof LEVEL_ORDER)[number]
+
+/**
+ * 유효한 msg 리스트 (스키마 문서와 동기화).
+ * whitelist 필터에 사용. 로그 파일에는 이 밖의 msg 도 등장 가능하지만 검색에서는
+ * 인식된 값만 필터 옵션으로 노출.
+ */
+export const KNOWN_MSGS = [
+  'tool_call',
+  'tool_call_reported_error',
+  'tool_call_sdk_error',
+  'tool_call_failed',
+  'sdk_error',
+  'transport_ready',
+  'http_request',
+  'http_request_error',
+  'http_server_error',
+  'session_initialized',
+  'session_closed',
+  'session_sweep',
+  'transport_close_error',
+  'shutdown_started',
+  'http_server_closed',
+  'force_exit_timeout',
+  'server_fatal',
+  'uncaught_exception',
+  'unhandled_rejection',
+] as const
+
+export type KnownMsg = (typeof KNOWN_MSGS)[number]
+
+export const MSG_LABELS: Record<string, string> = {
+  tool_call: '🟢 tool 호출',
+  tool_call_reported_error: '⚠️ tool 비즈니스 예외',
+  tool_call_sdk_error: '🔴 tool SDK 오류',
+  tool_call_failed: '💥 tool throw',
+  sdk_error: '🔴 SDK 오류',
+  transport_ready: '🚀 부팅',
+  http_request: '📥 HTTP 요청',
+  http_request_error: '⚡ HTTP 요청 오류',
+  http_server_error: '💥 HTTP 서버 오류',
+  session_initialized: '📡 세션 시작',
+  session_closed: '📴 세션 종료',
+  session_sweep: '🧹 세션 정리',
+  transport_close_error: '⚠️ 세션 닫기 오류',
+  shutdown_started: '⏸️ 종료 시작',
+  http_server_closed: '⏹️ HTTP 종료',
+  force_exit_timeout: '⏱️ 강제 종료',
+  server_fatal: '💀 서버 fatal',
+  uncaught_exception: '💀 uncaught',
+  unhandled_rejection: '💀 rejection',
+}
+
+/** 최근 N일 간의 로그 파일 이름을 KST 기준으로 생성 */
+export function recentLogDates(days: number, now: number = Date.now()): string[] {
+  const out: string[] = []
+  for (let i = 0; i < days; i++) {
+    const kst = new Date(now + 9 * 60 * 60 * 1000 - i * 24 * 60 * 60 * 1000)
+    out.push(kst.toISOString().slice(0, 10))
+  }
+  return out
+}

--- a/src/lib/mcp-logs/parser.ts
+++ b/src/lib/mcp-logs/parser.ts
@@ -1,0 +1,189 @@
+/**
+ * Phase 33-C (#418) — MCP pino JSON lines 파싱 + 필터.
+ * pure — filesystem I/O 는 route 에서 담당, 이 파일은 이미 읽은 텍스트에 대해 동작.
+ */
+
+import { KNOWN_MSGS } from './constants'
+
+export interface LogEntry {
+  level: string
+  time?: string
+  pid?: number
+  service?: string
+  msg?: string
+  tool?: string
+  args?: unknown
+  latency_ms?: number
+  traceId?: string
+  status?: string
+  err?: unknown
+  /** 원본 문자열 (파싱 실패 시 그대로 노출) */
+  raw?: string
+  /** 파싱 실패 여부 */
+  parseError?: boolean
+  /** 원본 파일에서의 line 번호 (1-indexed) */
+  lineNo?: number
+}
+
+export interface Filter {
+  level?: string
+  msg?: string
+  tool?: string
+  traceId?: string
+}
+
+/**
+ * pino JSON lines 텍스트 → LogEntry 배열. 빈 라인 skip. 파싱 실패는 raw 로 노출.
+ * pino 는 numeric level (`{"level":30,...}`) 을 출력할 수 있어 formatter 없이는
+ * 문자열이 아닐 수 있으나 이 프로젝트는 `formatters.level = label` 로 문자열 출력.
+ * 다만 방어적으로 numeric → 문자열 매핑.
+ */
+const NUMERIC_LEVEL: Record<number, string> = {
+  10: 'trace', 20: 'debug', 30: 'info', 40: 'warn', 50: 'error', 60: 'fatal',
+}
+
+export function parseLines(text: string): LogEntry[] {
+  const entries: LogEntry[] = []
+  const lines = text.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line.trim()) continue
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>
+      let level = parsed.level
+      if (typeof level === 'number') level = NUMERIC_LEVEL[level] ?? String(level)
+      entries.push({
+        ...parsed,
+        level: typeof level === 'string' ? level : 'info',
+        lineNo: i + 1,
+      } as LogEntry)
+    } catch {
+      entries.push({ level: 'unknown', msg: line.slice(0, 200), raw: line, parseError: true, lineNo: i + 1 })
+    }
+  }
+  return entries
+}
+
+export function applyFilter(entries: LogEntry[], f: Filter): LogEntry[] {
+  const level = f.level?.trim()
+  const msg = f.msg?.trim()
+  const tool = f.tool?.trim().toLowerCase()
+  const traceId = f.traceId?.trim()
+  if (!level && !msg && !tool && !traceId) return entries
+  return entries.filter((e) => {
+    if (level && e.level !== level) return false
+    if (msg && e.msg !== msg) return false
+    if (tool) {
+      const t = typeof e.tool === 'string' ? e.tool.toLowerCase() : ''
+      if (!t.includes(tool)) return false
+    }
+    if (traceId && e.traceId !== traceId) return false
+    return true
+  })
+}
+
+/**
+ * 대용량 파일 대응 — 텍스트 마지막 N 라인만 잘라서 반환.
+ * pino 로그는 매 record 끝에 `\n` → `split('\n')` 결과 마지막 원소가 `''` (빈 문자열).
+ * 이 empty 를 count/slice 에 포함하면 실제 반환되는 라인이 1개 부족 (Codex #425 P3).
+ * → 후행 empty 를 잘라낸 "effective" 배열로 count 와 slice 를 수행.
+ * 원본 파일 line 번호를 유지하기 위해 시작 라인 번호 (1-indexed) 도 함께 반환.
+ */
+export function tailN(text: string, maxLines: number): { text: string; startLineNo: number } {
+  if (maxLines <= 0) return { text: '', startLineNo: 1 }
+  const lines = text.split('\n')
+  const effective = lines.length > 0 && lines[lines.length - 1] === ''
+    ? lines.slice(0, -1)
+    : lines
+  if (effective.length <= maxLines) return { text, startLineNo: 1 }
+  const start = effective.length - maxLines
+  return {
+    text: effective.slice(start).join('\n'),
+    startLineNo: start + 1,
+  }
+}
+
+/**
+ * 집계용 통계.
+ * `latency` 는 tool_call 만 대상 (latency_ms 있는 항목).
+ */
+export interface Stats {
+  total: number
+  byLevel: Array<{ level: string; count: number }>
+  byMsg: Array<{ msg: string; count: number }>
+  byTool: Array<{ tool: string; count: number; errors: number }>
+  latencyByTool: Array<{ tool: string; avg_ms: number; p95_ms: number; p99_ms: number; count: number }>
+  errorRate: number
+}
+
+const ERROR_LEVELS = new Set(['error', 'fatal', 'warn'])
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const idx = Math.ceil(sorted.length * p) - 1
+  return sorted[Math.max(0, Math.min(sorted.length - 1, idx))]
+}
+
+export function computeStats(entries: LogEntry[]): Stats {
+  const byLevelMap = new Map<string, number>()
+  const byMsgMap = new Map<string, number>()
+  const byToolMap = new Map<string, { count: number; errors: number }>()
+  const latencyByToolRaw = new Map<string, number[]>()
+  let errors = 0
+
+  for (const e of entries) {
+    byLevelMap.set(e.level, (byLevelMap.get(e.level) ?? 0) + 1)
+    if (e.msg) byMsgMap.set(e.msg, (byMsgMap.get(e.msg) ?? 0) + 1)
+    if (ERROR_LEVELS.has(e.level)) errors++
+
+    if (typeof e.tool === 'string' && e.tool) {
+      const row = byToolMap.get(e.tool) ?? { count: 0, errors: 0 }
+      row.count++
+      if (e.status === 'error' || ERROR_LEVELS.has(e.level)) row.errors++
+      byToolMap.set(e.tool, row)
+
+      if (e.msg === 'tool_call' && typeof e.latency_ms === 'number') {
+        const arr = latencyByToolRaw.get(e.tool) ?? []
+        arr.push(e.latency_ms)
+        latencyByToolRaw.set(e.tool, arr)
+      }
+    }
+  }
+
+  const byLevel = Array.from(byLevelMap.entries())
+    .map(([level, count]) => ({ level, count }))
+    .sort((a, b) => b.count - a.count)
+
+  const byMsg = Array.from(byMsgMap.entries())
+    .map(([msg, count]) => ({ msg, count }))
+    .sort((a, b) => b.count - a.count)
+
+  const byTool = Array.from(byToolMap.entries())
+    .map(([tool, r]) => ({ tool, count: r.count, errors: r.errors }))
+    .sort((a, b) => b.count - a.count)
+
+  const latencyByTool = Array.from(latencyByToolRaw.entries()).map(([tool, samples]) => {
+    const sorted = [...samples].sort((a, b) => a - b)
+    const avg = sorted.reduce((s, v) => s + v, 0) / sorted.length
+    return {
+      tool,
+      avg_ms: Math.round(avg),
+      p95_ms: Math.round(percentile(sorted, 0.95)),
+      p99_ms: Math.round(percentile(sorted, 0.99)),
+      count: sorted.length,
+    }
+  }).sort((a, b) => b.count - a.count)
+
+  return {
+    total: entries.length,
+    byLevel,
+    byMsg,
+    byTool,
+    latencyByTool,
+    errorRate: entries.length === 0 ? 0 : errors / entries.length,
+  }
+}
+
+export function knownMsgs(): readonly string[] {
+  return KNOWN_MSGS
+}

--- a/src/lib/price-fetcher-utils.ts
+++ b/src/lib/price-fetcher-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * price-fetcher 순수 헬퍼 — DB / yahoo-finance2 사이드 이펙트 없이 유닛 테스트 가능.
+ * price-fetcher 본체 (Prisma / yahoo 인스턴스 top-level 생성) 에서 분리 (Codex #429 P2).
+ */
+
+export interface TickerMetaValue {
+  displayName: string
+  market: string
+  currency: string
+}
+
+/**
+ * Pure — 활성 전략의 크로스 티커를 tickerMeta 에 병합 (Phase 34-B follow-up / Codex #428 P2).
+ * 이미 등록된 티커 (홀딩·관심종목) 는 그대로. 신규 항목만 placeholder 로 삽입:
+ *   - displayName: ticker 자체 (사용자가 관심종목에 추가하면 그 이름 우선 사용됨)
+ *   - market: '?' (normalizeMarket 이 ticker suffix `.KS`/`.KQ` 로 fallback)
+ *   - currency: KRX suffix 면 KRW, 아니면 USD (SPY/VIX 등 대부분)
+ */
+export function mergeCrossTickersIntoMeta(
+  tickerMeta: Map<string, TickerMetaValue>,
+  crossTickers: Iterable<string>,
+): void {
+  for (const t of crossTickers) {
+    if (tickerMeta.has(t)) continue
+    tickerMeta.set(t, {
+      displayName: t,
+      market: '?',
+      currency: t.endsWith('.KS') || t.endsWith('.KQ') ? 'KRW' : 'USD',
+    })
+  }
+}

--- a/src/lib/price-fetcher-utils.ts
+++ b/src/lib/price-fetcher-utils.ts
@@ -10,11 +10,20 @@ export interface TickerMetaValue {
 }
 
 /**
- * Pure — 활성 전략의 크로스 티커를 tickerMeta 에 병합 (Phase 34-B follow-up / Codex #428 P2).
- * 이미 등록된 티커 (홀딩·관심종목) 는 그대로. 신규 항목만 placeholder 로 삽입:
- *   - displayName: ticker 자체 (사용자가 관심종목에 추가하면 그 이름 우선 사용됨)
- *   - market: '?' (normalizeMarket 이 ticker suffix `.KS`/`.KQ` 로 fallback)
- *   - currency: KRX suffix 면 KRW, 아니면 USD (SPY/VIX 등 대부분)
+ * Pure — 활성 전략의 크로스 티커를 tickerMeta 에 병합 (Phase 34-B follow-up, Codex #428 x2 P2 반영).
+ * 이미 등록된 티커 (홀딩·관심종목) 는 그대로. 신규 항목만 placeholder 로 삽입.
+ *
+ * 시장 fallback:
+ *   - `doRefreshPrices` 는 `normalizeMarket(meta.market, ticker)` 로 PriceCache.market 을 저장.
+ *     `normalizeMarket` 은 market 문자열 매치를 먼저 시도하고, 실패해야 ticker suffix 로 fallback.
+ *     즉 `market='US'` 로 두면 US 매치 즉시 반환 → `=X` FX suffix 체크 스킵 → FX 회귀.
+ *   - suffix 로부터 정확한 값을 명시:
+ *     - `.KS` / `.KQ` → 'KR' (KRW)
+ *     - `=X` → 'FX' (currency 는 pair 정확 반영이 어려워 USD 로 통일 — USDKRW=X 는 상위 흐름
+ *       (`doRefreshPrices` FX_TICKER 오버라이드) 이 덮어씀)
+ *     - 그 외 (SPY/VIX/QQQ 등) → 'US' (USD) — 사용실태상 US 벤치마크가 대다수
+ *   - 이렇게 하면 이후 사용자가 그 티커를 관심종목에 추가해도 PriceCache 는 이미 정확 값이라
+ *     시간대 alert 이 skip 되지 않음.
  */
 export function mergeCrossTickersIntoMeta(
   tickerMeta: Map<string, TickerMetaValue>,
@@ -22,10 +31,12 @@ export function mergeCrossTickersIntoMeta(
 ): void {
   for (const t of crossTickers) {
     if (tickerMeta.has(t)) continue
+    const isKrx = t.endsWith('.KS') || t.endsWith('.KQ')
+    const isFx = t.endsWith('=X')
     tickerMeta.set(t, {
       displayName: t,
-      market: '?',
-      currency: t.endsWith('.KS') || t.endsWith('.KQ') ? 'KRW' : 'USD',
+      market: isKrx ? 'KR' : isFx ? 'FX' : 'US',
+      currency: isKrx ? 'KRW' : 'USD',
     })
   }
 }

--- a/src/lib/price-fetcher.ts
+++ b/src/lib/price-fetcher.ts
@@ -1,6 +1,9 @@
 import YahooFinance from 'yahoo-finance2'
 import { prisma } from './prisma'
 import { normalizeMarket } from './market-hours'
+import { collectCrossTickers } from './custom-strategy/evaluator'
+import { mergeCrossTickersIntoMeta } from './price-fetcher-utils'
+export { mergeCrossTickersIntoMeta } from './price-fetcher-utils'
 
 const yahooFinance = new YahooFinance()
 
@@ -12,6 +15,7 @@ interface RefreshResult {
   failedTickers: string[]
   updatedAt: Date
 }
+
 
 /** 유효한 시세를 가져올 수 없을 때 발생하는 에러 */
 export class InvalidTickerError extends Error {
@@ -148,6 +152,16 @@ async function doRefreshPrices(): Promise<RefreshResult> {
       })
     }
   }
+
+  // Phase 34-B follow-up (Codex #428 P2): 크로스-티커 조건이 참조하는 벤치마크
+  // (SPY / VIX 등) 를 관심종목 등록 없이도 PriceCache 에 유지. 커스텀 전략 활성화된
+  // 것만 대상. 메타는 mergeCrossTickersIntoMeta 로 placeholder 삽입 → upsert 시점에
+  // quote.exchange 로 market 이 정확 값으로 자연 갱신.
+  const activeStrategies = await prisma.customStrategy.findMany({
+    where: { isActive: true },
+    select: { ticker: true, conditions: true },
+  })
+  mergeCrossTickersIntoMeta(tickerMeta, collectCrossTickers(activeStrategies))
 
   // FX 환율 추가
   tickerMeta.set(FX_TICKER, { displayName: 'USD/KRW', market: 'FX', currency: 'KRW' })

--- a/src/mcp/logger.ts
+++ b/src/mcp/logger.ts
@@ -41,6 +41,13 @@ let currentFileStream: pino.DestinationStream | null = null
 let currentFileDate = ''
 
 /**
+ * Phase 33-C (#418, #409 흡수): fatal 만 별도로 tee 되는 파일.
+ * `logs/mcp-crash-YYYY-MM-DD.log` — pm2 상태 진단 시 crash 만 빠르게 스캔.
+ * 일반 로그와 rotation·retention 동일 (KST 자정, 14일).
+ */
+let currentCrashStream: pino.DestinationStream | null = null
+
+/**
  * 오래된 로그 파일 정리 — 14일 (기본) 초과 시 삭제.
  * 매 rotation 시점과 부팅 시점에 실행. 실패는 조용히 넘김 (best effort).
  */
@@ -81,6 +88,23 @@ function openFileStream(): pino.DestinationStream | null {
 }
 
 /**
+ * Phase 33-C (#418): crash 전용 tee 파일 스트림 open.
+ * `logs/mcp-crash-<KST-date>.log`. LOG_ENABLE_FILE 이 켜져 있을 때만 활성.
+ */
+function openCrashFileStream(): pino.DestinationStream | null {
+  if (!LOG_ENABLE_FILE) return null
+  try {
+    fs.mkdirSync(LOG_DIR, { recursive: true })
+    const dateStr = currentFileDate || kstDateString()
+    const filePath = path.join(LOG_DIR, `mcp-crash-${dateStr}.log`)
+    return pino.destination({ dest: filePath, sync: true, mkdir: true })
+  } catch (error) {
+    console.error('[mcp/logger] crash tee 초기화 실패:', LOG_DIR, error)
+    return null
+  }
+}
+
+/**
  * 자정 감지 후 파일 스트림 교체. 5분 주기 setInterval (로그 시점마다 검사 X).
  * 순서: flushSync (in-flight write 안전) → 새 stream open → old stream end.
  */
@@ -88,17 +112,23 @@ function scheduleFileRotation(): void {
   if (!LOG_ENABLE_FILE) return
   const check = setInterval(() => {
     const today = kstDateString()
-    if (today !== currentFileDate && currentFileStream) {
-      const oldStream = currentFileStream
+    if (today !== currentFileDate && (currentFileStream || currentCrashStream)) {
       // 새 스트림을 먼저 만든 뒤 old 를 flush + end → 그 사이 write 는 old 로 감.
-      // wrapper 에서 currentFileStream 을 참조하므로 새 write 는 자동으로 new 로 전환.
+      // wrapper 에서 currentFileStream / currentCrashStream 을 참조하므로 새 write 는
+      // 자동으로 new 로 전환. currentFileDate 는 openFileStream 안에서 갱신.
+      const oldMain = currentFileStream
+      const oldCrash = currentCrashStream
       currentFileStream = openFileStream()
-      try {
-        ;(oldStream as unknown as { flushSync?: () => void }).flushSync?.()
-      } catch { /* best effort */ }
-      try {
-        ;(oldStream as unknown as { end?: () => void }).end?.()
-      } catch { /* best effort */ }
+      currentCrashStream = openCrashFileStream()
+      for (const s of [oldMain, oldCrash]) {
+        if (!s) continue
+        try {
+          ;(s as unknown as { flushSync?: () => void }).flushSync?.()
+        } catch { /* best effort */ }
+        try {
+          ;(s as unknown as { end?: () => void }).end?.()
+        } catch { /* best effort */ }
+      }
     }
   }, 5 * 60 * 1000)
   check.unref()
@@ -125,6 +155,26 @@ function buildStreams(): pino.StreamEntry[] {
         },
       } as pino.DestinationStream,
     })
+
+    // Phase 33-C (#418, #409 A): fatal 만 별도로 crash 파일에 tee.
+    // pino.multistream 은 entry level 이상만 그 stream 에 씀 → level 'fatal' 이면
+    // fatal 이상만 crash 파일. uncaughtException/unhandledRejection 도 logger.fatal
+    // 로 기록 (installCrashHandlers 참조) → 자동 포함.
+    currentCrashStream = openCrashFileStream()
+    if (currentCrashStream) {
+      streams.push({
+        level: 'fatal',
+        stream: {
+          write(chunk: string) {
+            try {
+              currentCrashStream?.write(chunk)
+            } catch {
+              // ignore — 다음 write 에서 새 stream 사용
+            }
+          },
+        } as pino.DestinationStream,
+      })
+    }
   }
 
   return streams
@@ -216,9 +266,11 @@ export function summarizeArgs(args: unknown, maxLen = 200): unknown {
  * currentFileStream (sonic-boom) 의 flushSync 를 직접 호출.
  */
 function flushAll(): void {
-  try {
-    ;(currentFileStream as unknown as { flushSync?: () => void })?.flushSync?.()
-  } catch { /* best effort */ }
+  for (const s of [currentFileStream, currentCrashStream]) {
+    try {
+      ;(s as unknown as { flushSync?: () => void })?.flushSync?.()
+    } catch { /* best effort */ }
+  }
 }
 
 /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -36,6 +36,7 @@ import { listAssets, createAsset, updateAsset, deleteAsset, createAssetDeposit }
 import { listBudgets, setBudget, deleteBudget } from './tools/budget'
 import { listRecurringTransactions, createRecurringTransaction, updateRecurringTransaction, deleteRecurringTransaction } from './tools/recurring'
 import { listAlertConfigs, updateAlertConfig } from './tools/alert'
+import { listAlertHistory } from './tools/alert-history'
 import { createRsuSchedule, updateRsuSchedule, deleteRsuSchedule } from './tools/rsu-write'
 import { vestRsu } from './tools/rsu-vest'
 import {
@@ -759,6 +760,22 @@ server.tool(
     value: z.string().describe('숫자 문자열'),
   },
   async (args) => updateAlertConfig(args)
+)
+
+server.tool(
+  'list_alert_history',
+  '알림 발동 이력 조회. Phase 33-A (#416). 필터: kind, ticker, from~to (ISO 8601), limit (기본 50, 최대 200).',
+  {
+    kind: z
+      .enum(['surge', 'drop', 'fx', 'target_hit', 'stop_loss', 'watch_buy', 'watch_zone', 'ta_signal', 'custom_strategy'])
+      .optional()
+      .describe('알림 종류 필터'),
+    ticker: z.string().optional().describe('티커 필터 (예: AAPL, 005930.KS)'),
+    from: z.string().optional().describe('시작 시각 (ISO 8601)'),
+    to: z.string().optional().describe('종료 시각 (ISO 8601)'),
+    limit: z.number().int().positive().optional().describe('최대 반환 개수 (기본 50, 최대 200)'),
+  },
+  async (args) => listAlertHistory(args)
 )
 
 // --- RSU 스케줄 쓰기 ---

--- a/src/mcp/tools/__tests__/alert-history.test.ts
+++ b/src/mcp/tools/__tests__/alert-history.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { listAlertHistory } from '../alert-history'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+describe('listAlertHistory', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockReset()
+  })
+
+  it('알 수 없는 kind 는 toolError', async () => {
+    const result = await listAlertHistory({ kind: 'unknown' })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+    expect(result.content[0].text).toContain('알 수 없는 kind')
+  })
+
+  it('from 형식 오류 → toolError', async () => {
+    const result = await listAlertHistory({ from: 'not-a-date' })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+    expect(result.content[0].text).toContain('ISO 8601')
+  })
+
+  it('to 형식 오류 → toolError', async () => {
+    const result = await listAlertHistory({ to: 'invalid' })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+  })
+
+  it('limit 이 양수 아님 → toolError', async () => {
+    const result = await listAlertHistory({ limit: -1 })
+    expect((result as { isError?: boolean }).isError).toBe(true)
+    expect(result.content[0].text).toContain('limit')
+  })
+
+  it('빈 결과 → "이력이 없습니다"', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    const result = await listAlertHistory({})
+    expect(result.content[0].text).toContain('이력이 없습니다')
+  })
+
+  it('limit 상한 200 초과 시 clamp', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    await listAlertHistory({ limit: 1000 })
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect(call?.take).toBe(200)
+  })
+
+  it('필터 조합이 where 로 전달됨', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    await listAlertHistory({
+      kind: 'surge',
+      ticker: 'AAPL',
+      from: '2026-07-01T00:00:00Z',
+      to: '2026-07-08T00:00:00Z',
+      limit: 30,
+    })
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect(call?.where).toEqual({
+      kind: 'surge',
+      ticker: 'AAPL',
+      firedAt: {
+        gte: new Date('2026-07-01T00:00:00Z'),
+        lte: new Date('2026-07-08T00:00:00Z'),
+      },
+    })
+    expect(call?.take).toBe(30)
+    expect(call?.orderBy).toEqual({ firedAt: 'desc' })
+  })
+
+  it('ticker 소문자/공백 입력을 trim().toUpperCase() 로 정규화 (Codex #423 P2 회귀 방지)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([])
+
+    await listAlertHistory({ ticker: '  aapl ' })
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect((call?.where as { ticker?: string })?.ticker).toBe('AAPL')
+  })
+
+  it('결과 rendering — 시간/kind 라벨/티커/상태/메시지 포함', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([
+      {
+        id: '1',
+        firedAt: new Date('2026-07-08T02:30:00Z'),
+        kind: 'drop',
+        ticker: 'AAPL',
+        price: 150,
+        changePercent: -6.2,
+        message: '🔴 AAPL 급락',
+        deliveryStatus: 'sent',
+        recipientCount: 1,
+        errorMessage: null,
+      },
+    ] as never)
+
+    const result = await listAlertHistory({})
+    const text = result.content[0].text
+    expect(text).toContain('🔴 급락')
+    expect(text).toContain('[AAPL]')
+    expect(text).toContain('전송')
+    expect(text).toContain('🔴 AAPL 급락')
+    expect(text).toContain('2026-07-08')
+  })
+})

--- a/src/mcp/tools/alert-history.ts
+++ b/src/mcp/tools/alert-history.ts
@@ -1,0 +1,105 @@
+/**
+ * Phase 33-A (#416) — MCP tool: `list_alert_history`.
+ * 텔레그램 AI 에서 최근 알림 발동 이력 조회.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { toolResult, toolError } from '../utils'
+import type { Prisma } from '@prisma/client'
+
+const KIND_LABELS: Record<string, string> = {
+  surge: '🟢 급등',
+  drop: '🔴 급락',
+  fx: '💱 환율',
+  target_hit: '🎯 목표가',
+  stop_loss: '🛑 손절가',
+  watch_buy: '💰 목표매수가',
+  watch_zone: '🔔 매수구간',
+  ta_signal: '📊 TA 시그널',
+  custom_strategy: '🧠 커스텀 전략',
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  sent: '전송',
+  partial: '일부 전송',
+  failed: '실패',
+}
+
+const MAX_LIMIT = 200
+const DEFAULT_LIMIT = 50
+
+/**
+ * ISO 8601 문자열 → Date. 잘못된 형식이면 null.
+ */
+function parseISO(s: string | undefined): Date | null {
+  if (!s) return null
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+export interface ListAlertHistoryArgs {
+  kind?: string
+  ticker?: string
+  from?: string
+  to?: string
+  limit?: number
+}
+
+export async function listAlertHistory(args: ListAlertHistoryArgs = {}) {
+  try {
+    const where: Prisma.AlertHistoryWhereInput = {}
+    if (args.kind) {
+      if (!(args.kind in KIND_LABELS)) {
+        return toolError(
+          `알 수 없는 kind: ${args.kind}. 사용 가능: ${Object.keys(KIND_LABELS).join(', ')}`,
+        )
+      }
+      where.kind = args.kind
+    }
+    // 티커 정규화 — MCP 호출자가 자연어로 소문자/공백 포함으로 넘길 수 있음.
+    // Prisma 저장값은 대문자 정규화된 상태 (holdings/watchlist/priceCache 파이프라인).
+    // 미정규화 exact match 는 rows 있어도 "이력 없음" 오탐 (Codex #423 P2).
+    if (args.ticker) where.ticker = args.ticker.trim().toUpperCase()
+
+    const from = parseISO(args.from)
+    const to = parseISO(args.to)
+    if (args.from && !from) return toolError(`from 이 ISO 8601 형식이 아닙니다: ${args.from}`)
+    if (args.to && !to) return toolError(`to 가 ISO 8601 형식이 아닙니다: ${args.to}`)
+    if (from || to) {
+      where.firedAt = {}
+      if (from) where.firedAt.gte = from
+      if (to) where.firedAt.lte = to
+    }
+
+    const requested = args.limit ?? DEFAULT_LIMIT
+    if (!Number.isFinite(requested) || requested <= 0) {
+      return toolError('limit 은 양수여야 합니다.')
+    }
+    const limit = Math.min(Math.floor(requested), MAX_LIMIT)
+
+    const rows = await prisma.alertHistory.findMany({
+      where,
+      orderBy: { firedAt: 'desc' },
+      take: limit,
+    })
+
+    if (rows.length === 0) return toolResult('해당 조건의 알림 이력이 없습니다.')
+
+    const lines: string[] = [
+      `## 알림 이력 (${rows.length}건, 최신순, 최대 ${limit})`,
+      '',
+    ]
+    for (const r of rows) {
+      const time = r.firedAt.toISOString().replace('T', ' ').slice(0, 16)
+      const kindLabel = KIND_LABELS[r.kind] ?? r.kind
+      const statusLabel = STATUS_LABELS[r.deliveryStatus] ?? r.deliveryStatus
+      const tickerPart = r.ticker ? ` [${r.ticker}]` : ''
+      lines.push(`- ${time} · ${kindLabel}${tickerPart} · ${statusLabel}`)
+      lines.push(`  ${r.message}`)
+    }
+
+    return toolResult(lines.join('\n'))
+  } catch (error) {
+    return toolError(error)
+  }
+}

--- a/src/mcp/tools/alert.ts
+++ b/src/mcp/tools/alert.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma'
+import { isToggleKey } from '@/lib/alert-config/categories'
 import { toolResult, toolError } from '../utils'
 
 /**
@@ -19,9 +20,6 @@ export async function listAlertConfigs() {
   }
 }
 
-/** on/off 문자열만 받는 키 (다른 키는 숫자) */
-const ON_OFF_KEYS = new Set(['active_review'])
-
 /**
  * update_alert_config: 기존 키의 값 변경 (신규 키 생성 금지)
  */
@@ -33,10 +31,10 @@ export async function updateAlertConfig(args: { key: string; value: string }) {
     const existing = await prisma.alertConfig.findUnique({ where: { key: args.key } })
     if (!existing) return toolError(`알림 설정 키를 찾을 수 없습니다: ${args.key}`)
 
-    // 값 형식 검증 — 키별 규칙
+    // 값 형식 검증 — 키별 규칙 (isToggleKey 로 단일 진실)
     const trimmed = args.value.trim()
     let finalValue: string
-    if (ON_OFF_KEYS.has(args.key)) {
+    if (isToggleKey(args.key)) {
       const v = trimmed.toLowerCase()
       if (v !== 'on' && v !== 'off') return toolError(`${args.key} 는 on 또는 off 만 허용됩니다.`)
       finalValue = v


### PR DESCRIPTION
15차 마일스톤 릴리즈. **34-C (뉴스 조건, #421) 는 외부 API 승인 대기로 이월** — 다음 마일스톤 스코프.

## Phase 33 — 관측 & 이력 & 정책
- **33-D** (#415/#422): 관심종목 알림 시간대 토글 (24h ↔ 장중 only). `isToggleKey` 헬퍼로 웹/봇/MCP 세 경로 통일 → 기존 누락 토글 (`ta_ai_guide`, `custom_strategy_alerts`) 도 편집 가능
- **33-A** (#416/#423): AlertHistory 모델 + 9개 kind 발동 hook. MCP tool `list_alert_history`
- **33-B** (#417/#424): 알림 이력 페이지 `/alerts/history`. 필터바 (기간/kind chip/ticker), Stat 4개, Recharts (일별 라인 + 종류별 파이), 페이지네이션 (tie-breaker 포함)
- **33-C** (#418/#425 + #409 흡수): MCP 로그 대시보드 `/admin/mcp-logs`. crash 별도 파일, 스키마 문서 (`docs/mcp-log-schema.md`), EOF 8MB tail 대용량 방어

## Phase 34 — 커스텀 전략 v3
- **34-A** (#419/#426): 어닝 캘린더 조건 (`earnings_within_days`) — yahoo-finance2 무료. `EarningsCache` + 매일 06:00 KST cron + 부팅 즉시 초기 시드. `src/lib/kst-date.ts` 공유 유틸 도입
- **34-B** (#420/#427): 크로스-티커 조건 (`cross_ticker`) — SPY/VIX 등 벤치마크 게이트. `collectCrossTickers` pure + PriceCache union 조회

## 주요 사용자 임팩트

### 관측 대폭 강화
- `/alerts/history` 로 지난 알림 기간별·종류별 확인
- `/admin/mcp-logs` 로 MCP tool 호출 latency / 에러 조회 (crash 파일 별도)
- 시간대 토글로 노이즈 알림 개인화

### 전략 조건 확장
- 어닝 임박 회피 (`earnings_within_days <= 3`)
- 벤치마크 게이트 (`SPY.change_percent > -2`, `VIX.price > 25`)

## 배포 절차
1. dev → main 머지 → v0.13.0 태그 push → GitHub Release publish
2. Deploy on Release workflow 자동 트리거
3. Migration 자동 적용 (AlertHistory, EarningsCache)
4. 어닝 캐시는 부팅 즉시 초기 시드 → 배포 직후 곧바로 활용 가능

**AI advisor system-prompt 갱신 있음 (v3 조건 예시 추가) → 텔레그램 `/reset` 권장.**

## Test plan
- [x] 각 PR self-review + Codex ~15 라운드 반영
- [x] 465 tests / lint / typecheck / build 모두 통과
- [x] verify skill 로 실제 running 서버 검증 (33-B, 33-C)
- [ ] 머지 후 v0.13.0 태그 → 서버 배포 → `/alerts/history`, `/admin/mcp-logs` 렌더 확인
- [ ] 어닝 초기 시드 완료 확인 (`pm2 logs myfinance-bot` 에서 "어닝 스캔 완료")

Closes #414 (34-C 제외)