### PR TITLE
fix(price-fetcher): 크로스-티커 벤치마크도 refresh 대상 (Codex P2, #420 follow-up)

### DIFF
--- a/src/lib/__tests__/price-fetcher-utils.test.ts
+++ b/src/lib/__tests__/price-fetcher-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { mergeCrossTickersIntoMeta } from '../price-fetcher'
+// price-fetcher 본체 (Prisma / yahoo top-level 로드) 대신 순수 유틸 모듈에서 직접 import →
+// Prisma generate / DATABASE_URL 없이도 테스트 가능 (Codex #429 P2).
+import { mergeCrossTickersIntoMeta } from '../price-fetcher-utils'
 
 describe('mergeCrossTickersIntoMeta (Codex #428 P2 회귀 방지)', () => {
   it('신규 크로스 티커를 placeholder 로 삽입', () => {

--- a/src/lib/__tests__/price-fetcher.test.ts
+++ b/src/lib/__tests__/price-fetcher.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { mergeCrossTickersIntoMeta } from '../price-fetcher'
+
+describe('mergeCrossTickersIntoMeta (Codex #428 P2 회귀 방지)', () => {
+  it('신규 크로스 티커를 placeholder 로 삽입', () => {
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, ['SPY', 'VIX'])
+    expect(meta.get('SPY')).toEqual({ displayName: 'SPY', market: '?', currency: 'USD' })
+    expect(meta.get('VIX')).toEqual({ displayName: 'VIX', market: '?', currency: 'USD' })
+  })
+
+  it('KRX suffix (.KS/.KQ) 는 KRW 통화 부여', () => {
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, ['005930.KS', '035720.KS', '091990.KQ'])
+    expect(meta.get('005930.KS')?.currency).toBe('KRW')
+    expect(meta.get('091990.KQ')?.currency).toBe('KRW')
+  })
+
+  it('이미 등록된 티커는 덮어쓰지 않음 (holdings/watchlist 메타 우선)', () => {
+    const meta = new Map([['SPY', { displayName: 'S&P 500 ETF', market: 'US', currency: 'USD' }]])
+    mergeCrossTickersIntoMeta(meta, ['SPY', 'VIX'])
+    expect(meta.get('SPY')).toEqual({ displayName: 'S&P 500 ETF', market: 'US', currency: 'USD' })
+    expect(meta.get('VIX')?.displayName).toBe('VIX')
+  })
+
+  it('빈 crossTickers → 원본 그대로', () => {
+    const meta = new Map([['AAPL', { displayName: 'Apple', market: 'US', currency: 'USD' }]])
+    const before = new Map(meta)
+    mergeCrossTickersIntoMeta(meta, [])
+    expect(meta).toEqual(before)
+  })
+
+  it('Set 타입도 수용 (Iterable 인터페이스)', () => {
+    const meta = new Map()
+    mergeCrossTickersIntoMeta(meta, new Set(['SPY', 'QQQ']))
+    expect(meta.has('SPY')).toBe(true)
+    expect(meta.has('QQQ')).toBe(true)
+  })
+})

--- a/src/lib/price-fetcher-utils.ts
+++ b/src/lib/price-fetcher-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * price-fetcher 순수 헬퍼 — DB / yahoo-finance2 사이드 이펙트 없이 유닛 테스트 가능.
+ * price-fetcher 본체 (Prisma / yahoo 인스턴스 top-level 생성) 에서 분리 (Codex #429 P2).
+ */
+
+export interface TickerMetaValue {
+  displayName: string
+  market: string
+  currency: string
+}
+
+/**
+ * Pure — 활성 전략의 크로스 티커를 tickerMeta 에 병합 (Phase 34-B follow-up / Codex #428 P2).
+ * 이미 등록된 티커 (홀딩·관심종목) 는 그대로. 신규 항목만 placeholder 로 삽입:
+ *   - displayName: ticker 자체 (사용자가 관심종목에 추가하면 그 이름 우선 사용됨)
+ *   - market: '?' (normalizeMarket 이 ticker suffix `.KS`/`.KQ` 로 fallback)
+ *   - currency: KRX suffix 면 KRW, 아니면 USD (SPY/VIX 등 대부분)
+ */
+export function mergeCrossTickersIntoMeta(
+  tickerMeta: Map<string, TickerMetaValue>,
+  crossTickers: Iterable<string>,
+): void {
+  for (const t of crossTickers) {
+    if (tickerMeta.has(t)) continue
+    tickerMeta.set(t, {
+      displayName: t,
+      market: '?',
+      currency: t.endsWith('.KS') || t.endsWith('.KQ') ? 'KRW' : 'USD',
+    })
+  }
+}

--- a/src/lib/price-fetcher.ts
+++ b/src/lib/price-fetcher.ts
@@ -2,6 +2,8 @@ import YahooFinance from 'yahoo-finance2'
 import { prisma } from './prisma'
 import { normalizeMarket } from './market-hours'
 import { collectCrossTickers } from './custom-strategy/evaluator'
+import { mergeCrossTickersIntoMeta } from './price-fetcher-utils'
+export { mergeCrossTickersIntoMeta } from './price-fetcher-utils'
 
 const yahooFinance = new YahooFinance()
 
@@ -14,32 +16,6 @@ interface RefreshResult {
   updatedAt: Date
 }
 
-interface TickerMetaValue {
-  displayName: string
-  market: string
-  currency: string
-}
-
-/**
- * Pure — 활성 전략의 크로스 티커를 tickerMeta 에 병합 (Phase 34-B follow-up / Codex #428 P2).
- * 이미 등록된 티커 (홀딩·관심종목) 는 그대로. 신규 항목만 placeholder 로 삽입:
- *   - displayName: ticker 자체 (사용자가 관심종목에 추가하면 그 이름 우선 사용됨)
- *   - market: '?' (normalizeMarket 이 ticker suffix `.KS`/`.KQ` 로 fallback)
- *   - currency: KRX suffix 면 KRW, 아니면 USD (SPY/VIX 등 대부분)
- */
-export function mergeCrossTickersIntoMeta(
-  tickerMeta: Map<string, TickerMetaValue>,
-  crossTickers: Iterable<string>,
-): void {
-  for (const t of crossTickers) {
-    if (tickerMeta.has(t)) continue
-    tickerMeta.set(t, {
-      displayName: t,
-      market: '?',
-      currency: t.endsWith('.KS') || t.endsWith('.KQ') ? 'KRW' : 'USD',
-    })
-  }
-}
 
 /** 유효한 시세를 가져올 수 없을 때 발생하는 에러 */
 export class InvalidTickerError extends Error {

--- a/src/lib/price-fetcher.ts
+++ b/src/lib/price-fetcher.ts
@@ -1,6 +1,7 @@
 import YahooFinance from 'yahoo-finance2'
 import { prisma } from './prisma'
 import { normalizeMarket } from './market-hours'
+import { collectCrossTickers } from './custom-strategy/evaluator'
 
 const yahooFinance = new YahooFinance()
 
@@ -11,6 +12,33 @@ interface RefreshResult {
   failed: number
   failedTickers: string[]
   updatedAt: Date
+}
+
+interface TickerMetaValue {
+  displayName: string
+  market: string
+  currency: string
+}
+
+/**
+ * Pure — 활성 전략의 크로스 티커를 tickerMeta 에 병합 (Phase 34-B follow-up / Codex #428 P2).
+ * 이미 등록된 티커 (홀딩·관심종목) 는 그대로. 신규 항목만 placeholder 로 삽입:
+ *   - displayName: ticker 자체 (사용자가 관심종목에 추가하면 그 이름 우선 사용됨)
+ *   - market: '?' (normalizeMarket 이 ticker suffix `.KS`/`.KQ` 로 fallback)
+ *   - currency: KRX suffix 면 KRW, 아니면 USD (SPY/VIX 등 대부분)
+ */
+export function mergeCrossTickersIntoMeta(
+  tickerMeta: Map<string, TickerMetaValue>,
+  crossTickers: Iterable<string>,
+): void {
+  for (const t of crossTickers) {
+    if (tickerMeta.has(t)) continue
+    tickerMeta.set(t, {
+      displayName: t,
+      market: '?',
+      currency: t.endsWith('.KS') || t.endsWith('.KQ') ? 'KRW' : 'USD',
+    })
+  }
 }
 
 /** 유효한 시세를 가져올 수 없을 때 발생하는 에러 */
@@ -148,6 +176,16 @@ async function doRefreshPrices(): Promise<RefreshResult> {
       })
     }
   }
+
+  // Phase 34-B follow-up (Codex #428 P2): 크로스-티커 조건이 참조하는 벤치마크
+  // (SPY / VIX 등) 를 관심종목 등록 없이도 PriceCache 에 유지. 커스텀 전략 활성화된
+  // 것만 대상. 메타는 mergeCrossTickersIntoMeta 로 placeholder 삽입 → upsert 시점에
+  // quote.exchange 로 market 이 정확 값으로 자연 갱신.
+  const activeStrategies = await prisma.customStrategy.findMany({
+    where: { isActive: true },
+    select: { ticker: true, conditions: true },
+  })
+  mergeCrossTickersIntoMeta(tickerMeta, collectCrossTickers(activeStrategies))
 
   // FX 환율 추가
   tickerMeta.set(FX_TICKER, { displayName: 'USD/KRW', market: 'FX', currency: 'KRW' })


### PR DESCRIPTION
## Summary
Release PR #428 Codex 리뷰 반영. #427 (34-B) 크로스-티커 조건이 관심종목/보유에 없는 벤치마크 (SPY/VIX 등) 를 참조할 때 `refreshPrices` 가 그 티커를 안 채워 조건이 영구 false 였음.

- `mergeCrossTickersIntoMeta` pure 헬퍼 신설
- `doRefreshPrices` 가 활성 CustomStrategy 스캔 후 크로스 티커를 tickerMeta 에 병합
- placeholder 메타 → yahoo `quote.exchange` 로 자연 정확화

## Test plan (470 pass)
- [x] `mergeCrossTickersIntoMeta` 5 케이스 (신규/KRW/기존유지/빈/Set)
- [x] lint / typecheck / test / build 통과

머지 후 Release PR #428 자동 업데이트.

Closes #420 (follow-up)