### PR TITLE
feat(ai): /ai 자유대화 sonnet 승격 + intent API (Phase 35-A, #433)

### DIFF
--- a/src/app/api/ai/ask/route.ts
+++ b/src/app/api/ai/ask/route.ts
@@ -35,7 +35,8 @@ export async function POST(request: NextRequest) {
       return fail('질문을 입력해주세요.', 400)
     }
 
-    const result = await askAdvisor(prompt.trim())
+    // 웹 `/ai` — 자유 질문 → sonnet (Phase 35-A / #433)
+    const result = await askAdvisor(prompt.trim(), { intent: 'conversation' })
 
     return ok({
       response: result.response,

--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -52,7 +52,11 @@ function fireAiQuestion(ctx: Context, question: string): void {
   }, TYPING_INTERVAL_MS)
 
   cleanExpiredSessions()
-  askAdvisor(question, { sessionId: chatSessions.get(chatId)?.sessionId, persist: true })
+  askAdvisor(question, {
+    sessionId: chatSessions.get(chatId)?.sessionId,
+    persist: true,
+    intent: 'conversation',  // 자유 질문 → sonnet (35-A / #433)
+  })
     .then(async (result) => {
       if (result.sessionId) chatSessions.set(chatId, { sessionId: result.sessionId, lastUsed: Date.now() })
       const chunks = splitMessage(result.response)
@@ -138,7 +142,7 @@ function fireTradeParseQuestion(ctx: Context, text: string): void {
       .catch(() => { /* 무시 */ })
   }, TYPING_INTERVAL_MS)
 
-  askAdvisor(TRADE_PARSE_PROMPT + text)
+  askAdvisor(TRADE_PARSE_PROMPT + text, { intent: 'parse' })  // 구조 JSON 파싱 → haiku (35-A)
     .then(async (result) => {
       await handleParsedTrade(ctx, result.response)
     })

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -427,7 +427,7 @@ function fireMultiExpenseParse(ctx: Context, text: string): void {
     ctx.replyWithChatAction('typing').catch(() => {})
   }, 5000)
 
-  askAdvisor(buildMultiParsePrompt() + text, { timeout: 60_000 })
+  askAdvisor(buildMultiParsePrompt() + text, { timeout: 60_000, intent: 'parse' })  // 구조 JSON 파싱 → haiku (35-A)
     .then(async (result) => {
       await handleMultiExpenseParsed(ctx, result.response)
     })

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -296,7 +296,7 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     for (const r of guideTargets) {
       try {
         const prompt = `${r.displayName}(${r.ticker})에서 다음 TA 시그널이 발생했다: ${r.signals.join(', ')}. stock-trading-method 프레임워크 기준으로 현재 상황 1~2줄 가이드를 작성해줘. 간결하게.`
-        const guide = await askAdvisor(prompt, { timeout: 30_000, maxBudgetUsd: 0.10 })
+        const guide = await askAdvisor(prompt, { timeout: 30_000, maxBudgetUsd: 0.10, intent: 'guide' })  // 1~2줄 가이드 → haiku (35-A)
         aiGuides.set(r.ticker, guide.response.trim())
       } catch (error) {
         console.warn(`[ta-signal] ${r.ticker} AI 가이드 실패:`, error instanceof Error ? error.message : error)

--- a/src/lib/ai/__tests__/advisor-intent.test.ts
+++ b/src/lib/ai/__tests__/advisor-intent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { pickModel } from '../claude-advisor'
+
+describe('pickModel (Phase 35-A / #433)', () => {
+  it('명시 model 이 있으면 intent 무시하고 그대로', () => {
+    expect(pickModel('sonnet', 'parse')).toBe('sonnet')
+    expect(pickModel('haiku', 'conversation')).toBe('haiku')
+    expect(pickModel('sonnet', undefined)).toBe('sonnet')
+  })
+
+  it('conversation → sonnet (사용자 자유 질문)', () => {
+    expect(pickModel(undefined, 'conversation')).toBe('sonnet')
+  })
+
+  it('parse → haiku (구조 JSON 파싱)', () => {
+    expect(pickModel(undefined, 'parse')).toBe('haiku')
+  })
+
+  it('guide → haiku (짧은 1~2줄 가이드)', () => {
+    expect(pickModel(undefined, 'guide')).toBe('haiku')
+  })
+
+  it('intent 도 없으면 haiku (하위호환)', () => {
+    expect(pickModel(undefined, undefined)).toBe('haiku')
+  })
+})

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -4,9 +4,32 @@ import { SYSTEM_PROMPT } from './system-prompt'
 
 export type AdvisorModel = 'haiku' | 'sonnet'
 
+/**
+ * 호출 의도 — 모델 자동 선택 근거 (Phase 35-A / #433).
+ *   - `conversation`: `/ai` 자유 질문. 도구 체이닝·트레이드오프 서술 필요 → sonnet
+ *   - `parse`: 사용자 자연어 → 구조 JSON (거래·가계부·전략). 짧고 결정적 → haiku
+ *   - `guide`: 짧은 TA 조언 등 1~2줄 가이드 → haiku
+ *
+ * 명시 `model` 이 있으면 그 값이 우선. intent 는 폴백 선택.
+ */
+export type AdvisorIntent = 'conversation' | 'parse' | 'guide'
+
+/**
+ * Pure — intent → model 매핑. 명시 model 이 있으면 그대로, 없으면 intent 로 결정.
+ * intent 도 없으면 haiku (하위호환 — 기존 호출부 default).
+ */
+export function pickModel(model: AdvisorModel | undefined, intent: AdvisorIntent | undefined): AdvisorModel {
+  if (model) return model
+  if (intent === 'conversation') return 'sonnet'
+  // 'parse' / 'guide' / undefined 는 모두 haiku
+  return 'haiku'
+}
+
 export interface AdvisorOptions {
-  /** 모델 선택 (기본: haiku) */
+  /** 모델 선택 (명시 시 intent 무시하고 이 값 사용) */
   model?: AdvisorModel
+  /** 호출 의도 — 모델 자동 선택 근거. 명시 model 이 없을 때 폴백 매핑. */
+  intent?: AdvisorIntent
   /** 타임아웃 ms (기본: 180_000) */
   timeout?: number
   /** API 비용 상한 USD (기본: 0.50) */
@@ -131,12 +154,13 @@ export async function askAdvisor(
   options: AdvisorOptions = {}
 ): Promise<AdvisorResult> {
   const {
-    model = 'haiku',
     timeout = 180_000,
     maxBudgetUsd = 0.50,
     sessionId,
     persist = false,
   } = options
+  // Phase 35-A (#433): intent → model 폴백 매핑. 명시 model 우선.
+  const model = pickModel(options.model, options.intent)
 
   // 프롬프트 길이 제한
   const MAX_PROMPT_LENGTH = 10_000

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -121,6 +121,8 @@ export async function parseStrategyText(text: string): Promise<ParsedStrategy> {
 
   const prompt = `${PROMPT_HEADER}\n${text.trim()}`
 
+  // 명시 model='sonnet' — 자연어 → 구조화 JSON 파싱 안정성 우선 (35-A intent='parse'
+  // 매핑은 haiku 지만 전략 파서는 스키마 위반 회귀 방지 위해 sonnet 유지 예외).
   const result = await askAdvisor(prompt, {
     model: 'sonnet',
     timeout: 60_000,


### PR DESCRIPTION
## Summary
텔레그램 `/ai` / 웹 `/api/ai/ask` 를 sonnet 로 승격. 파서·짧은 가이드는 haiku 유지. `AdvisorOptions.intent` 로 의도 명시 → 향후 모델 정책 조정 시 한 곳에서만 관리.

- Master: #432 (16차)
- `pickModel(model, intent)` pure 헬퍼 도입 (명시 model 우선)
- 호출부 5곳 intent 명시 (`/ai` × 2, 파싱 × 2, TA 가이드 × 1)
- `custom-strategy/parser.ts` 는 스키마 위반 방지 목적 명시 `sonnet` 유지 예외 (self-review P0 반영: 주석)

## 배포 후 조치
`--resume` + `--model` 함께 넘겨 기존 haiku 세션도 sonnet 로 재개됨. Claude CLI 는 override 허용. 이질감 있으면 텔레그램 `/reset` 권장. (참고: [[project_ai_session_resume]] 메모리 패턴)

## Test plan (481 pass)
- [x] `pickModel` 5 케이스
- [x] lint / typecheck / build 통과
- [x] self-review (pr-review-toolkit) P0/P1/P2 = 0
- [ ] 배포 후 텔레그램 `/ai` 응답 JSON `model` 필드 확인

Closes #433