### PR TITLE
feat(strategy): 자연어 전략 편집 (Phase 35-B, #434)

### DIFF
--- a/docs/specs/434-nl-strategy-edit.md
+++ b/docs/specs/434-nl-strategy-edit.md
@@ -1,0 +1,79 @@
+# [Phase 35-B] 자연어 전략 편집
+
+- **이슈**: #434
+- **마스터**: #432
+- **작성일**: 2026-07-10
+
+## 목표
+
+`/strategies` 편집 모달에서 자연어로 조건 수정. 등록 뿐 아니라 편집도 자연어 → UX 통일. **상대 편집** 지원 ("SPY 조건 빼줘", "어닝 5일로 완화", "OR 로 바꿔").
+
+## 현재 상태
+
+- 등록: 자연어 → `parseStrategyText` → ParsedStrategy 저장
+- 편집: JSON 손편집 (이름/logic/frequency/isActive 만, 조건 자체 편집 X — 삭제 후 재등록 안내)
+
+## 신규
+
+### `editStrategyByNL(current, instruction)` — parser.ts 확장
+
+- 입력: 기존 전략 (name/ticker/conditions/logic/frequency) + 자연어 지시
+- 출력: 갱신된 `ParsedStrategy` (또는 error)
+- 프롬프트: 기존 스키마 규칙 + 현재 상태 컨텍스트 + 편집 지시
+- 상대 편집 명시: "빼줘 / 완화 / 강화 / OR 로 바꿔" 등 사용자 표현 이해
+- 지원 조건 외 지시 → error 응답
+
+### API `POST /api/custom-strategies/[id]/nl-edit`
+
+- 입력: `{ instruction: string }`
+- 출력 (미리보기, 저장 X):
+  ```json
+  {
+    "success": true,
+    "data": {
+      "before": ParsedStrategy,
+      "after":  ParsedStrategy,
+      "diff": { conditionsAdded: [...], conditionsRemoved: [...], logicChanged?: {from, to}, frequencyChanged?: {from, to} }
+    }
+  }
+  ```
+- 실패 → 400 with error message
+
+### PUT 확장
+
+기존 `PUT /api/custom-strategies/[id]` 가 이름/logic/frequency/isActive 만 허용. **conditions 도 허용하도록 확장** — nl-edit 미리보기 결과를 사용자가 승인 시 이 필드로 저장.
+
+### UI (`StrategyEditModal.tsx`)
+
+기존 필드 + 신규 자연어 편집 섹션:
+- 텍스트 영역 (자연어 지시 입력)
+- "미리보기" 버튼 → API 호출 → diff 표시
+- diff: 조건 추가/제거 하이라이트 (기존 conditionToString 재사용)
+- "적용" 버튼 → PUT with `conditions` (+ 변경된 logic/frequency)
+
+"조건 자체는 편집 불가" 경고 문구 제거.
+
+## 파일 변경
+
+- `src/lib/custom-strategy/parser.ts` — `editStrategyByNL` + `EDIT_PROMPT_HEADER`
+- `src/app/api/custom-strategies/[id]/nl-edit/route.ts` (신규)
+- `src/app/api/custom-strategies/[id]/route.ts` — PUT 에 conditions 필드 허용 (검증 재사용)
+- `src/components/strategies/StrategyEditModal.tsx` — 자연어 편집 섹션 + preview UI
+
+## 테스트
+
+- `editStrategyByNL` — mock askAdvisor 로 성공/실패 시나리오
+- diff 계산 pure 함수 (`computeStrategyDiff`)
+- PUT conditions 유효성
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] verify: 실제 편집 요청 → preview 반환 → 저장 성공
+
+## 제외
+
+- **자연어로 신규 조건 발명** (뉴스/펀더 등) — 지원 밖은 error
+- **다중 지시 순차 적용** — 한 번의 편집은 한 개 지시 (여러 변경은 사용자가 개별 입력)
+- **음성 편집** — 스코프 밖

