### PR TITLE
Release v0.14.0 — 16차 마일스톤 (AI 정책 강화, Phase 36 이월)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -402,4 +402,19 @@
 ## Phase 34: 커스텀 전략 v3
 - [x] **34-A**: 어닝 캘린더 조건 (`earnings_within_days`, yahoo-finance2 무료)
 - [x] **34-B**: 크로스-티커 조건 (`cross_ticker` SPY/VIX 등 벤치마크 게이트)
-- [ ] **34-C**: 뉴스 조건 (외부 API 승인 후 별도 마일스톤으로 이월, #421)
+- [ ] **34-C**: 뉴스 조건 (16차 Phase 36 으로 재구성, 다시 17차로 이월)
+
+---
+
+# 16차 마일스톤 — AI 정책 강화 & 뉴스 조건
+
+> `/ai` sonnet 승격 + 자연어 전략 편집 (Phase 35). 뉴스 조건 (Phase 36) 은 17차 이월.
+
+## Phase 35: AI 정책 강화
+- [x] **35-A**: `/ai` 자유대화 sonnet 승격 + `AdvisorIntent` API
+- [x] **35-B**: 자연어 전략 편집 (미리보기 + diff + PUT conditions 확장)
+
+## Phase 36: 뉴스 조건 (17차 이월)
+- [ ] **36-A**: 뉴스 API 도입 결정 — 조사 완료 (`docs/specs/435-news-api-decision.md`), 17차에서 결정
+- [ ] **36-B**: NewsCache + fetcher + cron
+- [ ] **36-C**: `news_keyword` 조건

--- a/docs/specs/432-milestone-16-master.md
+++ b/docs/specs/432-milestone-16-master.md
@@ -1,0 +1,139 @@
+# 16차 마일스톤 — AI 정책 강화 & 뉴스 조건 (마스터)
+
+- **작성일**: 2026-07-10
+- **타입**: 마일스톤 (마스터 스펙, sub-phase 분할)
+- **참조**: 15차 마스터 #414, `memory/project_next_milestone_16.md`
+- **대체**: #421 (기존 34-C 뉴스 조건 이슈는 close, Phase 36 3개 서브로 재발행)
+
+## 1. 배경
+
+15차 완료 후 사용자 명시 pain:
+1. `/ai` 자유 질문 채널이 haiku 로 돌아 도구 체이닝·트레이드오프 서술이 얕음 (능동 리뷰·브리핑은 이미 sonnet 로 올려둔 상태와 불일관).
+2. `/strategies` 는 등록 시만 자연어. 편집은 JSON 손편집 → 자연어 기반 관리 UX 결여.
+3. 15차 이월된 뉴스 조건 (#421) 은 외부 API 승인 대기 상태. API 후보 확정 후 정식 착수.
+
+## 2. 목표
+
+16차 종료 시:
+- ✅ `/ai` (텔레그램 + 웹) 이 sonnet 로 동작. 파서·짧은 가이드는 haiku 유지 (비용·응답속도 균형)
+- ✅ `AdvisorOptions.intent` 로 의도 명시 → 향후 모델 정책 조정 시 한 곳에서만 관리
+- ✅ `/strategies` 편집 모달에서 자연어로 조건 수정 (상대 편집 지원)
+- ✅ 뉴스 조건 (`news_keyword`) 도입 → 벤치마크/어닝에 이어 v3 완결
+
+## 3. Sub-Phase 분할
+
+### Phase 35: AI 정책 강화
+
+#### 35-A: `/ai` 자유대화 채널 sonnet 승격 + intent API (~반나절)
+
+**목적**: 사용자 명시 pain 해소. 도구 체이닝·트레이드오프 서술 강화.
+
+- [ ] `AdvisorOptions.intent?: 'conversation' | 'parse' | 'guide'` 신설
+- [ ] `askAdvisor` 가 intent 기반으로 model 자동 결정 (명시 model 이 있으면 우선)
+  - `conversation` → sonnet
+  - `parse` / `guide` → haiku (default)
+- [ ] 호출부 갱신:
+  - `src/bot/commands/ai.ts` (텔레그램 `/ai`) → `intent: 'conversation'`
+  - `src/app/api/ai/ask/route.ts` → `intent: 'conversation'`
+  - `src/bot/commands/expense.ts` (가계부 파싱) → `intent: 'parse'`
+  - `src/bot/commands/ai.ts` (거래 파싱 라인 141) → `intent: 'parse'`
+  - `src/bot/notifications/ta-signal-alert.ts` (TA 가이드) → `intent: 'guide'`
+  - `src/lib/custom-strategy/parser.ts` → `intent: 'parse'`
+- [ ] 테스트: intent → model 매핑 pure 유닛
+
+**노력**: XS
+
+#### 35-B: 자연어 전략 편집 (~1일)
+
+**목적**: 등록 뿐 아니라 편집도 자연어로 → 관리 UX 통일.
+
+- [ ] 편집 프롬프트 (`editStrategyByNL`):
+  - 입력: 기존 `CustomStrategy` (name / ticker / conditions / logic / frequency) + 자연어 지시
+  - 출력: 갱신된 `ParsedStrategy` (또는 error)
+- [ ] "SPY 조건 빼줘", "어닝 5일로 완화", "OR 로 바꿔" 같은 **상대 편집** 지원
+- [ ] `/strategies` 편집 모달에 자연어 입력 필드 (기존 JSON 편집과 병존)
+- [ ] 미리보기 UI (변경 사항 diff 표기)
+- [ ] 테스트: 프롬프트 spec + evaluator 통과 여부
+
+**노력**: S
+
+### Phase 36: 뉴스 조건 (v3 완결)
+
+#### 36-A: 뉴스 API 도입 결정 (스펙) (~반나절)
+
+**목적**: 후보 API 비교 → 사용자 승인 획득 → 아래 단계 진행 근거.
+
+- [ ] 후보 매트릭스: newsapi.org 무료 (100 req/day) / alpha vantage news / benzinga
+- [ ] 비교 축: 가격 · 커버리지 (KRX 포함 여부) · rate limit · headline vs full content · sentiment 제공 여부
+- [ ] 개인 서비스 규모 (관심종목 + 활성 전략 ~30~50 티커) 대비 rate limit 계산
+- [ ] 사용자 최종 선택 → `docs/specs/*-news-api-decision.md` 커밋 후 착수
+
+**노력**: XS (조사 위주)
+
+#### 36-B: NewsCache + fetcher + cron (~1일)
+
+- [ ] Prisma 신규 모델:
+  ```
+  NewsCache {
+    id           String   @id @default(cuid())
+    ticker       String
+    headline     String
+    publishedAt  DateTime
+    source       String
+    url          String
+    sentiment    Float?
+    insertedAt   DateTime @default(now())
+
+    @@unique([ticker, url])       // 티커 스코프 dedupe (Codex #438 P2 재리뷰)
+    @@index([ticker, publishedAt])
+  }
+  ```
+  - **`@@unique([ticker, url])`**: 하나의 기사 URL 이 여러 티커에 언급될 수 있음 (예:
+    "Big Tech 어닝" 기사 → AAPL/MSFT/GOOG). 글로벌 `url @unique` 는 후속 티커의 upsert
+    를 막거나 이전 row 를 덮어써 ticker 별 조회에서 헤드라인 누락. composite key 로
+    같은 기사 = 티커별 1 row 유지.
+  - `(ticker, publishedAt)` composite index (조회 성능)
+  - Retention: 30일 (cron 정리)
+- [ ] `src/lib/news/fetcher.ts` — 단일 티커 조회, 실패 → error 필드
+- [ ] `src/lib/news/cache.ts` — upsert / getByTickerRange / 오래된 삭제
+- [ ] `scheduleNewsFetch` — 시간별 (rate limit 감안). 대상 = 활성 전략 티커 ∪ 관심종목
+- [ ] 부팅 즉시 초기 시드 (34-A 어닝 패턴)
+- [ ] 테스트: fetcher mock + cache upsert + gather 로직
+
+**노력**: S
+
+#### 36-C: `news_keyword` 조건 (evaluator + parser) (~1일)
+
+- [ ] 조건 스키마:
+  ```
+  { type: 'news_keyword', operator: '>=' | '<=' | '>' | '<' | '==',
+    value: number,  // headline 개수
+    keyword: string,  // 필수 (필터 키워드)
+    timeframe: '24h' | '7d',
+  }
+  ```
+- [ ] Evaluator: NewsCache 조회 → keyword 매치 개수 산출 → numeric 비교
+- [ ] Parser 프롬프트 v3 섹션에 예시 추가 (예: "AAPL 관련 24h 뉴스 3건 이상 시")
+- [ ] `types.ts` 확장 (NUMERIC 유형이지만 keyword/timeframe 필수 검증)
+- [ ] `custom-strategy-alert` 에 `newsMap` 스냅샷 주입
+- [ ] 테스트
+
+**노력**: S
+
+## 4. 착수 순서
+
+```
+35-A (워밍업) → 35-B → 36-A (승인) → 36-B → 36-C
+```
+
+## 5. 제외 사항
+
+- **뉴스 감정 (sentiment) 조건** — 36-B/C 이후 데이터 관찰 → 필요 시 별도 이슈
+- **전략 편집 자연어에서 신규 조건 발명** — 지원 조건 밖은 error 로 응답 (등록 로직과 동일)
+- **AI advisor 모델 정책 변경** — intent 기반 오토 매핑 이후 개별 오버라이드는 명시 model 로만
+- **뉴스 KRX 종목 지원** — 국내 뉴스 API 별도 스코프 (후속)
+
+## 6. 참고
+
+- 15차 도입된 `src/lib/kst-date.ts` — 뉴스 timeframe 계산 시 재사용 가능
+- 15차 도입된 `AlertHistory` — 뉴스 조건 발동도 자동 저장 (kind: `custom_strategy` 그대로)

--- a/docs/specs/434-nl-strategy-edit.md
+++ b/docs/specs/434-nl-strategy-edit.md
@@ -1,0 +1,79 @@
+# [Phase 35-B] 자연어 전략 편집
+
+- **이슈**: #434
+- **마스터**: #432
+- **작성일**: 2026-07-10
+
+## 목표
+
+`/strategies` 편집 모달에서 자연어로 조건 수정. 등록 뿐 아니라 편집도 자연어 → UX 통일. **상대 편집** 지원 ("SPY 조건 빼줘", "어닝 5일로 완화", "OR 로 바꿔").
+
+## 현재 상태
+
+- 등록: 자연어 → `parseStrategyText` → ParsedStrategy 저장
+- 편집: JSON 손편집 (이름/logic/frequency/isActive 만, 조건 자체 편집 X — 삭제 후 재등록 안내)
+
+## 신규
+
+### `editStrategyByNL(current, instruction)` — parser.ts 확장
+
+- 입력: 기존 전략 (name/ticker/conditions/logic/frequency) + 자연어 지시
+- 출력: 갱신된 `ParsedStrategy` (또는 error)
+- 프롬프트: 기존 스키마 규칙 + 현재 상태 컨텍스트 + 편집 지시
+- 상대 편집 명시: "빼줘 / 완화 / 강화 / OR 로 바꿔" 등 사용자 표현 이해
+- 지원 조건 외 지시 → error 응답
+
+### API `POST /api/custom-strategies/[id]/nl-edit`
+
+- 입력: `{ instruction: string }`
+- 출력 (미리보기, 저장 X):
+  ```json
+  {
+    "success": true,
+    "data": {
+      "before": ParsedStrategy,
+      "after":  ParsedStrategy,
+      "diff": { conditionsAdded: [...], conditionsRemoved: [...], logicChanged?: {from, to}, frequencyChanged?: {from, to} }
+    }
+  }
+  ```
+- 실패 → 400 with error message
+
+### PUT 확장
+
+기존 `PUT /api/custom-strategies/[id]` 가 이름/logic/frequency/isActive 만 허용. **conditions 도 허용하도록 확장** — nl-edit 미리보기 결과를 사용자가 승인 시 이 필드로 저장.
+
+### UI (`StrategyEditModal.tsx`)
+
+기존 필드 + 신규 자연어 편집 섹션:
+- 텍스트 영역 (자연어 지시 입력)
+- "미리보기" 버튼 → API 호출 → diff 표시
+- diff: 조건 추가/제거 하이라이트 (기존 conditionToString 재사용)
+- "적용" 버튼 → PUT with `conditions` (+ 변경된 logic/frequency)
+
+"조건 자체는 편집 불가" 경고 문구 제거.
+
+## 파일 변경
+
+- `src/lib/custom-strategy/parser.ts` — `editStrategyByNL` + `EDIT_PROMPT_HEADER`
+- `src/app/api/custom-strategies/[id]/nl-edit/route.ts` (신규)
+- `src/app/api/custom-strategies/[id]/route.ts` — PUT 에 conditions 필드 허용 (검증 재사용)
+- `src/components/strategies/StrategyEditModal.tsx` — 자연어 편집 섹션 + preview UI
+
+## 테스트
+
+- `editStrategyByNL` — mock askAdvisor 로 성공/실패 시나리오
+- diff 계산 pure 함수 (`computeStrategyDiff`)
+- PUT conditions 유효성
+
+## 완료 조건
+
+- [ ] lint / typecheck / test / build 통과
+- [ ] self-review P0/P1/P2 = 0
+- [ ] verify: 실제 편집 요청 → preview 반환 → 저장 성공
+
+## 제외
+
+- **자연어로 신규 조건 발명** (뉴스/펀더 등) — 지원 밖은 error
+- **다중 지시 순차 적용** — 한 번의 편집은 한 개 지시 (여러 변경은 사용자가 개별 입력)
+- **음성 편집** — 스코프 밖

--- a/docs/specs/435-news-api-decision.md
+++ b/docs/specs/435-news-api-decision.md
@@ -1,0 +1,89 @@
+# [Phase 36-A] 뉴스 API 도입 결정
+
+- **이슈**: #435
+- **마스터**: #432
+- **작성일**: 2026-07-10
+- **상태**: 조사 완료 → **17차 마일스톤으로 이월 결정** (2026-07-10)
+
+## 1. 요구사항 재확인
+
+- **사용 규모**: 개인 서비스, 활성 전략 + 관심종목 ~30~50 티커
+- **갱신 주기**: 시간별 cron (24 회/일/티커) → 최대 ~1,200 req/day 이론치
+- **데이터**: headline / publishedAt / source / url 필수. sentiment 있으면 활용
+- **커버리지**: 미국주 우선. KRX 는 후속 스코프
+- **비용 상한**: 월 $50 이하 목표
+- **라이선스**: **실서비스 배포 필수** (dev 전용 tier 불가)
+
+## 2. 후보 매트릭스
+
+| 항목 | newsapi.org | Alpha Vantage News | Benzinga Basic |
+|---|---|---|---|
+| **무료 tier req** | 100/day | **25/day** (공식 support 페이지 명시, 2026-07 확인) | Basic (구체 불명) |
+| **무료 라이선스** | ❌ dev 전용 (localhost CORS, 24h 지연, 상용 금지) | 개인/비상용만 (ToS §2 — 상용은 별도 협의) | 확인 필요 (Basic 상용 여부 문의) |
+| **유료 최저** | $449/월 (250k req/월) | **$49.99/월** (75 req/min, no daily) | 문의 (전용 상담) |
+| **sentiment 내장** | ❌ | ✓ (핵심 강점) | ✓ (higher tier) |
+| **historical** | 1개월 (유료 5년) | 광범위 | 광범위 (financial 특화) |
+| **KRX 커버** | 부분 | ❌ (미국 위주) | ❌ (미국 금융 전용) |
+| **개발자 경험** | REST 단순, SDK 없음 | REST 단순, 문서 명확 | SDK + 문서 풍부 |
+
+### 상세 판단
+
+**newsapi.org 무료 tier — ❌ 실사용 불가**
+- CORS localhost 만 허용 → 서버 사이드 fetch 도 규정상 dev 전용
+- 상용 금지 명시
+- 24h 지연 → 알림 조건에 부적절
+- 유료 $449/월 은 스코프 대비 과잉
+
+**Alpha Vantage — ⭐ 후보 1**
+- 무료 tier: **25 req/day** (공식 support 페이지 2026-07 확인). 30~50 티커 × 하루 1회
+  스캔이면 이미 초과 → **free 검증 경로는 실질 불가**
+- 유료 $49.99/월: 75 req/min, no daily → 시간별 갱신 여유
+- **sentiment 필드 내장** → 별도 NLP 불필요
+- 커버리지 미국 위주 (KRX 없음 — 스펙과 일치)
+- 문서 명확
+- **라이선스 (ToS §2)**: 개인/비상용만 무료. myFinance 는 세진 개인 서비스 (가족 자산관리)
+  → 이 프로젝트 스코프에는 적합. 다른 프로젝트에서 이 문서를 참조 시 유료 협의 필요.
+
+**Benzinga — 조건부 후보 2**
+- Basic tier 무료 실제 스펙 불명 (AWS marketplace 리스팅 있으나 세부 미공개)
+- 유료는 개별 문의 → 소규모 개인 서비스 대응성 확인 필요
+- 미국 금융 전용이라 뉴스 품질 우수 예상
+
+## 3. 추천
+
+### 1순위: Alpha Vantage News Sentiment 유료 $49.99/월
+- 이유: 스코프 완벽 매치. sentiment 내장으로 개발 단순화. 예산 여유.
+- 30~50 티커 × 24h = 1,200 req/day → 75 req/min 여유 (분당 실제 1건 이하)
+
+### 2순위: Alpha Vantage 무료 tier 로 시작 (스코프 축소) — **재검토 필요**
+- 조사 결과 free tier 가 25 req/day 로 확인됨 (Codex #441 P2 반영) → 30~50 티커 스캔에는
+  실질 불가. 남는 옵션:
+  - 뉴스 조건 등록한 티커만 하루 1회 fetch → 티커 20개 이하로 제한 (약간 여유)
+  - 티커 그루핑 조회 지원 여부 확인 (Alpha Vantage news 는 티커 필터 다중 지원 확인 필요)
+- 유료 승격 없이 실사용 어려움 → 이 경로는 사실상 유료가 최소 조건
+
+### 3순위: Benzinga Basic
+- 이유: 사용자 문의 필요. 즉시 구현 어려움. 재검토 시점 미정
+
+## 4. 사용자 결정
+
+**17차 마일스톤으로 이월** (2026-07-10). 이유:
+- 뉴스 조건 도입은 유지·운영·API 비용 부담이 다른 응용 미수 이슈보다 낮은 우선순위
+- Phase 35 (35-A `/ai` sonnet 승격 + 35-B 자연어 전략 편집) 만 16차로 배포하고 사용자 검증
+- 17차 마일스톤 초입에서 우선순위 재검토 (계속 후속 / 또다시 이월 / 대안 조건)
+
+## 5. 후속
+
+- Phase 36 서브 이슈 (#435 / #436 / #437) 는 **close** — 17차 스코프 결정 시 재발행
+- 참고 리서치 결과는 이 문서에 보존 → 재검토 시 재활용
+
+## 5. 참고
+
+- Sources:
+  - [News API Pricing](https://newsapi.org/pricing)
+  - [Alpha Vantage Premium](https://www.alphavantage.co/premium/)
+  - [Alpha Vantage Support (2026-07 rate limits)](https://www.alphavantage.co/support/)
+  - [Alpha Vantage Terms of Service (§2 개인/비상용)](https://www.alphavantage.co/terms_of_service/)
+  - [Alpha Vantage Rate Limits Guide](https://www.macroption.com/alpha-vantage-api-limits/)
+  - [Benzinga API Docs](https://docs.benzinga.com/home)
+  - [Best News APIs Compared (Thunderbit)](https://thunderbit.com/blog/best-news-apis-compared)

--- a/src/app/api/ai/ask/route.ts
+++ b/src/app/api/ai/ask/route.ts
@@ -35,7 +35,8 @@ export async function POST(request: NextRequest) {
       return fail('질문을 입력해주세요.', 400)
     }
 
-    const result = await askAdvisor(prompt.trim())
+    // 웹 `/ai` — 자유 질문 → sonnet (Phase 35-A / #433)
+    const result = await askAdvisor(prompt.trim(), { intent: 'conversation' })
 
     return ok({
       response: result.response,

--- a/src/app/api/custom-strategies/[id]/nl-edit/route.ts
+++ b/src/app/api/custom-strategies/[id]/nl-edit/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Phase 35-B (#434) — 자연어 전략 편집 미리보기.
+ * POST /api/custom-strategies/[id]/nl-edit
+ *
+ * 입력: { instruction: string }
+ * 출력: { before, after, diff }  — **저장 X**. 사용자 승인 후 PUT 로 저장.
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
+import { editStrategyByNL } from '@/lib/custom-strategy/parser'
+import { computeStrategyDiff } from '@/lib/custom-strategy/diff'
+import type { Condition, LogicOp, Frequency, ParsedStrategy } from '@/lib/custom-strategy/types'
+import { validateCondition } from '@/lib/custom-strategy/types'
+
+export const dynamic = 'force-dynamic'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params
+    if (!id) return fail('전략 id가 필요합니다.', 400)
+
+    let body: Record<string, unknown>
+    try {
+      body = await request.json()
+    } catch {
+      return fail('유효한 JSON 형식이 아닙니다.', 400)
+    }
+
+    const instruction = typeof body.instruction === 'string' ? body.instruction.trim() : ''
+    if (!instruction) return fail('편집 지시를 입력해주세요.', 400)
+
+    const existing = await prisma.customStrategy.findUnique({ where: { id } })
+    if (!existing) return fail('전략을 찾을 수 없습니다.', 404)
+
+    const rawConds = Array.isArray(existing.conditions) ? (existing.conditions as unknown[]) : []
+    const before: ParsedStrategy = {
+      name: existing.name,
+      ticker: existing.ticker,
+      conditions: rawConds.filter(validateCondition) as Condition[],
+      logic: (existing.logic === 'OR' ? 'OR' : 'AND') as LogicOp,
+      frequency: (['once', 'daily', 'always'].includes(existing.frequency)
+        ? existing.frequency
+        : 'daily') as Frequency,
+    }
+
+    let after: ParsedStrategy
+    try {
+      after = await editStrategyByNL(before, instruction)
+    } catch (error) {
+      return fail(error instanceof Error ? error.message : '편집 실패', 400)
+    }
+
+    // self-review P1 (#434): ticker 변경은 지원 밖 (PUT 도 ticker 무시).
+    // AI 가 지시로 ticker 를 바꿔 돌려주더라도 여기서 명시 거부 → 조건이 새 티커에
+    // 맞춰 재조정된 상태로 원래 티커에 저장돼 잘못된 트리거 되는 상황 방지.
+    if (after.ticker !== before.ticker) {
+      return fail(
+        `티커 변경 (${before.ticker} → ${after.ticker}) 은 지원되지 않습니다. 다른 종목으로 바꾸려면 이 전략을 삭제 후 재등록해주세요.`,
+        400,
+      )
+    }
+
+    const diff = computeStrategyDiff(before, after)
+    return ok({ before, after, diff })
+  } catch (error) {
+    console.error('[api/custom-strategies/id/nl-edit] POST 실패:', error)
+    return fail('편집 미리보기에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/custom-strategies/[id]/route.ts
+++ b/src/app/api/custom-strategies/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { ok, fail, noContent } from '@/lib/api-response'
+import { validateCondition } from '@/lib/custom-strategy/types'
+import { conditionsEqual } from '@/lib/custom-strategy/diff'
+import type { Condition } from '@/lib/custom-strategy/types'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,8 +18,10 @@ const VALID_LOGIC = new Set(['AND', 'OR'])
 /**
  * PUT /api/custom-strategies/[id] — 부분 수정.
  *
- * 편집 가능 필드: name / isActive / frequency / logic.
- * 조건 자체 (conditions, ticker) 편집은 v1 지원 X — 삭제 후 재등록.
+ * 편집 가능 필드: name / isActive / frequency / logic / conditions.
+ * conditions 편집은 Phase 35-B (#434) 부터 지원 — 자연어 편집 (POST .../nl-edit)
+ * 미리보기 결과를 사용자가 승인한 뒤 이 필드로 저장.
+ * ticker 편집은 여전히 지원 X (다른 종목으로 바꾸려면 삭제 후 재등록).
  */
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
@@ -32,12 +38,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const existing = await prisma.customStrategy.findUnique({ where: { id } })
     if (!existing) return fail('전략을 찾을 수 없습니다.', 404)
 
-    const data: {
-      name?: string
-      isActive?: boolean
-      frequency?: string
-      logic?: string
-    } = {}
+    const data: Prisma.CustomStrategyUpdateInput = {}
 
     if (body.name !== undefined) {
       const name = typeof body.name === 'string' ? body.name.trim() : ''
@@ -63,6 +64,30 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         return fail('logic 은 AND / OR 중 하나여야 합니다.', 400)
       }
       data.logic = body.logic
+    }
+
+    if (body.conditions !== undefined) {
+      if (!Array.isArray(body.conditions) || body.conditions.length === 0) {
+        return fail('conditions 는 최소 1개 이상의 조건 배열이어야 합니다.', 400)
+      }
+      if (!body.conditions.every(validateCondition)) {
+        return fail('conditions 에 유효하지 않은 항목이 있습니다.', 400)
+      }
+      // Codex #440 재리뷰 P2: 실제로 변경됐을 때만 conditions/lastTriggeredAt 갱신.
+      // 순서 무관 비교 (`conditionsEqual`): `JSON.stringify` 는 필드 순서에 민감해서
+      // `{type, operator, value}` vs `{value, operator, type}` 를 다르다고 오판 →
+      // 무변경인데 lastTriggeredAt 리셋 → `once` 재무장 / `daily` 중복 발동.
+      const existingConds = (Array.isArray(existing.conditions)
+        ? (existing.conditions as unknown[])
+        : []
+      ).filter(validateCondition) as Condition[]
+      const newConds = body.conditions as unknown as Condition[]
+      if (!conditionsEqual(existingConds, newConds)) {
+        data.conditions = body.conditions as unknown as Prisma.InputJsonValue
+        // 조건이 실제 바뀔 때만 발동 이력 리셋 → fresh signal 로 평가.
+        data.lastTriggeredAt = null
+      }
+      // 같으면 아무것도 안 함 → PUT 이 name/logic 등 다른 필드만 수정.
     }
 
     if (Object.keys(data).length === 0) {

--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -52,7 +52,11 @@ function fireAiQuestion(ctx: Context, question: string): void {
   }, TYPING_INTERVAL_MS)
 
   cleanExpiredSessions()
-  askAdvisor(question, { sessionId: chatSessions.get(chatId)?.sessionId, persist: true })
+  askAdvisor(question, {
+    sessionId: chatSessions.get(chatId)?.sessionId,
+    persist: true,
+    intent: 'conversation',  // 자유 질문 → sonnet (35-A / #433)
+  })
     .then(async (result) => {
       if (result.sessionId) chatSessions.set(chatId, { sessionId: result.sessionId, lastUsed: Date.now() })
       const chunks = splitMessage(result.response)
@@ -138,7 +142,7 @@ function fireTradeParseQuestion(ctx: Context, text: string): void {
       .catch(() => { /* 무시 */ })
   }, TYPING_INTERVAL_MS)
 
-  askAdvisor(TRADE_PARSE_PROMPT + text)
+  askAdvisor(TRADE_PARSE_PROMPT + text, { intent: 'parse' })  // 구조 JSON 파싱 → haiku (35-A)
     .then(async (result) => {
       await handleParsedTrade(ctx, result.response)
     })

--- a/src/bot/commands/expense.ts
+++ b/src/bot/commands/expense.ts
@@ -427,7 +427,7 @@ function fireMultiExpenseParse(ctx: Context, text: string): void {
     ctx.replyWithChatAction('typing').catch(() => {})
   }, 5000)
 
-  askAdvisor(buildMultiParsePrompt() + text, { timeout: 60_000 })
+  askAdvisor(buildMultiParsePrompt() + text, { timeout: 60_000, intent: 'parse' })  // 구조 JSON 파싱 → haiku (35-A)
     .then(async (result) => {
       await handleMultiExpenseParsed(ctx, result.response)
     })

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -296,7 +296,7 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
     for (const r of guideTargets) {
       try {
         const prompt = `${r.displayName}(${r.ticker})에서 다음 TA 시그널이 발생했다: ${r.signals.join(', ')}. stock-trading-method 프레임워크 기준으로 현재 상황 1~2줄 가이드를 작성해줘. 간결하게.`
-        const guide = await askAdvisor(prompt, { timeout: 30_000, maxBudgetUsd: 0.10 })
+        const guide = await askAdvisor(prompt, { timeout: 30_000, maxBudgetUsd: 0.10, intent: 'guide' })  // 1~2줄 가이드 → haiku (35-A)
         aiGuides.set(r.ticker, guide.response.trim())
       } catch (error) {
         console.warn(`[ta-signal] ${r.ticker} AI 가이드 실패:`, error instanceof Error ? error.message : error)

--- a/src/components/strategies/StrategyEditModal.tsx
+++ b/src/components/strategies/StrategyEditModal.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useState } from 'react'
 import { useToast } from '@/components/ui/Toast'
 import type { CustomStrategyRow } from './types'
+import { conditionToString } from '@/lib/custom-strategy/types'
+import type {
+  Condition, LogicOp, Frequency, ParsedStrategy,
+} from '@/lib/custom-strategy/types'
+import type { StrategyDiff } from '@/lib/custom-strategy/diff'
 
 interface StrategyEditModalProps {
   item: CustomStrategyRow
@@ -10,13 +15,24 @@ interface StrategyEditModalProps {
   onSaved: () => void
 }
 
+interface NLPreview {
+  before: ParsedStrategy
+  after: ParsedStrategy
+  diff: StrategyDiff
+}
+
 export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEditModalProps) {
   const { show } = useToast()
   const [name, setName] = useState(item.name)
-  const [frequency, setFrequency] = useState(item.frequency)
-  const [logic, setLogic] = useState(item.logic)
+  const [frequency, setFrequency] = useState<Frequency>(item.frequency as Frequency)
+  const [logic, setLogic] = useState<LogicOp>(item.logic as LogicOp)
   const [isActive, setIsActive] = useState(item.isActive)
   const [saving, setSaving] = useState(false)
+
+  // Phase 35-B (#434) — 자연어 편집
+  const [nlInput, setNlInput] = useState('')
+  const [nlPreview, setNlPreview] = useState<NLPreview | null>(null)
+  const [nlLoading, setNlLoading] = useState(false)
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -26,11 +42,55 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
-  const dirty =
+  const dirtyBasics =
     name.trim() !== item.name ||
     frequency !== item.frequency ||
     logic !== item.logic ||
     isActive !== item.isActive
+  const dirty = dirtyBasics || nlPreview !== null
+  // self-review P1 (#434): 미리보기 활성 시 기본 필드는 잠금.
+  // 원래 로직은 nlPreview 있으면 nlPreview.after 값을 우선 → 사용자가 name 을
+  // 수동 편집해도 무시. 시각적 disable 로 혼란 방지.
+  const basicsLocked = nlPreview !== null
+
+  const handlePreview = async () => {
+    if (!nlInput.trim() || nlLoading) return
+    // Codex #440 P2: preview 요청은 DB 상태 (before) 만 참조 → 로컬에서 name/logic/
+    // frequency 수동 편집 상태 후 preview 하면 `after` 가 DB 값 기준이라 save 시
+    // 사용자의 수동 변경이 사일런트 드롭됨. dirty 시 preview 차단해 순서 강제.
+    if (dirtyBasics) {
+      show({
+        variant: 'error',
+        title: '기본 필드 변경 사항이 있습니다. 먼저 저장하거나 되돌린 뒤 미리보기 해주세요.',
+      })
+      return
+    }
+    setNlLoading(true)
+    setNlPreview(null)
+    try {
+      const res = await fetch(`/api/custom-strategies/${item.id}/nl-edit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instruction: nlInput.trim() }),
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        show({ variant: 'error', title: json?.error ?? '미리보기 실패' })
+        return
+      }
+      setNlPreview(json.data as NLPreview)
+    } catch (e) {
+      console.error('[strategies] nl-edit preview 실패:', e)
+      show({ variant: 'error', title: '미리보기 요청 중 오류가 발생했습니다.' })
+    } finally {
+      setNlLoading(false)
+    }
+  }
+
+  const clearPreview = () => {
+    setNlPreview(null)
+    setNlInput('')
+  }
 
   const handleSave = async () => {
     if (!dirty || saving) return
@@ -42,10 +102,24 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
     setSaving(true)
     try {
       const body: Record<string, unknown> = {}
-      if (trimmedName !== item.name) body.name = trimmedName
-      if (frequency !== item.frequency) body.frequency = frequency
-      if (logic !== item.logic) body.logic = logic
+      const eff = nlPreview?.after
+      // NL 편집 반영: after 값을 기본 필드에도 적용
+      const effName = eff?.name ?? trimmedName
+      const effFreq = eff?.frequency ?? frequency
+      const effLogic = eff?.logic ?? logic
+
+      if (effName !== item.name) body.name = effName
+      if (effFreq !== item.frequency) body.frequency = effFreq
+      if (effLogic !== item.logic) body.logic = effLogic
       if (isActive !== item.isActive) body.isActive = isActive
+      // Codex #440 재리뷰 P2: conditions 는 실제 조건 변경이 있을 때만 포함.
+      // preview 가 이름만 바꿔도 항상 conditions 를 넘기면 서버가 lastTriggeredAt
+      // 을 리셋할 수 있어 `once` 가 재무장. diff 에서 실제 add/remove 있을 때만.
+      const conditionsChanged = nlPreview
+        && (nlPreview.diff.conditionsAdded.length > 0 || nlPreview.diff.conditionsRemoved.length > 0)
+      if (conditionsChanged && eff?.conditions) {
+        body.conditions = eff.conditions
+      }
 
       const res = await fetch(`/api/custom-strategies/${item.id}`, {
         method: 'PUT',
@@ -71,7 +145,7 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center px-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
       <div
-        className="w-full max-w-md rounded-xl border border-border bg-bg-raised p-6 space-y-4"
+        className="w-full max-w-lg rounded-xl border border-border bg-bg-raised p-6 space-y-4 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
@@ -86,13 +160,20 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
         </div>
 
         <div className="space-y-3">
+          {basicsLocked && (
+            <div className="text-[11px] text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded-md px-3 py-1.5">
+              🔒 자연어 미리보기 활성 — 기본 필드는 잠금. 수동 편집하려면 위에서 &quot;미리보기 취소&quot;.
+            </div>
+          )}
+
           <div>
             <label className="text-sub text-xs">이름</label>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
               maxLength={100}
-              className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin"
+              disabled={basicsLocked}
+              className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin disabled:opacity-50 disabled:cursor-not-allowed"
             />
           </div>
 
@@ -101,8 +182,9 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
               <label className="text-sub text-xs">발동 빈도</label>
               <select
                 value={frequency}
-                onChange={(e) => setFrequency(e.target.value)}
-                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin"
+                onChange={(e) => setFrequency(e.target.value as Frequency)}
+                disabled={basicsLocked}
+                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <option value="once">한 번만 (once)</option>
                 <option value="daily">매일 1회 (daily)</option>
@@ -113,8 +195,9 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
               <label className="text-sub text-xs">조건 결합</label>
               <select
                 value={logic}
-                onChange={(e) => setLogic(e.target.value)}
-                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin"
+                onChange={(e) => setLogic(e.target.value as LogicOp)}
+                disabled={basicsLocked}
+                className="w-full mt-1 bg-surface-dim border border-border rounded-lg px-3 py-2 text-sm text-bright focus:outline-none focus:border-sejin disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <option value="AND">AND (모두)</option>
                 <option value="OR">OR (하나)</option>
@@ -144,9 +227,60 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
             </button>
           </div>
 
-          <div className="rounded-lg bg-surface-dim border border-border px-3 py-2 text-xs text-sub">
-            <div className="font-semibold text-amber-400 mb-1">⚠️ 조건 자체는 편집 불가</div>
-            조건 (price/rsi/… ) 을 변경하려면 이 전략을 삭제 후 다시 등록해주세요.
+          {/* Phase 35-B — 자연어 편집 */}
+          <div className="rounded-lg bg-surface-dim border border-border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="text-bright font-semibold text-sm">🧠 자연어 편집</div>
+              {nlPreview && (
+                <button
+                  onClick={clearPreview}
+                  className="text-[11px] text-sub hover:text-bright"
+                >
+                  미리보기 취소
+                </button>
+              )}
+            </div>
+            <div className="text-[11px] text-sub">
+              예: &quot;SPY 조건 빼줘&quot; · &quot;어닝 5일로 완화&quot; · &quot;OR 로 바꿔&quot;
+            </div>
+            <textarea
+              value={nlInput}
+              onChange={(e) => {
+                setNlInput(e.target.value)
+                // Codex #440 P2: 지시 텍스트가 편집되면 이전 preview 는 stale.
+                // 사용자가 preview 재실행 없이 save 하면 이전 지시의 after 로 저장돼
+                // 화면 텍스트와 실제 저장이 어긋남. 텍스트 변경 시 preview 무효화.
+                if (nlPreview) setNlPreview(null)
+              }}
+              placeholder="편집 지시를 자연어로 입력..."
+              rows={2}
+              maxLength={500}
+              disabled={nlLoading}
+              className="w-full bg-surface border border-border rounded-md px-3 py-2 text-sm text-bright placeholder:text-dim focus:outline-none focus:border-sejin disabled:opacity-50"
+            />
+            <div className="flex items-center justify-between">
+              <div className="text-[11px] text-dim">{nlInput.length}/500</div>
+              <button
+                onClick={handlePreview}
+                disabled={!nlInput.trim() || nlLoading || dirtyBasics}
+                title={dirtyBasics ? '기본 필드 변경 사항이 있어 미리보기 차단 (먼저 저장/되돌리기)' : ''}
+                className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-sejin/40 bg-sejin/15 text-sejin hover:bg-sejin/25 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {nlLoading ? '분석 중…' : '미리보기'}
+              </button>
+            </div>
+
+            {nlPreview && (
+              <div className="mt-2 space-y-2 border-t border-border pt-2">
+                <div className="text-[12px] font-semibold text-bright">변경 사항</div>
+                <DiffView diff={nlPreview.diff} />
+                {!hasAnyDiff(nlPreview.diff) && (
+                  <div className="text-[12px] text-amber-400">
+                    ⚠️ 변경 사항이 감지되지 않았습니다. 지시를 더 명확히 해주세요.
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
 
@@ -167,6 +301,53 @@ export default function StrategyEditModal({ item, onClose, onSaved }: StrategyEd
           </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+function hasAnyDiff(d: StrategyDiff): boolean {
+  return !!(d.nameChanged || d.logicChanged || d.frequencyChanged || d.tickerChanged
+    || d.conditionsAdded.length > 0 || d.conditionsRemoved.length > 0)
+}
+
+function DiffView({ diff }: { diff: StrategyDiff }) {
+  return (
+    <div className="text-[12px] space-y-1">
+      {diff.nameChanged && (
+        <Line label="이름" from={diff.nameChanged.from} to={diff.nameChanged.to} />
+      )}
+      {diff.tickerChanged && (
+        <Line label="티커" from={diff.tickerChanged.from} to={diff.tickerChanged.to} />
+      )}
+      {diff.logicChanged && (
+        <Line label="Logic" from={diff.logicChanged.from} to={diff.logicChanged.to} />
+      )}
+      {diff.frequencyChanged && (
+        <Line label="빈도" from={diff.frequencyChanged.from} to={diff.frequencyChanged.to} />
+      )}
+      {diff.conditionsRemoved.map((c: Condition, i: number) => (
+        <div key={`r-${i}`} className="flex items-start gap-2">
+          <span className="text-red-400 font-mono">−</span>
+          <span className="text-red-400 font-mono">{conditionToString(c)}</span>
+        </div>
+      ))}
+      {diff.conditionsAdded.map((c: Condition, i: number) => (
+        <div key={`a-${i}`} className="flex items-start gap-2">
+          <span className="text-emerald-400 font-mono">+</span>
+          <span className="text-emerald-400 font-mono">{conditionToString(c)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Line({ label, from, to }: { label: string; from: string; to: string }) {
+  return (
+    <div className="flex items-center gap-1 text-sub">
+      <span className="text-dim w-14">{label}</span>
+      <span className="text-red-400 font-mono">{from}</span>
+      <span className="text-dim">→</span>
+      <span className="text-emerald-400 font-mono">{to}</span>
     </div>
   )
 }

--- a/src/lib/ai/__tests__/advisor-intent.test.ts
+++ b/src/lib/ai/__tests__/advisor-intent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { pickModel } from '../claude-advisor'
+
+describe('pickModel (Phase 35-A / #433)', () => {
+  it('명시 model 이 있으면 intent 무시하고 그대로', () => {
+    expect(pickModel('sonnet', 'parse')).toBe('sonnet')
+    expect(pickModel('haiku', 'conversation')).toBe('haiku')
+    expect(pickModel('sonnet', undefined)).toBe('sonnet')
+  })
+
+  it('conversation → sonnet (사용자 자유 질문)', () => {
+    expect(pickModel(undefined, 'conversation')).toBe('sonnet')
+  })
+
+  it('parse → haiku (구조 JSON 파싱)', () => {
+    expect(pickModel(undefined, 'parse')).toBe('haiku')
+  })
+
+  it('guide → haiku (짧은 1~2줄 가이드)', () => {
+    expect(pickModel(undefined, 'guide')).toBe('haiku')
+  })
+
+  it('intent 도 없으면 haiku (하위호환)', () => {
+    expect(pickModel(undefined, undefined)).toBe('haiku')
+  })
+})

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -4,9 +4,32 @@ import { SYSTEM_PROMPT } from './system-prompt'
 
 export type AdvisorModel = 'haiku' | 'sonnet'
 
+/**
+ * 호출 의도 — 모델 자동 선택 근거 (Phase 35-A / #433).
+ *   - `conversation`: `/ai` 자유 질문. 도구 체이닝·트레이드오프 서술 필요 → sonnet
+ *   - `parse`: 사용자 자연어 → 구조 JSON (거래·가계부·전략). 짧고 결정적 → haiku
+ *   - `guide`: 짧은 TA 조언 등 1~2줄 가이드 → haiku
+ *
+ * 명시 `model` 이 있으면 그 값이 우선. intent 는 폴백 선택.
+ */
+export type AdvisorIntent = 'conversation' | 'parse' | 'guide'
+
+/**
+ * Pure — intent → model 매핑. 명시 model 이 있으면 그대로, 없으면 intent 로 결정.
+ * intent 도 없으면 haiku (하위호환 — 기존 호출부 default).
+ */
+export function pickModel(model: AdvisorModel | undefined, intent: AdvisorIntent | undefined): AdvisorModel {
+  if (model) return model
+  if (intent === 'conversation') return 'sonnet'
+  // 'parse' / 'guide' / undefined 는 모두 haiku
+  return 'haiku'
+}
+
 export interface AdvisorOptions {
-  /** 모델 선택 (기본: haiku) */
+  /** 모델 선택 (명시 시 intent 무시하고 이 값 사용) */
   model?: AdvisorModel
+  /** 호출 의도 — 모델 자동 선택 근거. 명시 model 이 없을 때 폴백 매핑. */
+  intent?: AdvisorIntent
   /** 타임아웃 ms (기본: 180_000) */
   timeout?: number
   /** API 비용 상한 USD (기본: 0.50) */
@@ -131,12 +154,13 @@ export async function askAdvisor(
   options: AdvisorOptions = {}
 ): Promise<AdvisorResult> {
   const {
-    model = 'haiku',
     timeout = 180_000,
     maxBudgetUsd = 0.50,
     sessionId,
     persist = false,
   } = options
+  // Phase 35-A (#433): intent → model 폴백 매핑. 명시 model 우선.
+  const model = pickModel(options.model, options.intent)
 
   // 프롬프트 길이 제한
   const MAX_PROMPT_LENGTH = 10_000

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import { computeStrategyDiff, hasDiff, conditionsEqual } from '../diff'
+import type { Condition, ParsedStrategy } from '../types'
+
+const base: ParsedStrategy = {
+  name: 'AAPL 저점',
+  ticker: 'AAPL',
+  conditions: [
+    { type: 'price', operator: '<=', value: 150 },
+    { type: 'rsi', operator: '<=', value: 30 },
+  ],
+  logic: 'AND',
+  frequency: 'daily',
+}
+
+describe('computeStrategyDiff (Phase 35-B / #434)', () => {
+  it('동일 전략 → 변경 없음', () => {
+    const d = computeStrategyDiff(base, base)
+    expect(hasDiff(d)).toBe(false)
+    expect(d.conditionsAdded).toEqual([])
+    expect(d.conditionsRemoved).toEqual([])
+  })
+
+  it('name 변경 감지', () => {
+    const after = { ...base, name: 'AAPL 매수' }
+    const d = computeStrategyDiff(base, after)
+    expect(d.nameChanged).toEqual({ from: 'AAPL 저점', to: 'AAPL 매수' })
+    expect(hasDiff(d)).toBe(true)
+  })
+
+  it('logic 변경 감지', () => {
+    const after = { ...base, logic: 'OR' as const }
+    const d = computeStrategyDiff(base, after)
+    expect(d.logicChanged).toEqual({ from: 'AND', to: 'OR' })
+  })
+
+  it('frequency 변경 감지', () => {
+    const after = { ...base, frequency: 'always' as const }
+    const d = computeStrategyDiff(base, after)
+    expect(d.frequencyChanged).toEqual({ from: 'daily', to: 'always' })
+  })
+
+  it('조건 제거 감지', () => {
+    const after = { ...base, conditions: [base.conditions[0]] }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsRemoved).toHaveLength(1)
+    expect(d.conditionsRemoved[0].type).toBe('rsi')
+    expect(d.conditionsAdded).toEqual([])
+  })
+
+  it('조건 추가 감지', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [
+        ...base.conditions,
+        { type: 'earnings_within_days', operator: '>=', value: 7 },
+      ],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsAdded).toHaveLength(1)
+    expect(d.conditionsAdded[0].type).toBe('earnings_within_days')
+    expect(d.conditionsRemoved).toEqual([])
+  })
+
+  it('조건 값 변경 → 제거 1 + 추가 1 (문자열 비교 기반 대체)', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [
+        { type: 'price', operator: '<=', value: 140 },  // 150 → 140
+        base.conditions[1],
+      ],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsRemoved).toHaveLength(1)
+    expect(d.conditionsAdded).toHaveLength(1)
+  })
+
+  it('조건 순서 바뀌어도 변경 없음 (문자열 기반, 순서 무관)', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [base.conditions[1], base.conditions[0]],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsAdded).toEqual([])
+    expect(d.conditionsRemoved).toEqual([])
+    expect(hasDiff(d)).toBe(false)
+  })
+
+  it('conditionsEqual — 순서 무관 (Codex #440 재리뷰 P2 회귀 방지)', () => {
+    const a: Condition[] = [
+      { type: 'price', operator: '<=', value: 150 },
+      { type: 'rsi', operator: '<=', value: 30 },
+    ]
+    // 조건 순서 뒤바꾼 배열
+    const b: Condition[] = [
+      { type: 'rsi', operator: '<=', value: 30 },
+      { type: 'price', operator: '<=', value: 150 },
+    ]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — 조건 오브젝트 필드 순서가 달라도 true', () => {
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
+    // JSON.stringify 는 field-order 민감하지만 conditionToString 은 무관
+    const b: Condition[] = [{ value: 150, operator: '<=', type: 'price' } as Condition]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — 길이 다르면 false', () => {
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
+    const b: Condition[] = [
+      { type: 'price', operator: '<=', value: 150 },
+      { type: 'rsi', operator: '<=', value: 30 },
+    ]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('conditionsEqual — weekday value 순서 무관 (Codex #440 재재리뷰 P2 회귀 방지)', () => {
+    // evaluator 는 weekday value 를 `includes` 로 처리 → 배열 순서 무관.
+    // conditionToString 은 순서 유지 → JSON.stringify 비교였다면 오검출.
+    // canonical key (정렬) 로 정정 확인.
+    const a: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'TUE', 'WED'] }]
+    const b: Condition[] = [{ type: 'weekday', operator: 'is', value: ['WED', 'MON', 'TUE'] }]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — cross_ticker crossTicker 대소문자/공백 무관 (Codex #440 재재재리뷰 P2)', () => {
+    // evaluator 는 `trim().toUpperCase()` 정규화 → 'vix' 와 'VIX' 의미 동일.
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    }]
+    const b: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: '  vix ', metric: 'price',
+    }]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — 비-change_pct 조건의 timeframe 은 무시 (Codex #440 재재재재리뷰 P2)', () => {
+    // evaluator 는 price/rsi/문자열 조건에서 timeframe 을 사용 안 함.
+    // conditionToString 이 렌더링 하는 게 문제 → canonical key 에서 timeframe 배제.
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 40 }]
+    const b: Condition[] = [{ type: 'price', operator: '<=', value: 40, timeframe: '1d' }]
+    expect(conditionsEqual(a, b)).toBe(true)
+
+    const c: Condition[] = [{ type: 'rsi', operator: '<=', value: 30 }]
+    const d: Condition[] = [{ type: 'rsi', operator: '<=', value: 30, timeframe: '5d' }]
+    expect(conditionsEqual(c, d)).toBe(true)
+  })
+
+  it('conditionsEqual — change_pct 는 timeframe 다르면 not equal', () => {
+    const a: Condition[] = [{ type: 'change_pct', operator: '<=', value: -5, timeframe: '1d' }]
+    const b: Condition[] = [{ type: 'change_pct', operator: '<=', value: -5, timeframe: '5d' }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('conditionsEqual — cross_ticker 다른 crossTicker 는 여전히 not equal', () => {
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'VIX', metric: 'price',
+    }]
+    const b: Condition[] = [{
+      type: 'cross_ticker', operator: '>', value: 25,
+      crossTicker: 'SPY', metric: 'price',
+    }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('conditionsEqual — 다른 weekday 조합은 여전히 다르다고 판정', () => {
+    const a: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'TUE'] }]
+    const b: Condition[] = [{ type: 'weekday', operator: 'is', value: ['MON', 'FRI'] }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('conditionsEqual — 값 다르면 false', () => {
+    const a: Condition[] = [{ type: 'price', operator: '<=', value: 150 }]
+    const b: Condition[] = [{ type: 'price', operator: '<=', value: 140 }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('복합 변경 (logic + 조건 추가 + 조건 제거)', () => {
+    const after: ParsedStrategy = {
+      name: base.name,
+      ticker: base.ticker,
+      conditions: [
+        { type: 'price', operator: '<=', value: 150 },
+        { type: 'earnings_within_days', operator: '>=', value: 7 },
+      ],
+      logic: 'OR',
+      frequency: 'daily',
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.logicChanged).toEqual({ from: 'AND', to: 'OR' })
+    expect(d.conditionsAdded).toHaveLength(1)
+    expect(d.conditionsRemoved).toHaveLength(1)
+    expect(hasDiff(d)).toBe(true)
+  })
+})

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -1,0 +1,98 @@
+/**
+ * Phase 35-B (#434) — 전략 편집 diff 계산 (pure).
+ * 미리보기 UI 가 변경 사항을 하이라이트하기 위한 순수 함수.
+ */
+
+import type { Condition, LogicOp, Frequency, ParsedStrategy, WeekdayCode } from './types'
+import { conditionToString } from './types'
+
+export interface StrategyDiff {
+  nameChanged?: { from: string; to: string }
+  logicChanged?: { from: LogicOp; to: LogicOp }
+  frequencyChanged?: { from: Frequency; to: Frequency }
+  tickerChanged?: { from: string; to: string }
+  conditionsAdded: Condition[]
+  conditionsRemoved: Condition[]
+}
+
+/**
+ * Condition 등가 판정용 canonical key.
+ * `conditionToString` 을 기본으로 사용하되, evaluator 가 실행 시 무시하거나 정규화하는
+ * 필드는 canonical key 도 동일하게 처리해 무변경 편집 false-positive 를 방지.
+ *
+ * 정규화 대상 (evaluator semantics 대비):
+ *   - `weekday.value`: `includes` 로 unordered set 취급 → 정렬 (#440 재재리뷰 P2)
+ *   - `cross_ticker.crossTicker`: `trim().toUpperCase()` (#440 재재재리뷰 P2)
+ *   - **비-change_pct 조건의 `timeframe`**: change_pct 전용 필드. price/rsi/문자열
+ *     타입에 timeframe 이 붙어 와도 evaluator 는 무시 → canonical 에서도 배제
+ *     (#440 재재재재리뷰 P2). conditionToString 이 timeframe 을 어느 타입에나 렌더
+ *     하는 것이 문제 원인.
+ */
+function condKey(c: Condition): string {
+  if (c.type === 'weekday' && Array.isArray(c.value)) {
+    const sorted = [...(c.value as WeekdayCode[])].sort()
+    return `weekday ${c.operator} [${sorted.join(',')}]`
+  }
+  if (c.type === 'cross_ticker') {
+    const t = (c.crossTicker ?? '').trim().toUpperCase()
+    return `${t}.${c.metric ?? '?'} ${c.operator} ${c.value}`
+  }
+  // change_pct 만 timeframe 관여. 그 외 타입은 timeframe 무시.
+  if (c.type !== 'change_pct') {
+    return `${c.type} ${c.operator} ${c.value}`
+  }
+  return conditionToString(c)
+}
+
+export function computeStrategyDiff(before: ParsedStrategy, after: ParsedStrategy): StrategyDiff {
+  const diff: StrategyDiff = { conditionsAdded: [], conditionsRemoved: [] }
+
+  if (before.name !== after.name) {
+    diff.nameChanged = { from: before.name, to: after.name }
+  }
+  if (before.ticker !== after.ticker) {
+    diff.tickerChanged = { from: before.ticker, to: after.ticker }
+  }
+  if (before.logic !== after.logic) {
+    diff.logicChanged = { from: before.logic, to: after.logic }
+  }
+  if (before.frequency !== after.frequency) {
+    diff.frequencyChanged = { from: before.frequency, to: after.frequency }
+  }
+
+  const beforeKeys = new Map(before.conditions.map((c) => [condKey(c), c]))
+  const afterKeys = new Map(after.conditions.map((c) => [condKey(c), c]))
+
+  for (const [k, c] of afterKeys) {
+    if (!beforeKeys.has(k)) diff.conditionsAdded.push(c)
+  }
+  for (const [k, c] of beforeKeys) {
+    if (!afterKeys.has(k)) diff.conditionsRemoved.push(c)
+  }
+
+  return diff
+}
+
+/** diff 가 실제 변경을 포함하는지 (미리보기 UI 에서 "변경 없음" 표시용) */
+export function hasDiff(d: StrategyDiff): boolean {
+  return !!(
+    d.nameChanged || d.logicChanged || d.frequencyChanged || d.tickerChanged ||
+    d.conditionsAdded.length > 0 || d.conditionsRemoved.length > 0
+  )
+}
+
+/**
+ * Pure — 두 조건 배열이 의미적으로 동일한지 (순서·필드순 무관) 비교.
+ * `conditionToString` 은 fixed key order (`type / operator / value / timeframe`) 로
+ * 렌더링하므로 원본 오브젝트의 필드 순서에 관계없이 같은 문자열을 생성.
+ *
+ * PUT 흐름에서 conditions 무변경 판정에 사용 (Codex #440 재리뷰 P2 — 이전 구현은
+ * `JSON.stringify` 로 field-order-sensitive 비교 → 동일 의미인데 필드 순서만 다른
+ * 요청도 변경으로 오판 → lastTriggeredAt 오리셋 → `once` 재무장).
+ */
+export function conditionsEqual(a: Condition[], b: Condition[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = a.map(condKey).sort()
+  const sb = b.map(condKey).sort()
+  return sa.every((s, i) => s === sb[i])
+}

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -157,3 +157,88 @@ export async function parseStrategyText(text: string): Promise<ParsedStrategy> {
   // ticker 대문자 정규화 (parser 프롬프트에도 있지만 방어)
   return { ...parsed, ticker: parsed.ticker.toUpperCase().trim() }
 }
+
+/**
+ * Phase 35-B (#434) — 자연어 전략 편집.
+ * 기존 전략 컨텍스트 + 자연어 지시 → 갱신된 ParsedStrategy 반환. 상대 편집
+ * ("SPY 조건 빼줘", "어닝 5일로 완화") 지원. 지원 조건 밖 지시는 error throw.
+ */
+export async function editStrategyByNL(
+  current: ParsedStrategy,
+  instruction: string,
+): Promise<ParsedStrategy> {
+  if (!instruction || !instruction.trim()) {
+    throw new Error('편집 지시를 입력해주세요.')
+  }
+  if (instruction.length > 500) {
+    throw new Error('편집 지시가 너무 깁니다 (500자 이하).')
+  }
+
+  const contextBlock = JSON.stringify(
+    {
+      name: current.name,
+      ticker: current.ticker,
+      conditions: current.conditions,
+      logic: current.logic,
+      frequency: current.frequency,
+    },
+    null,
+    2,
+  )
+
+  const editHeader = `
+사용자가 아래 기존 전략을 자연어 지시대로 수정한 결과를 JSON 으로 응답해줘.
+반환 스키마는 등록과 동일 (name / ticker / conditions / logic / frequency).
+오직 JSON 오브젝트만 출력 — 다른 설명/코드블록 없이.
+
+## 상대 편집 규칙
+- "SPY 조건 빼줘" / "어닝 조건 제거" → 해당 type 의 condition 삭제
+- "어닝 5일로 완화" / "RSI 25 로 강화" → 해당 condition value 조정
+- "OR 로 바꿔" → logic 변경
+- "매일 한 번만" / "always 로" → frequency 변경
+- "이름을 X 로" → name 변경
+- 지시가 애매하면 { "error": "지시 애매: ..." } 로 응답
+- 기존 전략에 없는 조건 타입을 새로 요구 → 등록 규칙 그대로 (지원 타입 밖이면 error)
+
+${PROMPT_HEADER}
+
+## 기존 전략 (JSON)
+${contextBlock}
+
+## 편집 지시
+`
+
+  const prompt = `${editHeader}${instruction.trim()}`
+
+  // 편집도 등록과 동일하게 sonnet 로 (스키마 안정성 우선).
+  const result = await askAdvisor(prompt, {
+    model: 'sonnet',
+    timeout: 60_000,
+    maxBudgetUsd: 0.2,
+  })
+
+  const raw = result.response.trim()
+  const firstBrace = raw.indexOf('{')
+  const lastBrace = raw.lastIndexOf('}')
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
+    throw new Error(`AI 편집 응답에 JSON 오브젝트가 없습니다. 표현을 바꿔서 재시도해주세요.\n원문: ${raw.slice(0, 200)}`)
+  }
+  const cleaned = raw.slice(firstBrace, lastBrace + 1).trim()
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(cleaned)
+  } catch {
+    throw new Error(`AI 편집 응답이 JSON 이 아닙니다. 재시도 하거나 표현을 바꿔주세요.\n원문: ${cleaned.slice(0, 200)}`)
+  }
+
+  if (isParseError(parsed)) {
+    throw new Error(`편집 실패: ${parsed.error}`)
+  }
+
+  if (!validateParsedStrategy(parsed)) {
+    throw new Error(`AI 편집 결과가 유효한 전략 스키마가 아닙니다. 지시를 더 명확히 해주세요.`)
+  }
+
+  return { ...parsed, ticker: parsed.ticker.toUpperCase().trim() }
+}

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -121,6 +121,8 @@ export async function parseStrategyText(text: string): Promise<ParsedStrategy> {
 
   const prompt = `${PROMPT_HEADER}\n${text.trim()}`
 
+  // 명시 model='sonnet' — 자연어 → 구조화 JSON 파싱 안정성 우선 (35-A intent='parse'
+  // 매핑은 haiku 지만 전략 파서는 스키마 위반 회귀 방지 위해 sonnet 유지 예외).
   const result = await askAdvisor(prompt, {
     model: 'sonnet',
     timeout: 60_000,


### PR DESCRIPTION
16차 마일스톤 릴리스. **Phase 36 (뉴스 조건, #435/#436/#437) 은 17차로 이월** — 사용자 결정 (2026-07-10).

## Phase 35 — AI 정책 강화
- **35-A** (#433/#439): `/ai` 자유대화 채널 **sonnet 승격** + `AdvisorIntent` API (`conversation`/`parse`/`guide`). `pickModel(model, intent)` pure 헬퍼 — 명시 model 우선, intent 폴백. 5개 호출부에 intent 명시 (`/ai` × 2, 파싱 × 2, TA 가이드 × 1).
- **35-B** (#434/#440): **자연어 전략 편집**. `editStrategyByNL` + `computeStrategyDiff` + `conditionsEqual` canonical key. 미리보기 API + PUT conditions 확장 + UI diff. Codex 8+ 라운드 반영 (canonical key = evaluator semantics 원칙 확립).

## Phase 36 — 뉴스 조건 (17차 이월)
- 사용자 결정: 유지·운영·API 비용 부담이 다른 우선순위 대비 낮음
- Alpha Vantage / newsapi.org / Benzinga 후보 조사 결과 `docs/specs/435-news-api-decision.md` 에 보존 (Codex P2 x2 반영)
- 이슈 #435 / #436 / #437 close, 17차 스코프 결정 시 재발행

## 주요 사용자 임팩트

### `/ai` 응답 품질 향상
- 텔레그램 `/ai`, 웹 `/api/ai/ask` 가 sonnet 사용 → 도구 체이닝·트레이드오프 서술 개선
- 파서 (거래·가계부·TA 가이드) 는 haiku 유지 → 응답속도·비용 균형

### 자연어 전략 편집
- `/strategies` 편집 모달에서 "SPY 조건 빼줘", "어닝 5일로 완화", "OR 로 바꿔" 같은 상대 편집 지원
- 미리보기 후 확인 → PUT 저장. 조건 변경 시 `lastTriggeredAt` 자동 리셋

## 배포 절차
GitHub Release publish → **Deploy on Release** workflow 자동 트리거. 실서비스 반영 후:
- 텔레그램 `/reset` **권장** — `--resume` 세션이 옛 model 유지 방지
- `/strategies` 편집 자연어 flow 검증

## Test plan
- [x] 각 PR self-review + Codex ~10 라운드 반영
- [x] 500 tests / lint / typecheck / build 통과
- [ ] 배포 후 텔레그램 `/ai` sonnet 사용 확인 (JSON output `model` 필드)
- [ ] 자연어 전략 편집 flow 검증

Closes #432 (Phase 36 제외)