### PR TITLE
fix(alerts/history): to 단독 지정 시 inverted range 방지 (Codex P2, #417 follow-up)

### DIFF
--- a/src/app/api/alerts/history/__tests__/shared.test.ts
+++ b/src/app/api/alerts/history/__tests__/shared.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets, parseKindsParam } from '../shared'
+import {
+  KNOWN_KINDS, parseISOOrNull, kstDateKey, buildKstDayBuckets, parseKindsParam,
+  resolveTimeWindow,
+} from '../shared'
 
 describe('KNOWN_KINDS', () => {
   it('9종 kind 를 모두 포함 (33-A AlertHistory 매핑과 동기화)', () => {
@@ -140,5 +143,40 @@ describe('buildKstDayBuckets (self-review P1 회귀 방지 #417)', () => {
     const d = new Date('2026-07-08T05:00:00Z')
     const buckets = buildKstDayBuckets(new Map([['2026-07-08', 2]]), d, d)
     expect(buckets).toEqual([{ date: '2026-07-08', count: 2 }])
+  })
+})
+
+describe('resolveTimeWindow (Codex #428 P2 회귀 방지)', () => {
+  const now = new Date('2026-07-09T00:00:00Z')
+  const DAY = 24 * 60 * 60 * 1000
+
+  it('both null → now anchored, from = now - N일', () => {
+    const r = resolveTimeWindow(null, null, 7, now)
+    expect(r.effectiveTo).toBe(now)
+    expect(r.effectiveFrom.getTime()).toBe(now.getTime() - 7 * DAY)
+  })
+
+  it('to 만 지정 (과거) → from = to - N일 (inverted range 방지)', () => {
+    const to = new Date('2026-06-01T00:00:00Z')
+    const r = resolveTimeWindow(null, to, 7, now)
+    expect(r.effectiveTo).toBe(to)
+    expect(r.effectiveFrom.getTime()).toBe(to.getTime() - 7 * DAY)
+    // 실제 위험 조건: from <= to (기존 버그 재현 방지)
+    expect(r.effectiveFrom.getTime()).toBeLessThanOrEqual(r.effectiveTo.getTime())
+  })
+
+  it('from 만 지정 → to = now', () => {
+    const from = new Date('2026-06-01T00:00:00Z')
+    const r = resolveTimeWindow(from, null, 7, now)
+    expect(r.effectiveFrom).toBe(from)
+    expect(r.effectiveTo).toBe(now)
+  })
+
+  it('both 지정 → 그대로', () => {
+    const from = new Date('2026-05-01T00:00:00Z')
+    const to = new Date('2026-06-01T00:00:00Z')
+    const r = resolveTimeWindow(from, to, 7, now)
+    expect(r.effectiveFrom).toBe(from)
+    expect(r.effectiveTo).toBe(to)
   })
 })

--- a/src/app/api/alerts/history/route.ts
+++ b/src/app/api/alerts/history/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { paginated, fail } from '@/lib/api-response'
 import type { Prisma } from '@prisma/client'
-import { parseISOOrNull, parseKindsParam } from './shared'
+import { parseISOOrNull, parseKindsParam, resolveTimeWindow } from './shared'
 
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
@@ -41,10 +41,8 @@ export async function GET(req: NextRequest) {
     let offset = offsetStr ? parseInt(offsetStr, 10) : 0
     if (!Number.isFinite(offset) || offset < 0) offset = 0
 
-    // 기본 기간: 최근 N일 (from/to 미지정 시)
-    const now = new Date()
-    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
-    const effectiveTo = to ?? now
+    // 기본 기간: `to` anchored (Codex #428 P2 fix). from/to 조합별 규칙은 resolveTimeWindow 참고.
+    const { effectiveFrom, effectiveTo } = resolveTimeWindow(from, to, DEFAULT_LOOKBACK_DAYS)
 
     const where: Prisma.AlertHistoryWhereInput = {
       firedAt: { gte: effectiveFrom, lte: effectiveTo },

--- a/src/app/api/alerts/history/shared.ts
+++ b/src/app/api/alerts/history/shared.ts
@@ -16,6 +16,28 @@ export function parseISOOrNull(s: string | undefined | null): Date | null {
 }
 
 /**
+ * 조회 기간 계산 (Codex #428 P2 회귀 방지 — 이전에는 `from` 미지정 시 항상 서버 now 기준
+ * -N일 로 anchored → 사용자가 `to` 만 과거로 지정하면 inverted range → 0 rows).
+ *
+ * 규칙:
+ *   - both provided → 그대로 사용
+ *   - `to` 만 → `from = to - lookbackDays`
+ *   - `from` 만 → `to = now`
+ *   - both omitted → `to = now`, `from = now - lookbackDays`
+ */
+export function resolveTimeWindow(
+  from: Date | null,
+  to: Date | null,
+  lookbackDays: number,
+  now: Date = new Date(),
+): { effectiveFrom: Date; effectiveTo: Date } {
+  const DAY = 24 * 60 * 60 * 1000
+  const effectiveTo = to ?? now
+  const effectiveFrom = from ?? new Date(effectiveTo.getTime() - lookbackDays * DAY)
+  return { effectiveFrom, effectiveTo }
+}
+
+/**
  * `kind` 쿼리 파라미터 정규화 — repeated (`?kind=a&kind=b`) 와 CSV (`?kind=a,b`) 모두 허용.
  * Codex P2 (#417 PR #424): 다중 kind 를 서버에서 지원해야 페이지네이션/집계가
  * 정합. 이전 구현은 클라 다중 선택 시 서버 필터를 skip 하고 페이지 후 클라 필터 →

--- a/src/app/api/alerts/history/stats/route.ts
+++ b/src/app/api/alerts/history/stats/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { ok, fail } from '@/lib/api-response'
 import type { Prisma } from '@prisma/client'
-import { parseISOOrNull, parseKindsParam, buildKstDayBuckets, kstDateKey } from '../shared'
+import { parseISOOrNull, parseKindsParam, buildKstDayBuckets, kstDateKey, resolveTimeWindow } from '../shared'
 
 const DEFAULT_LOOKBACK_DAYS = 7
 
@@ -30,9 +30,8 @@ export async function GET(req: NextRequest) {
     if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
     if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
 
-    const now = new Date()
-    const effectiveFrom = from ?? new Date(now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
-    const effectiveTo = to ?? now
+    // 기본 기간: `to` anchored (Codex #428 P2 fix). resolveTimeWindow 규칙 통일.
+    const { effectiveFrom, effectiveTo } = resolveTimeWindow(from, to, DEFAULT_LOOKBACK_DAYS)
 
     const where: Prisma.AlertHistoryWhereInput = {
       firedAt: { gte: effectiveFrom, lte: effectiveTo },


### PR DESCRIPTION
## Summary
Release PR #428 Codex 리뷰 반영. 사용자가 `to` 만 과거 시각으로 지정하면 `from` 이 서버 now-7d 로 anchored → inverted range → 0 rows.

- `resolveTimeWindow` pure 헬퍼로 4 케이스 통일 규칙
- 리스트 route + stats route 모두 대체

## Test plan (474 pass)
- [x] `resolveTimeWindow` 4 시나리오 (both null/to-only/from-only/both) — inverted range 재현 방지 assertion
- [x] lint / typecheck / test / build 통과

머지 후 Release PR #428 자동 업데이트.

Closes #417 (follow-up)