--- a/src/app/api/custom-strategies/[id]/nl-edit/route.ts
+++ b/src/app/api/custom-strategies/[id]/nl-edit/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Phase 35-B (#434) — 자연어 전략 편집 미리보기.
+ * POST /api/custom-strategies/[id]/nl-edit
+ *
+ * 입력: { instruction: string }
+ * 출력: { before, after, diff }  — **저장 X**. 사용자 승인 후 PUT 로 저장.
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
+import { editStrategyByNL } from '@/lib/custom-strategy/parser'
+import { computeStrategyDiff } from '@/lib/custom-strategy/diff'
+import type { Condition, LogicOp, Frequency, ParsedStrategy } from '@/lib/custom-strategy/types'
+import { validateCondition } from '@/lib/custom-strategy/types'
+
+export const dynamic = 'force-dynamic'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params
+    if (!id) return fail('전략 id가 필요합니다.', 400)
+
+    let body: Record<string, unknown>
+    try {
+      body = await request.json()
+    } catch {
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
+    }
+
+    const instruction = typeof body.instruction === 'string' ? body.instruction.trim() : ''
+    if (!instruction) return fail('편집 지시를 입력해주세요.', 400)
+
+    const existing = await prisma.customStrategy.findUnique({ where: { id } })
+    if (!existing) return fail('전략을 찾을 수 없습니다.', 404)
+
+    const rawConds = Array.isArray(existing.conditions) ? (existing.conditions as unknown[]) : []
+    const before: ParsedStrategy = {
+      name: existing.name,
+      ticker: existing.ticker,
+      conditions: rawConds.filter(validateCondition) as Condition[],
+      logic: (existing.logic === 'OR' ? 'OR' : 'AND') as LogicOp,
+      frequency: (['once', 'daily', 'always'].includes(existing.frequency)
+        ? existing.frequency
+        : 'daily') as Frequency,
+    }
+
+    let after: ParsedStrategy
+    try {
+      after = await editStrategyByNL(before, instruction)
+    } catch (error) {
+      return fail(error instanceof Error ? error.message : '편집 실패', 400)
+    }
+
+    // self-review P1 (#434): ticker 변경은 지원 밖 (PUT 도 ticker 무시).
+    // AI 가 지시로 ticker 를 바꿔 돌려주더라도 여기서 명시 거부 → 조건이 새 티커에
+    // 맞춰 재조정된 상태로 원래 티커에 저장돼 잘못된 트리거 되는 상황 방지.
+    if (after.ticker !== before.ticker) {
+      return fail(
+        `티커 변경 (${before.ticker} → ${after.ticker}) 은 지원되지 않습니다. 다른 종목으로 바꾸려면 이 전략을 삭제 후 재등록해주세요.`,
+        400,
+      )
+    }
+
+    const diff = computeStrategyDiff(before, after)
+    return ok({ before, after, diff })
+  } catch (error) {
+    console.error('[api/custom-strategies/id/nl-edit] POST 실패:', error)
+    return fail('편집 미리보기에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/custom-strategies/[id]/route.ts
+++ b/src/app/api/custom-strategies/[id]/route.ts
@@ -3,6 +3,8 @@ import type { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { ok, fail, noContent } from '@/lib/api-response'
 import { validateCondition } from '@/lib/custom-strategy/types'
+import { conditionsEqual } from '@/lib/custom-strategy/diff'
+import type { Condition } from '@/lib/custom-strategy/types'
 
 export const dynamic = 'force-dynamic'
 
@@ -72,11 +74,15 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         return fail('conditions 에 유효하지 않은 항목이 있습니다.', 400)
       }
       // Codex #440 재리뷰 P2: 실제로 변경됐을 때만 conditions/lastTriggeredAt 갱신.
-      // 클라이언트가 nlPreview 있으면 항상 conditions 를 넘길 수 있어, 무변경 시에도
-      // 서버가 리셋하면 `once` 가 재무장되거나 `daily` 가 같은 날 중복 알림 발동.
-      const existingConditionsStr = JSON.stringify(existing.conditions)
-      const newConditionsStr = JSON.stringify(body.conditions)
-      if (existingConditionsStr !== newConditionsStr) {
+      // 순서 무관 비교 (`conditionsEqual`): `JSON.stringify` 는 필드 순서에 민감해서
+      // `{type, operator, value}` vs `{value, operator, type}` 를 다르다고 오판 →
+      // 무변경인데 lastTriggeredAt 리셋 → `once` 재무장 / `daily` 중복 발동.
+      const existingConds = (Array.isArray(existing.conditions)
+        ? (existing.conditions as unknown[])
+        : []
+      ).filter(validateCondition) as Condition[]
+      const newConds = body.conditions as unknown as Condition[]
+      if (!conditionsEqual(existingConds, newConds)) {
         data.conditions = body.conditions as unknown as Prisma.InputJsonValue
         // 조건이 실제 바뀔 때만 발동 이력 리셋 → fresh signal 로 평가.
         data.lastTriggeredAt = null

--- a/src/app/api/custom-strategies/[id]/route.ts
+++ b/src/app/api/custom-strategies/[id]/route.ts
@@ -71,11 +71,17 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       if (!body.conditions.every(validateCondition)) {
         return fail('conditions 에 유효하지 않은 항목이 있습니다.', 400)
       }
-      data.conditions = body.conditions as unknown as Prisma.InputJsonValue
-      // Codex #440 P2: 조건 변경 = 새 전략 정의 → 이전 발동 이력 리셋해야 shouldFire
-      // 가 fresh signal 로 평가. 그렇지 않으면 `once` 는 영구 비활성, `daily` 는
-      // 같은 KST 날짜 재발동 skip → 편집한 새 조건이 알림 안 나오는 사일런트 버그.
-      data.lastTriggeredAt = null
+      // Codex #440 재리뷰 P2: 실제로 변경됐을 때만 conditions/lastTriggeredAt 갱신.
+      // 클라이언트가 nlPreview 있으면 항상 conditions 를 넘길 수 있어, 무변경 시에도
+      // 서버가 리셋하면 `once` 가 재무장되거나 `daily` 가 같은 날 중복 알림 발동.
+      const existingConditionsStr = JSON.stringify(existing.conditions)
+      const newConditionsStr = JSON.stringify(body.conditions)
+      if (existingConditionsStr !== newConditionsStr) {
+        data.conditions = body.conditions as unknown as Prisma.InputJsonValue
+        // 조건이 실제 바뀔 때만 발동 이력 리셋 → fresh signal 로 평가.
+        data.lastTriggeredAt = null
+      }
+      // 같으면 아무것도 안 함 → PUT 이 name/logic 등 다른 필드만 수정.
     }
 
     if (Object.keys(data).length === 0) {

--- a/src/app/api/custom-strategies/[id]/route.ts
+++ b/src/app/api/custom-strategies/[id]/route.ts
@@ -72,6 +72,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         return fail('conditions 에 유효하지 않은 항목이 있습니다.', 400)
       }
       data.conditions = body.conditions as unknown as Prisma.InputJsonValue
+      // Codex #440 P2: 조건 변경 = 새 전략 정의 → 이전 발동 이력 리셋해야 shouldFire
+      // 가 fresh signal 로 평가. 그렇지 않으면 `once` 는 영구 비활성, `daily` 는
+      // 같은 KST 날짜 재발동 skip → 편집한 새 조건이 알림 안 나오는 사일런트 버그.
+      data.lastTriggeredAt = null
     }
 
     if (Object.keys(data).length === 0) {

--- a/src/app/api/custom-strategies/[id]/route.ts
+++ b/src/app/api/custom-strategies/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { ok, fail, noContent } from '@/lib/api-response'
+import { validateCondition } from '@/lib/custom-strategy/types'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,8 +16,10 @@ const VALID_LOGIC = new Set(['AND', 'OR'])
 /**
  * PUT /api/custom-strategies/[id] — 부분 수정.
  *
- * 편집 가능 필드: name / isActive / frequency / logic.
- * 조건 자체 (conditions, ticker) 편집은 v1 지원 X — 삭제 후 재등록.
+ * 편집 가능 필드: name / isActive / frequency / logic / conditions.
+ * conditions 편집은 Phase 35-B (#434) 부터 지원 — 자연어 편집 (POST .../nl-edit)
+ * 미리보기 결과를 사용자가 승인한 뒤 이 필드로 저장.
+ * ticker 편집은 여전히 지원 X (다른 종목으로 바꾸려면 삭제 후 재등록).
  */
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
@@ -32,12 +36,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const existing = await prisma.customStrategy.findUnique({ where: { id } })
     if (!existing) return fail('전략을 찾을 수 없습니다.', 404)
 
-    const data: {
-      name?: string
-      isActive?: boolean
-      frequency?: string
-      logic?: string
-    } = {}
+    const data: Prisma.CustomStrategyUpdateInput = {}
 
     if (body.name !== undefined) {
       const name = typeof body.name === 'string' ? body.name.trim() : ''
@@ -63,6 +62,16 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         return fail('logic 은 AND / OR 중 하나여야 합니다.', 400)
       }
       data.logic = body.logic
+    }
+
+    if (body.conditions !== undefined) {
+      if (!Array.isArray(body.conditions) || body.conditions.length === 0) {
+        return fail('conditions 는 최소 1개 이상의 조건 배열이어야 합니다.', 400)
+      }
+      if (!body.conditions.every(validateCondition)) {
+        return fail('conditions 에 유효하지 않은 항목이 있습니다.', 400)
+      }
+      data.conditions = body.conditions as unknown as Prisma.InputJsonValue
     }
 
     if (Object.keys(data).length === 0) {

--- a/src/components/strategies/StrategyEditModal.tsx
+++ b/src/components/strategies/StrategyEditModal.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useState } from 'react'
 import { useToast } from '@/components/ui/Toast'
 import type { CustomStrategyRow } from './types'
+import { conditionToString } from '@/lib/custom-strategy/types'
+import type {
+  Condition, LogicOp, Frequency, ParsedStrategy,
+} from '@/lib/custom-strategy/types'
+import type { StrategyDiff } from '@/lib/custom-strategy/diff'
 
 interface StrategyEditModalProps {
   item: CustomStrategyRow
@@ -10,13 +15,24 @@ interface StrategyEditModalProps {
   onSaved: () => void
 }
 
+interface NLPreview {
+  before: ParsedStrategy
+  after: ParsedStrategy
+  diff: StrategyDiff
+}
+
 export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEditModalProps) {
   const { show } = useToast()
   const [name, setName] = useState(item.name)
-  const [frequency, setFrequency] = useState(item.frequency)
-  const [logic, setLogic] = useState(item.logic)
+  const [frequency, setFrequency] = useState<Frequency>(item.frequency as Frequency)
+  const [logic, setLogic] = useState<LogicOp>(item.logic as LogicOp)
   const [isActive, setIsActive] = useState(item.isActive)
   const [saving, setSaving] = useState(false)
+
+  // Phase 35-B (#434) — 자연어 편집
+  const [nlInput, setNlInput] = useState('')
+  const [nlPreview, setNlPreview] = useState<NLPreview | null>(null)
+  const [nlLoading, setNlLoading] = useState(false)
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -26,11 +42,45 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
-  const dirty =
+  const dirtyBasics =
     name.trim() !== item.name ||
     frequency !== item.frequency ||
     logic !== item.logic ||
     isActive !== item.isActive
+  const dirty = dirtyBasics || nlPreview !== null
+  // self-review P1 (#434): 미리보기 활성 시 기본 필드는 잠금.
+  // 원래 로직은 nlPreview 있으면 nlPreview.after 값을 우선 → 사용자가 name 을
+  // 수동 편집해도 무시. 시각적 disable 로 혼란 방지.
+  const basicsLocked = nlPreview !== null
+
+  const handlePreview = async () => {
+    if (!nlInput.trim() || nlLoading) return
+    setNlLoading(true)
+    setNlPreview(null)
+    try {
+      const res = await fetch(`/api/custom-strategies/${item.id}/nl-edit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instruction: nlInput.trim() }),
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        show({ variant: 'error', title: json?.error ?? '미리보기 실패' })
+        return
+      }
+      setNlPreview(json.data as NLPreview)
+    } catch (e) {
+      console.error('[strategies] nl-edit preview 실패:', e)
+      show({ variant: 'error', title: '미리보기 요청 중 오류가 발생했습니다.' })
+    } finally {
+      setNlLoading(false)
+    }
+  }
+
+  const clearPreview = () => {
+    setNlPreview(null)
+    setNlInput('')
+  }
 
   const handleSave = async () => {
     if (!dirty || saving) return
@@ -42,10 +92,18 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
     setSaving(true)
     try {
       const body: Record<string, unknown> = {}
-      if (trimmedName !== item.name) body.name = trimmedName
-      if (frequency !== item.frequency) body.frequency = frequency
-      if (logic !== item.logic) body.logic = logic
+      const eff = nlPreview?.after
+      // NL 편집 반영: after 값을 기본 필드에도 적용
+      const effName = eff?.name ?? trimmedName
+      const effFreq = eff?.frequency ?? frequency
+      const effLogic = eff?.logic ?? logic
+      const effConds = eff?.conditions
+
+      if (effName !== item.name) body.name = effName
+      if (effFreq !== item.frequency) body.frequency = effFreq
+      if (effLogic !== item.logic) body.logic = effLogic
       if (isActive !== item.isActive) body.isActive = isActive
+      if (effConds) body.conditions = effConds
 
       const res = await fetch(`/api/custom-strategies/${item.id}`, {
         method: 'PUT',
@@ -71,7 +129,7 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center px-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
       <div
-        className="w-full max-w-md rounded-xl border border-border bg-bg-raised p-6 space-y-4"
+        className="w-full max-w-lg rounded-xl border border-border bg-bg-raised p-6 space-y-4 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
@@ -86,13 +144,20 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
         </div>
 
         <div className="space-y-3">
+          {basicsLocked && (
+            <div className="text-[11px] text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded-md px-3 py-1.5">
+              🔒 자연어 미리보기 활성 — 기본 필드는 잠금. 수동 편집하려면 위에서 &quot;미리보기 취소&quot;.
+            </div>
+          )}
+
           <div>
             <label className="text-sub text-xs">이름</label>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
               maxLength={100}
-              className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin"
+              disabled={basicsLocked}
+              className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin disabled:opacity-50 disabled:cursor-not-allowed"
             />
           </div>
 
@@ -101,8 +166,9 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
               <label className="text-sub text-xs">발동 빈도</label>
               <select
                 value={frequency}
-                onChange={(e) => setFrequency(e.target.value)}
-                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin"
+                onChange={(e) => setFrequency(e.target.value as Frequency)}
+                disabled={basicsLocked}
+                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <option value="once">한 번만 (once)</option>
                 <option value="daily">매일 1회 (daily)</option>
@@ -113,8 +179,9 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
               <label className="text-sub text-xs">조건 결합</label>
               <select
                 value={logic}
-                onChange={(e) => setLogic(e.target.value)}
-                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin"
+                onChange={(e) => setLogic(e.target.value as LogicOp)}
+                disabled={basicsLocked}
+                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <option value="AND">AND (모두)</option>
                 <option value="OR">OR (하나)</option>
@@ -144,9 +211,53 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
             </button>
           </div>
 
-          <div className="rounded-lg bg-surface-dim border border-border px-3 py-2 text-xs text-sub">
-            <div className="font-semibold text-amber-400 mb-1">⚠️ 조건 자체는 편집 불가</div>
-            조건 (price/rsi/… ) 을 변경하려면 이 전략을 삭제 후 다시 등록해주세요.
+          {/* Phase 35-B — 자연어 편집 */}
+          <div className="rounded-lg bg-surface-dim border border-border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="text-bright font-semibold text-sm">🧠 자연어 편집</div>
+              {nlPreview && (
+                <button
+                  onClick={clearPreview}
+                  className="text-[11px] text-sub hover:text-bright"
+                >
+                  미리보기 취소
+                </button>
+              )}
+            </div>
+            <div className="text-[11px] text-sub">
+              예: &quot;SPY 조건 빼줘&quot; · &quot;어닝 5일로 완화&quot; · &quot;OR 로 바꿔&quot;
+            </div>
+            <textarea
+              value={nlInput}
+              onChange={(e) => setNlInput(e.target.value)}
+              placeholder="편집 지시를 자연어로 입력..."
+              rows={2}
+              maxLength={500}
+              disabled={nlLoading}
+              className="w-full bg-surface border border-border rounded-md px-3 py-2 text-sm text-bright placeholder:text-dim focus:outline-none focus:border-sejin disabled:opacity-50"
+            />
+            <div className="flex items-center justify-between">
+              <div className="text-[11px] text-dim">{nlInput.length}/500</div>
+              <button
+                onClick={handlePreview}
+                disabled={!nlInput.trim() || nlLoading}
+                className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-sejin/40 bg-sejin/15 text-sejin hover:bg-sejin/25 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {nlLoading ? '분석 중…' : '미리보기'}
+              </button>
+            </div>
+
+            {nlPreview && (
+              <div className="mt-2 space-y-2 border-t border-border pt-2">
+                <div className="text-[12px] font-semibold text-bright">변경 사항</div>
+                <DiffView diff={nlPreview.diff} />
+                {!hasAnyDiff(nlPreview.diff) && (
+                  <div className="text-[12px] text-amber-400">
+                    ⚠️ 변경 사항이 감지되지 않았습니다. 지시를 더 명확히 해주세요.
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
 
@@ -167,6 +278,53 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
           </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+function hasAnyDiff(d: StrategyDiff): boolean {
+  return !!(d.nameChanged || d.logicChanged || d.frequencyChanged || d.tickerChanged
+    || d.conditionsAdded.length > 0 || d.conditionsRemoved.length > 0)
+}
+
+function DiffView({ diff }: { diff: StrategyDiff }) {
+  return (
+    <div className="text-[12px] space-y-1">
+      {diff.nameChanged && (
+        <Line label="이름" from={diff.nameChanged.from} to={diff.nameChanged.to} />
+      )}
+      {diff.tickerChanged && (
+        <Line label="티커" from={diff.tickerChanged.from} to={diff.tickerChanged.to} />
+      )}
+      {diff.logicChanged && (
+        <Line label="Logic" from={diff.logicChanged.from} to={diff.logicChanged.to} />
+      )}
+      {diff.frequencyChanged && (
+        <Line label="빈도" from={diff.frequencyChanged.from} to={diff.frequencyChanged.to} />
+      )}
+      {diff.conditionsRemoved.map((c: Condition, i: number) => (
+        <div key={`r-${i}`} className="flex items-start gap-2">
+          <span className="text-red-400 font-mono">−</span>
+          <span className="text-red-400 font-mono">{conditionToString(c)}</span>
+        </div>
+      ))}
+      {diff.conditionsAdded.map((c: Condition, i: number) => (
+        <div key={`a-${i}`} className="flex items-start gap-2">
+          <span className="text-emerald-400 font-mono">+</span>
+          <span className="text-emerald-400 font-mono">{conditionToString(c)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Line({ label, from, to }: { label: string; from: string; to: string }) {
+  return (
+    <div className="flex items-center gap-1 text-sub">
+      <span className="text-dim w-14">{label}</span>
+      <span className="text-red-400 font-mono">{from}</span>
+      <span className="text-dim">→</span>
+      <span className="text-emerald-400 font-mono">{to}</span>
     </div>
   )
 }

--- a/src/components/strategies/StrategyEditModal.tsx
+++ b/src/components/strategies/StrategyEditModal.tsx
@@ -107,13 +107,19 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
       const effName = eff?.name ?? trimmedName
       const effFreq = eff?.frequency ?? frequency
       const effLogic = eff?.logic ?? logic
-      const effConds = eff?.conditions
 
       if (effName !== item.name) body.name = effName
       if (effFreq !== item.frequency) body.frequency = effFreq
       if (effLogic !== item.logic) body.logic = effLogic
       if (isActive !== item.isActive) body.isActive = isActive
-      if (effConds) body.conditions = effConds
+      // Codex #440 재리뷰 P2: conditions 는 실제 조건 변경이 있을 때만 포함.
+      // preview 가 이름만 바꿔도 항상 conditions 를 넘기면 서버가 lastTriggeredAt
+      // 을 리셋할 수 있어 `once` 가 재무장. diff 에서 실제 add/remove 있을 때만.
+      const conditionsChanged = nlPreview
+        && (nlPreview.diff.conditionsAdded.length > 0 || nlPreview.diff.conditionsRemoved.length > 0)
+      if (conditionsChanged && eff?.conditions) {
+        body.conditions = eff.conditions
+      }
 
       const res = await fetch(`/api/custom-strategies/${item.id}`, {
         method: 'PUT',

--- a/src/components/strategies/StrategyEditModal.tsx
+++ b/src/components/strategies/StrategyEditModal.tsx
@@ -55,6 +55,16 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
 
   const handlePreview = async () => {
     if (!nlInput.trim() || nlLoading) return
+    // Codex #440 P2: preview 요청은 DB 상태 (before) 만 참조 → 로컬에서 name/logic/
+    // frequency 수동 편집 상태 후 preview 하면 `after` 가 DB 값 기준이라 save 시
+    // 사용자의 수동 변경이 사일런트 드롭됨. dirty 시 preview 차단해 순서 강제.
+    if (dirtyBasics) {
+      show({
+        variant: 'error',
+        title: '기본 필드 변경 사항이 있습니다. 먼저 저장하거나 되돌린 뒤 미리보기 해주세요.',
+      })
+      return
+    }
     setNlLoading(true)
     setNlPreview(null)
     try {
@@ -240,7 +250,8 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
               <div className="text-[11px] text-dim">{nlInput.length}/500</div>
               <button
                 onClick={handlePreview}
-                disabled={!nlInput.trim() || nlLoading}
+                disabled={!nlInput.trim() || nlLoading || dirtyBasics}
+                title={dirtyBasics ? '기본 필드 변경 사항이 있어 미리보기 차단 (먼저 저장/되돌리기)' : ''}
                 className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-sejin/40 bg-sejin/15 text-sejin hover:bg-sejin/25 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {nlLoading ? '분석 중…' : '미리보기'}

--- a/src/components/strategies/StrategyEditModal.tsx
+++ b/src/components/strategies/StrategyEditModal.tsx
@@ -245,7 +245,13 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
             </div>
             <textarea
               value={nlInput}
-              onChange={(e) => setNlInput(e.target.value)}
+              onChange={(e) => {
+                setNlInput(e.target.value)
+                // Codex #440 P2: 지시 텍스트가 편집되면 이전 preview 는 stale.
+                // 사용자가 preview 재실행 없이 save 하면 이전 지시의 after 로 저장돼
+                // 화면 텍스트와 실제 저장이 어긋남. 텍스트 변경 시 preview 무효화.
+                if (nlPreview) setNlPreview(null)
+              }}
               placeholder="편집 지시를 자연어로 입력..."
               rows={2}
               maxLength={500}

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -137,6 +137,24 @@ describe('computeStrategyDiff (Phase 35-B / #434)', () => {
     expect(conditionsEqual(a, b)).toBe(true)
   })
 
+  it('conditionsEqual — 비-change_pct 조건의 timeframe 은 무시 (Codex #440 재재재재리뷰 P2)', () => {
+    // evaluator 는 price/rsi/문자열 조건에서 timeframe 을 사용 안 함.
+    // conditionToString 이 렌더링 하는 게 문제 → canonical key 에서 timeframe 배제.
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 40 }]
+    const b: Condition[] = [{ type: 'price', operator: '<=', value: 40, timeframe: '1d' }]
+    expect(conditionsEqual(a, b)).toBe(true)
+
+    const c: Condition[] = [{ type: 'rsi', operator: '<=', value: 30 }]
+    const d: Condition[] = [{ type: 'rsi', operator: '<=', value: 30, timeframe: '5d' }]
+    expect(conditionsEqual(c, d)).toBe(true)
+  })
+
+  it('conditionsEqual — change_pct 는 timeframe 다르면 not equal', () => {
+    const a: Condition[] = [{ type: 'change_pct', operator: '<=', value: -5, timeframe: '1d' }]
+    const b: Condition[] = [{ type: 'change_pct', operator: '<=', value: -5, timeframe: '5d' }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
   it('conditionsEqual — cross_ticker 다른 crossTicker 는 여전히 not equal', () => {
     const a: Condition[] = [{
       type: 'cross_ticker', operator: '>', value: 25,

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -124,6 +124,31 @@ describe('computeStrategyDiff (Phase 35-B / #434)', () => {
     expect(conditionsEqual(a, b)).toBe(true)
   })
 
+  it('conditionsEqual — cross_ticker crossTicker 대소문자/공백 무관 (Codex #440 재재재리뷰 P2)', () => {
+    // evaluator 는 `trim().toUpperCase()` 정규화 → 'vix' 와 'VIX' 의미 동일.
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    }]
+    const b: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: '  vix ', metric: 'price',
+    }]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — cross_ticker 다른 crossTicker 는 여전히 not equal', () => {
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    }]
+    const b: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'SPY', metric: 'price',
+    }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
   it('conditionsEqual — 다른 weekday 조합은 여전히 다르다고 판정', () => {
     const a: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'TUE'] }]
     const b: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'FRI'] }]

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { computeStrategyDiff, hasDiff } from '../diff'
-import type { ParsedStrategy } from '../types'
+import { computeStrategyDiff, hasDiff, conditionsEqual } from '../diff'
+import type { Condition, ParsedStrategy } from '../types'
 
 const base: ParsedStrategy = {
   name: 'AAPL 저점',
@@ -84,6 +84,41 @@ describe('computeStrategyDiff (Phase 35-B / #434)', () => {
     expect(d.conditionsAdded).toEqual([])
     expect(d.conditionsRemoved).toEqual([])
     expect(hasDiff(d)).toBe(false)
+  })
+
+  it('conditionsEqual — 순서 무관 (Codex #440 재리뷰 P2 회귀 방지)', () => {
+    const a: Condition[] = [
+      { type: 'price', operator: '<=', value: 150 },
+      { type: 'rsi', operator: '<=', value: 30 },
+    ]
+    // 조건 순서 뒤바꾼 배열
+    const b: Condition[] = [
+      { type: 'rsi', operator: '<=', value: 30 },
+      { type: 'price', operator: '<=', value: 150 },
+    ]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — 조건 오브젝트 필드 순서가 달라도 true', () => {
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
+    // JSON.stringify 는 field-order 민감하지만 conditionToString 은 무관
+    const b: Condition[] = [{ value: 150, operator: '<=', type: 'price' } as Condition]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — 길이 다르면 false', () => {
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
+    const b: Condition[] = [
+      { type: 'price', operator: '<=', value: 150 },
+      { type: 'rsi', operator: '<=', value: 30 },
+    ]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('conditionsEqual — 값 다르면 false', () => {
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
+    const b: Condition[] = [{ type: 'price', operator: '<=', value: 140 }]
+    expect(conditionsEqual(a, b)).toBe(false)
   })
 
   it('복합 변경 (logic + 조건 추가 + 조건 제거)', () => {

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { computeStrategyDiff, hasDiff } from '../diff'
+import type { ParsedStrategy } from '../types'
+
+const base: ParsedStrategy = {
+  name: 'AAPL 저점',
+  ticker: 'AAPL',
+  conditions: [
+    { type: 'price', operator: '<=', value: 150 },
+    { type: 'rsi', operator: '<=', value: 30 },
+  ],
+  logic: 'AND',
+  frequency: 'daily',
+}
+
+describe('computeStrategyDiff (Phase 35-B / #434)', () => {
+  it('동일 전략 → 변경 없음', () => {
+    const d = computeStrategyDiff(base, base)
+    expect(hasDiff(d)).toBe(false)
+    expect(d.conditionsAdded).toEqual([])
+    expect(d.conditionsRemoved).toEqual([])
+  })
+
+  it('name 변경 감지', () => {
+    const after = { ...base, name: 'AAPL 매수' }
+    const d = computeStrategyDiff(base, after)
+    expect(d.nameChanged).toEqual({ from: 'AAPL 저점', to: 'AAPL 매수' })
+    expect(hasDiff(d)).toBe(true)
+  })
+
+  it('logic 변경 감지', () => {
+    const after = { ...base, logic: 'OR' as const }
+    const d = computeStrategyDiff(base, after)
+    expect(d.logicChanged).toEqual({ from: 'AND', to: 'OR' })
+  })
+
+  it('frequency 변경 감지', () => {
+    const after = { ...base, frequency: 'always' as const }
+    const d = computeStrategyDiff(base, after)
+    expect(d.frequencyChanged).toEqual({ from: 'daily', to: 'always' })
+  })
+
+  it('조건 제거 감지', () => {
+    const after = { ...base, conditions: [base.conditions[0]] }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsRemoved).toHaveLength(1)
+    expect(d.conditionsRemoved[0].type).toBe('rsi')
+    expect(d.conditionsAdded).toEqual([])
+  })
+
+  it('조건 추가 감지', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [
+        ...base.conditions,
+        { type: 'earnings_within_days', operator: '>=', value: 7 },
+      ],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsAdded).toHaveLength(1)
+    expect(d.conditionsAdded[0].type).toBe('earnings_within_days')
+    expect(d.conditionsRemoved).toEqual([])
+  })
+
+  it('조건 값 변경 → 제거 1 + 추가 1 (문자열 비교 기반 대체)', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [
+        { type: 'price', operator: '<=', value: 140 },  // 150 → 140
+        base.conditions[1],
+      ],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsRemoved).toHaveLength(1)
+    expect(d.conditionsAdded).toHaveLength(1)
+  })
+
+  it('조건 순서 바뀌어도 변경 없음 (문자열 기반, 순서 무관)', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [base.conditions[1], base.conditions[0]],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsAdded).toEqual([])
+    expect(d.conditionsRemoved).toEqual([])
+    expect(hasDiff(d)).toBe(false)
+  })
+
+  it('복합 변경 (logic + 조건 추가 + 조건 제거)', () => {
+    const after: ParsedStrategy = {
+      name: base.name,
+      ticker: base.ticker,
+      conditions: [
+        { type: 'price', operator: '<=', value: 150 },
+        { type: 'earnings_within_days', operator: '>=', value: 7 },
+      ],
+      logic: 'OR',
+      frequency: 'daily',
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.logicChanged).toEqual({ from: 'AND', to: 'OR' })
+    expect(d.conditionsAdded).toHaveLength(1)
+    expect(d.conditionsRemoved).toHaveLength(1)
+    expect(hasDiff(d)).toBe(true)
+  })
+})

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -115,6 +115,21 @@ describe('computeStrategyDiff (Phase 35-B / #434)', () => {
     expect(conditionsEqual(a, b)).toBe(false)
   })
 
+  it('conditionsEqual — weekday value 순서 무관 (Codex #440 재재리뷰 P2 회귀 방지)', () => {
+    // evaluator 는 weekday value 를 `includes` 로 처리 → 배열 순서 무관.
+    // conditionToString 은 순서 유지 → JSON.stringify 비교였다면 오검출.
+    // canonical key (정렬) 로 정정 확인.
+    const a: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'TUE', 'WED'] }]
+    const b: Condition[] = [{ type: 'weekday', operator: 'is', value: ['WED', 'MON', 'TUE'] }]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — 다른 weekday 조합은 여전히 다르다고 판정', () => {
+    const a: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'TUE'] }]
+    const b: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'FRI'] }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
   it('conditionsEqual — 값 다르면 false', () => {
     const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
     const b: Condition[] = [{ type: 'price', operator: '<=', value: 140 }]

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -56,3 +56,19 @@ export function hasDiff(d: StrategyDiff): boolean {
     d.conditionsAdded.length > 0 || d.conditionsRemoved.length > 0
   )
 }
+
+/**
+ * Pure — 두 조건 배열이 의미적으로 동일한지 (순서·필드순 무관) 비교.
+ * `conditionToString` 은 fixed key order (`type / operator / value / timeframe`) 로
+ * 렌더링하므로 원본 오브젝트의 필드 순서에 관계없이 같은 문자열을 생성.
+ *
+ * PUT 흐름에서 conditions 무변경 판정에 사용 (Codex #440 재리뷰 P2 — 이전 구현은
+ * `JSON.stringify` 로 field-order-sensitive 비교 → 동일 의미인데 필드 순서만 다른
+ * 요청도 변경으로 오판 → lastTriggeredAt 오리셋 → `once` 재무장).
+ */
+export function conditionsEqual(a: Condition[], b: Condition[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = a.map(conditionToString).sort()
+  const sb = b.map(conditionToString).sort()
+  return sa.every((s, i) => s === sb[i])
+}

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -3,7 +3,7 @@
  * 미리보기 UI 가 변경 사항을 하이라이트하기 위한 순수 함수.
  */
 
-import type { Condition, LogicOp, Frequency, ParsedStrategy } from './types'
+import type { Condition, LogicOp, Frequency, ParsedStrategy, WeekdayCode } from './types'
 import { conditionToString } from './types'
 
 export interface StrategyDiff {
@@ -15,8 +15,18 @@ export interface StrategyDiff {
   conditionsRemoved: Condition[]
 }
 
-/** Condition 등가 판정 — conditionToString 문자열 표현으로 비교 (조건 순서 무관). */
+/**
+ * Condition 등가 판정용 canonical key (Codex #440 재재리뷰 P2 반영).
+ * 대부분은 `conditionToString` 그대로 사용. 예외:
+ *   - `weekday` value 는 evaluator 가 `includes` 로 unordered set 취급 →
+ *     ['MON','TUE'] 와 ['TUE','MON'] 는 의미 동일. 순서 유지 시 오검출.
+ *     정렬한 배열로 별도 canonical key 생성.
+ */
 function condKey(c: Condition): string {
+  if (c.type === 'weekday' && Array.isArray(c.value)) {
+    const sorted = [...(c.value as WeekdayCode[])].sort()
+    return `weekday ${c.operator} [${sorted.join(',')}]`
+  }
   return conditionToString(c)
 }
 
@@ -68,7 +78,7 @@ export function hasDiff(d: StrategyDiff): boolean {
  */
 export function conditionsEqual(a: Condition[], b: Condition[]): boolean {
   if (a.length !== b.length) return false
-  const sa = a.map(conditionToString).sort()
-  const sb = b.map(conditionToString).sort()
+  const sa = a.map(condKey).sort()
+  const sb = b.map(condKey).sort()
   return sa.every((s, i) => s === sb[i])
 }

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -1,0 +1,58 @@
+/**
+ * Phase 35-B (#434) — 전략 편집 diff 계산 (pure).
+ * 미리보기 UI 가 변경 사항을 하이라이트하기 위한 순수 함수.
+ */
+
+import type { Condition, LogicOp, Frequency, ParsedStrategy } from './types'
+import { conditionToString } from './types'
+
+export interface StrategyDiff {
+  nameChanged?: { from: string; to: string }
+  logicChanged?: { from: LogicOp; to: LogicOp }
+  frequencyChanged?: { from: Frequency; to: Frequency }
+  tickerChanged?: { from: string; to: string }
+  conditionsAdded: Condition[]
+  conditionsRemoved: Condition[]
+}
+
+/** Condition 등가 판정 — conditionToString 문자열 표현으로 비교 (조건 순서 무관). */
+function condKey(c: Condition): string {
+  return conditionToString(c)
+}
+
+export function computeStrategyDiff(before: ParsedStrategy, after: ParsedStrategy): StrategyDiff {
+  const diff: StrategyDiff = { conditionsAdded: [], conditionsRemoved: [] }
+
+  if (before.name !== after.name) {
+    diff.nameChanged = { from: before.name, to: after.name }
+  }
+  if (before.ticker !== after.ticker) {
+    diff.tickerChanged = { from: before.ticker, to: after.ticker }
+  }
+  if (before.logic !== after.logic) {
+    diff.logicChanged = { from: before.logic, to: after.logic }
+  }
+  if (before.frequency !== after.frequency) {
+    diff.frequencyChanged = { from: before.frequency, to: after.frequency }
+  }
+
+  const beforeKeys = new Map(before.conditions.map((c) => [condKey(c), c]))
+  const afterKeys = new Map(after.conditions.map((c) => [condKey(c), c]))
+
+  for (const [k, c] of afterKeys) {
+    if (!beforeKeys.has(k)) diff.conditionsAdded.push(c)
+  }
+  for (const [k, c] of beforeKeys) {
+    if (!afterKeys.has(k)) diff.conditionsRemoved.push(c)
+  }
+
+  return diff
+}
+
+/** diff 가 실제 변경을 포함하는지 (미리보기 UI 에서 "변경 없음" 표시용) */
+export function hasDiff(d: StrategyDiff): boolean {
+  return !!(
+    d.nameChanged || d.logicChanged || d.frequencyChanged || d.tickerChanged ||
+    d.conditionsAdded.length > 0 || d.conditionsRemoved.length > 0
+  )
+}

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -16,16 +16,22 @@ export interface StrategyDiff {
 }
 
 /**
- * Condition 등가 판정용 canonical key (Codex #440 재재리뷰 P2 반영).
- * 대부분은 `conditionToString` 그대로 사용. 예외:
- *   - `weekday` value 는 evaluator 가 `includes` 로 unordered set 취급 →
- *     ['MON','TUE'] 와 ['TUE','MON'] 는 의미 동일. 순서 유지 시 오검출.
- *     정렬한 배열로 별도 canonical key 생성.
+ * Condition 등가 판정용 canonical key.
+ * 대부분은 `conditionToString` 그대로 사용. 예외 (evaluator 가 실행 시 정규화하는
+ * 필드는 canonical key 도 동일하게 정규화 → 무변경 편집이 false-positive 되지 않게):
+ *   - `weekday` value: evaluator 가 `includes` 로 unordered set 취급 → 정렬
+ *     (Codex #440 재재리뷰 P2)
+ *   - `cross_ticker.crossTicker`: evaluator 가 `trim().toUpperCase()` 정규화 →
+ *     canonical 도 대문자 (Codex #440 재재재리뷰 P2)
  */
 function condKey(c: Condition): string {
   if (c.type === 'weekday' && Array.isArray(c.value)) {
     const sorted = [...(c.value as WeekdayCode[])].sort()
     return `weekday ${c.operator} [${sorted.join(',')}]`
+  }
+  if (c.type === 'cross_ticker') {
+    const t = (c.crossTicker ?? '').trim().toUpperCase()
+    return `${t}.${c.metric ?? '?'} ${c.operator} ${c.value}`
   }
   return conditionToString(c)
 }

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -17,12 +17,16 @@ export interface StrategyDiff {
 
 /**
  * Condition 등가 판정용 canonical key.
- * 대부분은 `conditionToString` 그대로 사용. 예외 (evaluator 가 실행 시 정규화하는
- * 필드는 canonical key 도 동일하게 정규화 → 무변경 편집이 false-positive 되지 않게):
- *   - `weekday` value: evaluator 가 `includes` 로 unordered set 취급 → 정렬
- *     (Codex #440 재재리뷰 P2)
- *   - `cross_ticker.crossTicker`: evaluator 가 `trim().toUpperCase()` 정규화 →
- *     canonical 도 대문자 (Codex #440 재재재리뷰 P2)
+ * `conditionToString` 을 기본으로 사용하되, evaluator 가 실행 시 무시하거나 정규화하는
+ * 필드는 canonical key 도 동일하게 처리해 무변경 편집 false-positive 를 방지.
+ *
+ * 정규화 대상 (evaluator semantics 대비):
+ *   - `weekday.value`: `includes` 로 unordered set 취급 → 정렬 (#440 재재리뷰 P2)
+ *   - `cross_ticker.crossTicker`: `trim().toUpperCase()` (#440 재재재리뷰 P2)
+ *   - **비-change_pct 조건의 `timeframe`**: change_pct 전용 필드. price/rsi/문자열
+ *     타입에 timeframe 이 붙어 와도 evaluator 는 무시 → canonical 에서도 배제
+ *     (#440 재재재재리뷰 P2). conditionToString 이 timeframe 을 어느 타입에나 렌더
+ *     하는 것이 문제 원인.
  */
 function condKey(c: Condition): string {
   if (c.type === 'weekday' && Array.isArray(c.value)) {
@@ -32,6 +36,10 @@ function condKey(c: Condition): string {
   if (c.type === 'cross_ticker') {
     const t = (c.crossTicker ?? '').trim().toUpperCase()
     return `${t}.${c.metric ?? '?'} ${c.operator} ${c.value}`
+  }
+  // change_pct 만 timeframe 관여. 그 외 타입은 timeframe 무시.
+  if (c.type !== 'change_pct') {
+    return `${c.type} ${c.operator} ${c.value}`
   }
   return conditionToString(c)
 }

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -157,3 +157,88 @@ export async function parseStrategyText(text: string): Promise<ParsedStrategy> {
   // ticker 대문자 정규화 (parser 프롬프트에도 있지만 방어)
   return { ...parsed, ticker: parsed.ticker.toUpperCase().trim() }
 }
+
+/**
+ * Phase 35-B (#434) — 자연어 전략 편집.
+ * 기존 전략 컨텍스트 + 자연어 지시 → 갱신된 ParsedStrategy 반환. 상대 편집
+ * ("SPY 조건 빼줘", "어닝 5일로 완화") 지원. 지원 조건 밖 지시는 error throw.
+ */
+export async function editStrategyByNL(
+  current: ParsedStrategy,
+  instruction: string,
+): Promise<ParsedStrategy> {
+  if (!instruction || !instruction.trim()) {
+    throw new Error('편집 지시를 입력해주세요.')
+  }
+  if (instruction.length > 500) {
+    throw new Error('편집 지시가 너무 깁니다 (500자 이하).')
+  }
+
+  const contextBlock = JSON.stringify(
+    {
+      name: current.name,
+      ticker: current.ticker,
+      conditions: current.conditions,
+      logic: current.logic,
+      frequency: current.frequency,
+    },
+    null,
+    2,
+  )
+
+  const editHeader = `
+사용자가 아래 기존 전략을 자연어 지시대로 수정한 결과를 JSON 으로 응답해줘.
+반환 스키마는 등록과 동일 (name / ticker / conditions / logic / frequency).
+오직 JSON 오브젝트만 출력 — 다른 설명/코드블록 없이.
+
+## 상대 편집 규칙
+- "SPY 조건 빼줘" / "어닝 조건 제거" → 해당 type 의 condition 삭제
+- "어닝 5일로 완화" / "RSI 25 로 강화" → 해당 condition value 조정
+- "OR 로 바꿔" → logic 변경
+- "매일 한 번만" / "always 로" → frequency 변경
+- "이름을 X 로" → name 변경
+- 지시가 애매하면 { "error": "지시 애매: ..." } 로 응답
+- 기존 전략에 없는 조건 타입을 새로 요구 → 등록 규칙 그대로 (지원 타입 밖이면 error)
+
+${PROMPT_HEADER}
+
+## 기존 전략 (JSON)
+${contextBlock}
+
+## 편집 지시
+`
+
+  const prompt = `${editHeader}${instruction.trim()}`
+
+  // 편집도 등록과 동일하게 sonnet 로 (스키마 안정성 우선).
+  const result = await askAdvisor(prompt, {
+    model: 'sonnet',
+    timeout: 60_000,
+    maxBudgetUsd: 0.2,
+  })
+
+  const raw = result.response.trim()
+  const firstBrace = raw.indexOf('{')
+  const lastBrace = raw.lastIndexOf('}')
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
+    throw new Error(`AI 편집 응답에 JSON 오브젝트가 없습니다. 표현을 바꿔서 재시도해주세요.\n원문: ${raw.slice(0, 200)}`)
+  }
+  const cleaned = raw.slice(firstBrace, lastBrace + 1).trim()
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(cleaned)
+  } catch {
+    throw new Error(`AI 편집 응답이 JSON 이 아닙니다. 재시도 하거나 표현을 바꿔주세요.\n원문: ${cleaned.slice(0, 200)}`)
+  }
+
+  if (isParseError(parsed)) {
+    throw new Error(`편집 실패: ${parsed.error}`)
+  }
+
+  if (!validateParsedStrategy(parsed)) {
+    throw new Error(`AI 편집 결과가 유효한 전략 스키마가 아닙니다. 지시를 더 명확히 해주세요.`)
+  }
+
+  return { ...parsed, ticker: parsed.ticker.toUpperCase().trim() }
+}


### PR DESCRIPTION
## Summary
`/strategies` 편집 모달에서 자연어 지시로 조건 수정. 상대 편집 ("SPY 빼줘", "어닝 5일로 완화", "OR 로 바꿔") 지원.

- Master: #432 (16차). Spec: `docs/specs/434-nl-strategy-edit.md`
- `editStrategyByNL` parser 확장 (sonnet 사용)
- `computeStrategyDiff` pure diff 계산
- 신규 `POST .../nl-edit` (미리보기, 저장 X)
- `PUT .../[id]` conditions 필드 지원 확장
- UI: 자연어 입력 + 미리보기 + diff (+/−) + 적용

## Self-review 반영 (P0/P1/P2 = 0 → 2 P1 반영 후 clean)
- **P1-1 티커 silent drop**: nl-edit route 가 `after.ticker !== before.ticker` 를 400 거부 → 조건이 다른 티커 기준으로 잘못 저장되는 위험 차단
- **P1-2 기본 필드 override**: 미리보기 활성 시 name/frequency/logic 시각 disable + 안내 배지 (isActive 는 편집 가능 유지)

## Test plan (490 pass)
- [x] `diff.test.ts` 9 케이스
- [x] lint / typecheck / test / build 통과
- [ ] 실제 전략 편집 → 미리보기 → 저장 flow 확인 (배포 후)

Closes #434