### PR TITLE
feat(alert): 알림 이력 컨텍스트 필드 + 상세 모달 (Phase 37-A, #444)

### DIFF
--- a/prisma/migrations/20260714030819_add_alert_history_context/migration.sql
+++ b/prisma/migrations/20260714030819_add_alert_history_context/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AlertHistory" ADD COLUMN     "contextJson" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -329,6 +329,8 @@ model AlertConfig {
 
 // Phase 33-A (#416): 알림 발동 이력. 33-B 이력 페이지 + 사후 진단 데이터 소스.
 // 1 행 = 1 이벤트. 한 번의 텔레그램 배치 발송에 여러 알림이 포함되면 여러 행 저장.
+// Phase 37-A (#444): contextJson — kind 별 최소 스냅샷 (시세/TA/전략) 을 함께 저장해
+// 사후 진단 시 당시 판단 근거를 재조회할 수 있도록. 하위호환 위해 nullable — 기존 row 는 null.
 model AlertHistory {
   id             String   @id @default(cuid())
   firedAt        DateTime @default(now())
@@ -340,6 +342,7 @@ model AlertHistory {
   deliveryStatus String   // 'sent' | 'partial' | 'failed'
   recipientCount Int      @default(0)
   errorMessage   String?
+  contextJson    Json?    // Phase 37-A: kind 별 스냅샷 (src/lib/alert-history/context.ts 스키마)
 
   @@index([firedAt])
   @@index([kind, firedAt])

--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -8,6 +8,9 @@ import {
 } from 'recharts'
 import { KIND_META, kindMetaOf, STATUS_META, type AlertKind } from './kinds'
 import { formatFiredAt, stripHtml, periodFromISO } from './client-utils'
+import AlertHistoryDetailModal, {
+  type AlertHistoryDetailRow,
+} from '@/components/alerts/AlertHistoryDetailModal'
 
 interface HistoryRow {
   id: string
@@ -20,6 +23,8 @@ interface HistoryRow {
   deliveryStatus: string
   recipientCount: number
   errorMessage: string | null
+  /** Phase 37-A (#444): kind 별 스냅샷 (nullable — 이전 row 는 null) */
+  context: unknown
 }
 
 interface Stats {
@@ -48,6 +53,8 @@ export default function AlertHistoryClient() {
   const [offset, setOffset] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Phase 37-A (#444): 상세 모달 상태 — id 대신 row 를 통째로 저장해 fetch 재요청 회피.
+  const [selectedRow, setSelectedRow] = useState<AlertHistoryDetailRow | null>(null)
 
   // Codex P2 (#417 PR #424): 다중 kind 를 서버 쿼리로 전달 (`?kind=a&kind=b`) →
   // API 가 `in` 절로 필터 + 페이지네이션·집계가 정합. 클라 사이드 후처리 제거.
@@ -301,28 +308,35 @@ export default function AlertHistoryClient() {
               return (
                 <li
                   key={r.id}
-                  className="px-5 py-3 border-b border-border last:border-b-0 hover:bg-surface-dim transition-colors"
+                  className="border-b border-border last:border-b-0"
                 >
-                  <div className="flex flex-wrap items-center gap-2 text-[11px]">
-                    <span className="text-sub tabular-nums">{formatFiredAt(r.firedAt)}</span>
-                    <span className={`px-2 py-0.5 rounded border font-semibold ${meta?.colorClass ?? 'bg-surface text-sub border-border'}`}>
-                      {meta?.icon} {meta?.label ?? r.kind}
-                    </span>
-                    {r.ticker && (
-                      <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
-                        {r.ticker}
+                  <button
+                    type="button"
+                    onClick={() => setSelectedRow(r)}
+                    className="w-full text-left px-5 py-3 hover:bg-surface-dim transition-colors focus:outline-none focus:bg-surface-dim"
+                    aria-label={`${meta?.label ?? r.kind} 상세 보기`}
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                      <span className="text-sub tabular-nums">{formatFiredAt(r.firedAt)}</span>
+                      <span className={`px-2 py-0.5 rounded border font-semibold ${meta?.colorClass ?? 'bg-surface text-sub border-border'}`}>
+                        {meta?.icon} {meta?.label ?? r.kind}
                       </span>
+                      {r.ticker && (
+                        <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
+                          {r.ticker}
+                        </span>
+                      )}
+                      <span className={`ml-auto px-2 py-0.5 rounded border font-semibold ${status.colorClass}`}>
+                        {status.label} · {r.recipientCount}
+                      </span>
+                    </div>
+                    <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
+                      {stripHtml(r.message)}
+                    </div>
+                    {r.errorMessage && (
+                      <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>
                     )}
-                    <span className={`ml-auto px-2 py-0.5 rounded border font-semibold ${status.colorClass}`}>
-                      {status.label} · {r.recipientCount}
-                    </span>
-                  </div>
-                  <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
-                    {stripHtml(r.message)}
-                  </div>
-                  {r.errorMessage && (
-                    <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>
-                  )}
+                  </button>
                 </li>
               )
             })}
@@ -350,6 +364,13 @@ export default function AlertHistoryClient() {
           </div>
         )}
       </section>
+
+      {selectedRow && (
+        <AlertHistoryDetailModal
+          row={selectedRow}
+          onClose={() => setSelectedRow(null)}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/api/alerts/history/route.ts
+++ b/src/app/api/alerts/history/route.ts
@@ -75,6 +75,9 @@ export async function GET(req: NextRequest) {
         deliveryStatus: r.deliveryStatus,
         recipientCount: r.recipientCount,
         errorMessage: r.errorMessage,
+        // Phase 37-A (#444): kind 별 스냅샷 (nullable — 37-A 이전 row 는 null).
+        // UI 상세 모달이 이 필드로 렌더러 분기.
+        context: r.contextJson ?? null,
       })),
       total,
       limit,

--- a/src/bot/notifications/__tests__/alert-history.test.ts
+++ b/src/bot/notifications/__tests__/alert-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { computeDeliveryStatus, recordAlertHistory } from '../alert-history'
+import { Prisma } from '@prisma/client'
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
@@ -90,6 +91,74 @@ describe('recordAlertHistory', () => {
       kind: 'ta_signal', ticker: null, price: null, changePercent: null,
       deliveryStatus: 'partial', recipientCount: 3, errorMessage: '네트워크 오류',
     })
+  })
+
+  // Phase 37-A (#444) 회귀 방지 — context 필드가 그대로 contextJson 컬럼에 저장되어야.
+  it('valid context 는 contextJson 으로 보존', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    await recordAlertHistory(
+      [{
+        kind: 'drop',
+        ticker: 'AAPL',
+        price: 150,
+        changePercent: -6.2,
+        message: 'x',
+        context: {
+          type: 'drop', price: 150, changePercent: -6.2, threshold: -5, marketOpen: true,
+        },
+      }],
+      'sent',
+      1,
+    )
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0].contextJson).toMatchObject({
+      type: 'drop', price: 150, threshold: -5, marketOpen: true,
+    })
+  })
+
+  // Phase 37-A (#444) — context 미지정/손상 시 Prisma.JsonNull 로 정규화 (undefined 로 두면 Prisma 오류).
+  it('context 미지정 시 JsonNull, 알 수 없는 shape 도 JsonNull 로 저장', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 2 } as never)
+
+    await recordAlertHistory(
+      [
+        { kind: 'surge', message: 'x' }, // context 미지정
+        { kind: 'surge', message: 'y', context: { type: 'unknown_kind' } as never },
+      ],
+      'sent',
+      1,
+    )
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0].contextJson).toBe(Prisma.JsonNull)
+    expect(data[1].contextJson).toBe(Prisma.JsonNull)
+  })
+
+  // Phase 37-A (#444) — kind 별 다양한 context shape 모두 통과 (스모크)
+  it('모든 kind 컨텍스트가 정상적으로 저장됨', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 4 } as never)
+
+    await recordAlertHistory(
+      [
+        { kind: 'fx', message: 'x', context: { type: 'fx', rate: 1330, changeKrw: 55, changePercent: 4.3 } },
+        { kind: 'target_hit', message: 'x', context: { type: 'target_hit', price: 200, changePercent: 5, threshold: 195, marketOpen: false } },
+        { kind: 'ta_signal', message: 'x', context: { type: 'ta_signal', price: 150, changePercent: 1, rsi: 32, macdCrossover: 'GOLDEN', bbPosition: 'BELOW_LOWER', smaGoldenCross: true, smaDeathCross: false, volumeSurge: false, signals: ['RSI_OVERSOLD'], overall: 'BUY' } },
+        { kind: 'custom_strategy', message: 'x', context: { type: 'custom_strategy', strategyId: 's1', strategyName: 'test', strategyTicker: 'AAPL', logic: 'AND', conditions: [], perCondition: [] } },
+      ],
+      'sent',
+      1,
+    )
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    for (const d of data) {
+      expect(d.contextJson).not.toBe(Prisma.JsonNull)
+      expect(typeof d.contextJson).toBe('object')
+    }
   })
 
   it('Prisma 실패는 삼키고 예외 전파 X (알림 흐름 유지)', async () => {

--- a/src/bot/notifications/alert-history.ts
+++ b/src/bot/notifications/alert-history.ts
@@ -7,6 +7,9 @@
  */
 
 import { prisma } from '@/lib/prisma'
+import { isValidContext, type AlertHistoryContext } from '@/lib/alert-history/context'
+// Prisma 는 런타임 값 (`Prisma.JsonNull`) 을 사용하므로 `import type` 금지.
+import { Prisma } from '@prisma/client'
 
 export type AlertKind =
   | 'surge'
@@ -27,6 +30,12 @@ export interface AlertEventInput {
   price?: number | null
   changePercent?: number | null
   message: string
+  /**
+   * Phase 37-A (#444) — kind 별 최소 스냅샷.
+   * hook 이 이미 확보한 데이터만 채운다 (추가 fetch 금지).
+   * shape 검증 실패 시 저장 단계에서 null 로 저장 (조회 UI 는 "컨텍스트 없음" 표시).
+   */
+  context?: AlertHistoryContext | null
 }
 
 /**
@@ -65,6 +74,11 @@ export async function recordAlertHistory(
         deliveryStatus,
         recipientCount,
         errorMessage: errorMessage ?? null,
+        // Phase 37-A (#444): 손상된 context 는 조용히 null 로 저장 —
+        // 이력 자체는 남겨야 하므로 (알림 흐름 유지 원칙과 동일).
+        contextJson: e.context && isValidContext(e.context)
+          ? (e.context as unknown as Prisma.InputJsonValue)
+          : Prisma.JsonNull,
       })),
     })
   } catch (error) {

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -21,6 +21,7 @@ import {
   recordAlertHistory,
   type AlertEventInput,
 } from './alert-history'
+import { buildCustomStrategyContext } from '@/lib/alert-history/context'
 import {
   evaluateStrategy,
   requiresTA,
@@ -239,11 +240,30 @@ async function runScan(chatIds: number[]): Promise<void> {
     alerts.push(alertBlock)
 
     // 이력용 — HTML 태그 없이 이력 페이지에서 보기 편한 요약.
+    // Phase 37-A (#444): evaluator 결과와 스냅샷을 contextJson 으로 저장 →
+    // 상세 모달에서 어느 조건이 만족/미달이었는지 재현 가능.
+    const taReport = taByTicker.get(s.ticker) ?? null
     historyEvents.push({
       kind: 'custom_strategy',
       ticker: s.ticker,
       price: priceRow?.price ?? null,
+      changePercent: priceRow?.changePercent ?? null,
       message: `${s.name} (${s.ticker}) — ${s.logic} 조건 만족`,
+      context: buildCustomStrategyContext({
+        strategyId: s.id,
+        strategyName: s.name,
+        strategyTicker: s.ticker,
+        logic: s.logic === 'OR' ? 'OR' : 'AND',
+        conditions: conds,
+        perCondition,
+        snapshot: {
+          price: priceRow?.price ?? null,
+          changePercent: priceRow?.changePercent ?? null,
+          rsi: taReport?.indicators.rsi14.value ?? null,
+          macdCrossover: taReport?.indicators.macd.crossover ?? null,
+          bbPosition: taReport?.indicators.bollingerBands.position ?? null,
+        },
+      }),
     })
   }
 

--- a/src/bot/notifications/price-alert.ts
+++ b/src/bot/notifications/price-alert.ts
@@ -16,6 +16,7 @@ import {
   recordAlertHistory,
   type AlertEventInput,
 } from './alert-history'
+import { buildPriceContext, buildFxContext } from '@/lib/alert-history/context'
 
 const WATCHLIST_MHO_KEY = 'watchlist_market_hours_only'
 const WATCHLIST_MHO_LABEL = '관심종목 매수 알림 — 장중에만'
@@ -139,6 +140,11 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
           price: p.price,
           changePercent: p.changePercent,
           message: `💱 환율 ${direction}: ${p.price.toLocaleString('ko-KR')}원 (${p.change > 0 ? '+' : ''}${p.change.toFixed(0)}원)`,
+          context: buildFxContext({
+            rate: p.price,
+            changeKrw: p.change,
+            changePercent: p.changePercent,
+          }),
         })
       }
       continue
@@ -163,6 +169,14 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
         price: p.price,
         changePercent: p.changePercent,
         message: `🔴 ${name} (${p.ticker}) 급락: ${formatPercent(p.changePercent)}`,
+        context: buildPriceContext({
+          type: 'drop',
+          price: p.price,
+          changePercent: p.changePercent,
+          threshold: dropThreshold,
+          // 도착 조건상 marketOpen 은 true (isMarketOpenFor 통과했음)
+          marketOpen: true,
+        }),
       })
     } else if (p.changePercent >= surgeThreshold) {
       sentToday.set(key, today)
@@ -173,6 +187,13 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
         price: p.price,
         changePercent: p.changePercent,
         message: `🟢 ${name} (${p.ticker}) 급등: ${formatPercent(p.changePercent)}`,
+        context: buildPriceContext({
+          type: 'surge',
+          price: p.price,
+          changePercent: p.changePercent,
+          threshold: surgeThreshold,
+          marketOpen: true,
+        }),
       })
     }
   }
@@ -206,7 +227,16 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
           kind: 'target_hit',
           ticker: s.holding.ticker,
           price: currentPrice,
+          changePercent: price.changePercent,
           message: `🎯 ${name} (${ticker}) 목표가 도달: ${currentPrice.toLocaleString('ko-KR')} (목표 ${s.targetPrice.toLocaleString('ko-KR')})`,
+          context: buildPriceContext({
+            type: 'target_hit',
+            price: currentPrice,
+            changePercent: price.changePercent,
+            threshold: s.targetPrice,
+            // 24h 알림 — 시장 개장 여부는 티커별 판정
+            marketOpen: isMarketOpenFor(price.market, s.holding.ticker),
+          }),
         })
       }
     }
@@ -219,7 +249,15 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
           kind: 'stop_loss',
           ticker: s.holding.ticker,
           price: currentPrice,
+          changePercent: price.changePercent,
           message: `🛑 ${name} (${ticker}) 손절가 도달: ${currentPrice.toLocaleString('ko-KR')} (손절 ${s.stopLoss.toLocaleString('ko-KR')})`,
+          context: buildPriceContext({
+            type: 'stop_loss',
+            price: currentPrice,
+            changePercent: price.changePercent,
+            threshold: s.stopLoss,
+            marketOpen: isMarketOpenFor(price.market, s.holding.ticker),
+          }),
         })
       }
     }
@@ -254,7 +292,15 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
           kind: 'watch_buy',
           ticker: w.ticker,
           price: price.price,
+          changePercent: price.changePercent,
           message: `💰 ${name} (${ticker}) 목표 매수가 도달: ${price.price.toLocaleString('ko-KR')} (목표 ${w.targetBuy.toLocaleString('ko-KR')})`,
+          context: buildPriceContext({
+            type: 'watch_buy',
+            price: price.price,
+            changePercent: price.changePercent,
+            threshold: w.targetBuy,
+            marketOpen: isMarketOpenFor(price.market, w.ticker),
+          }),
         })
       }
     }
@@ -267,7 +313,16 @@ export async function checkPriceAlerts(chatIds: number[]): Promise<void> {
           kind: 'watch_zone',
           ticker: w.ticker,
           price: price.price,
+          changePercent: price.changePercent,
           message: `🔔 ${name} (${ticker}) 매수구간 진입: ${price.price.toLocaleString('ko-KR')} (구간 ${w.entryLow.toLocaleString('ko-KR')}~${w.entryHigh.toLocaleString('ko-KR')})`,
+          context: buildPriceContext({
+            type: 'watch_zone',
+            price: price.price,
+            changePercent: price.changePercent,
+            // 구간은 상한을 임계값으로 저장 (하한은 message 에 이미 포함)
+            threshold: w.entryHigh,
+            marketOpen: isMarketOpenFor(price.market, w.ticker),
+          }),
         })
       }
     }

--- a/src/bot/notifications/ta-signal-alert.ts
+++ b/src/bot/notifications/ta-signal-alert.ts
@@ -17,6 +17,7 @@ import {
   recordAlertHistory,
   type AlertEventInput,
 } from './alert-history'
+import { buildTaContext } from '@/lib/alert-history/context'
 import type { TAReport } from '@/lib/ta/types'
 
 /** 당일 시그널 발송 기록 (키 → date string) */
@@ -90,6 +91,8 @@ interface SignalResult {
   strategy: string
   signals: string[]
   signalIds: string[]
+  /** Phase 37-A (#444): 발동 당시 TA 리포트 — AlertHistory.contextJson 저장에 재활용 */
+  report: TAReport
 }
 
 interface Signal {
@@ -267,6 +270,7 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
           strategy: stratLabel,
           signals: newSignals.map((s) => s.message),
           signalIds: newSignals.map((s) => s.id),
+          report,
         })
       }
     } catch (error) {
@@ -351,6 +355,7 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
 
   // Phase 33-A (#416): 티커 단위 이력 저장 — 각 종목의 시그널을 한 이벤트로 통합.
   // 시세 스냅샷 (price / changePercent) 을 함께 캡처하여 사후 진단시 참고.
+  // Phase 37-A (#444): TA 지표 스냅샷도 contextJson 에 저장.
   const historyEvents: AlertEventInput[] = results.map((r) => {
     const snap = snapshotByTicker.get(r.ticker)
     return {
@@ -359,6 +364,12 @@ async function doCheckTASignals(chatIds: number[]): Promise<void> {
       price: snap?.price ?? null,
       changePercent: snap?.changePercent ?? null,
       message: `${r.displayName} (${r.ticker}) — ${r.strategy}: ${r.signals.join(', ')}`,
+      context: buildTaContext({
+        report: r.report,
+        price: snap?.price ?? null,
+        changePercent: snap?.changePercent ?? null,
+        signals: r.signalIds,
+      }),
     }
   })
   const status = computeDeliveryStatus(sendSuccess, chatIds.length)

--- a/src/components/alerts/AlertHistoryDetailModal.tsx
+++ b/src/components/alerts/AlertHistoryDetailModal.tsx
@@ -1,0 +1,394 @@
+'use client'
+
+/**
+ * Phase 37-A (#444) — 알림 발동 이력 상세 모달.
+ *
+ * `AlertHistory.contextJson` 을 kind 별로 렌더 분기.
+ * 컨텍스트가 없는 (v1) row 는 안내 문구 노출.
+ */
+
+import { useEffect } from 'react'
+import { STATUS_META, kindMetaOf } from '@/app/alerts/history/kinds'
+import { formatFiredAt, stripHtml } from '@/app/alerts/history/client-utils'
+import { conditionToString, type Condition } from '@/lib/custom-strategy/types'
+
+// 상세 모달이 필요로 하는 최소 필드셋. AlertHistoryClient 의 HistoryRow 와 호환.
+export interface AlertHistoryDetailRow {
+  id: string
+  firedAt: string
+  kind: string
+  ticker: string | null
+  price: number | null
+  changePercent: number | null
+  message: string
+  deliveryStatus: string
+  recipientCount: number
+  errorMessage: string | null
+  context: unknown
+}
+
+interface Props {
+  row: AlertHistoryDetailRow
+  onClose: () => void
+}
+
+export default function AlertHistoryDetailModal({ row, onClose }: Props) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const meta = kindMetaOf(row.kind)
+  const status =
+    STATUS_META[row.deliveryStatus] ??
+    { label: row.deliveryStatus, colorClass: 'bg-surface text-sub border-border' }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-xl border border-border bg-bg-raised p-6 space-y-4 max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="알림 상세"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={`px-2 py-0.5 rounded border font-semibold text-[11px] ${
+                  meta?.colorClass ?? 'bg-surface text-sub border-border'
+                }`}
+              >
+                {meta?.icon} {meta?.label ?? row.kind}
+              </span>
+              {row.ticker && (
+                <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono text-[11px]">
+                  {row.ticker}
+                </span>
+              )}
+              <span
+                className={`px-2 py-0.5 rounded border font-semibold text-[11px] ${status.colorClass}`}
+              >
+                {status.label} · {row.recipientCount}명
+              </span>
+            </div>
+            <div className="text-[11px] text-sub tabular-nums">{formatFiredAt(row.firedAt)}</div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-2 py-1 text-sub hover:text-bright hover:bg-surface rounded-md transition-colors"
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Message */}
+        <div className="rounded-lg bg-surface-dim border border-border p-3">
+          <div className="text-[11px] text-sub mb-1">알림 메시지</div>
+          <div className="text-[13px] text-bright whitespace-pre-line">
+            {stripHtml(row.message)}
+          </div>
+          {row.errorMessage && (
+            <div className="mt-2 pt-2 border-t border-border text-[11px] text-red-400 font-mono">
+              에러: {row.errorMessage}
+            </div>
+          )}
+        </div>
+
+        {/* Context (kind 별 분기) */}
+        <ContextSection kind={row.kind} context={row.context} />
+      </div>
+    </div>
+  )
+}
+
+// ─── 렌더러 ──────────────────────────────────────────
+
+function ContextSection({ kind, context }: { kind: string; context: unknown }) {
+  if (!context || typeof context !== 'object') {
+    return (
+      <div className="rounded-lg bg-surface-dim border border-border p-3 text-[12px] text-sub">
+        컨텍스트 없음 (v1 데이터 · Phase 37-A 이전 기록)
+      </div>
+    )
+  }
+
+  const ctx = context as Record<string, unknown>
+  const t = typeof ctx.type === 'string' ? ctx.type : kind
+
+  if (
+    t === 'surge' || t === 'drop' ||
+    t === 'target_hit' || t === 'stop_loss' ||
+    t === 'watch_buy' || t === 'watch_zone'
+  ) {
+    return <PriceContextView ctx={ctx} />
+  }
+  if (t === 'fx') return <FxContextView ctx={ctx} />
+  if (t === 'ta_signal') return <TaContextView ctx={ctx} />
+  if (t === 'custom_strategy') return <CustomStrategyContextView ctx={ctx} />
+
+  return (
+    <div className="rounded-lg bg-surface-dim border border-border p-3 text-[12px] text-sub">
+      알 수 없는 컨텍스트 타입: <span className="font-mono">{String(t)}</span>
+    </div>
+  )
+}
+
+// ─── 개별 renderer ────────────────────────────────────
+
+function PriceContextView({ ctx }: { ctx: Record<string, unknown> }) {
+  const price = num(ctx.price)
+  const changePct = num(ctx.changePercent)
+  const threshold = num(ctx.threshold)
+  const marketOpen = typeof ctx.marketOpen === 'boolean' ? ctx.marketOpen : null
+
+  return (
+    <div className="rounded-lg bg-surface-dim border border-border p-3 space-y-2">
+      <div className="text-[11px] text-sub">시세 스냅샷</div>
+      <div className="grid grid-cols-2 gap-3 text-[13px]">
+        <Stat label="현재가" value={price != null ? price.toLocaleString('ko-KR') : '—'} />
+        <Stat
+          label="변동률"
+          value={changePct != null ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%` : '—'}
+          tone={changePct == null ? 'sub' : changePct >= 0 ? 'up' : 'down'}
+        />
+        <Stat
+          label="기준값"
+          value={threshold != null ? threshold.toLocaleString('ko-KR') : '—'}
+        />
+        <Stat
+          label="시장"
+          value={marketOpen == null ? '—' : marketOpen ? '장중' : '장외'}
+          tone={marketOpen == null ? 'sub' : marketOpen ? 'up' : 'sub'}
+        />
+      </div>
+    </div>
+  )
+}
+
+function FxContextView({ ctx }: { ctx: Record<string, unknown> }) {
+  const rate = num(ctx.rate)
+  const changeKrw = num(ctx.changeKrw)
+  const changePct = num(ctx.changePercent)
+
+  return (
+    <div className="rounded-lg bg-surface-dim border border-border p-3 space-y-2">
+      <div className="text-[11px] text-sub">환율 스냅샷</div>
+      <div className="grid grid-cols-3 gap-3 text-[13px]">
+        <Stat label="USDKRW" value={rate != null ? `${rate.toLocaleString('ko-KR')}원` : '—'} />
+        <Stat
+          label="변동"
+          value={changeKrw != null ? `${changeKrw > 0 ? '+' : ''}${changeKrw.toFixed(0)}원` : '—'}
+          tone={changeKrw == null ? 'sub' : changeKrw >= 0 ? 'up' : 'down'}
+        />
+        <Stat
+          label="변동률"
+          value={changePct != null ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%` : '—'}
+          tone={changePct == null ? 'sub' : changePct >= 0 ? 'up' : 'down'}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TaContextView({ ctx }: { ctx: Record<string, unknown> }) {
+  const price = num(ctx.price)
+  const changePct = num(ctx.changePercent)
+  const rsi = num(ctx.rsi)
+  const macdCrossover = str(ctx.macdCrossover)
+  const bbPosition = str(ctx.bbPosition)
+  const smaGolden = typeof ctx.smaGoldenCross === 'boolean' ? ctx.smaGoldenCross : null
+  const smaDead = typeof ctx.smaDeathCross === 'boolean' ? ctx.smaDeathCross : null
+  const volumeSurge = typeof ctx.volumeSurge === 'boolean' ? ctx.volumeSurge : null
+  const overall = str(ctx.overall)
+  const signals = Array.isArray(ctx.signals) ? (ctx.signals as unknown[]).map(String) : []
+
+  return (
+    <div className="rounded-lg bg-surface-dim border border-border p-3 space-y-3">
+      <div className="text-[11px] text-sub">TA 지표 스냅샷</div>
+
+      <div className="grid grid-cols-2 gap-3 text-[13px]">
+        <Stat label="현재가" value={price != null ? price.toLocaleString('ko-KR') : '—'} />
+        <Stat
+          label="변동률"
+          value={changePct != null ? `${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%` : '—'}
+          tone={changePct == null ? 'sub' : changePct >= 0 ? 'up' : 'down'}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-[11px]">
+        {rsi != null && (
+          <Badge color="violet" label={`RSI ${rsi.toFixed(1)}`} />
+        )}
+        {macdCrossover && (
+          <Badge color={macdCrossover === 'GOLDEN' ? 'emerald' : 'red'} label={`MACD ${macdCrossover}`} />
+        )}
+        {bbPosition && (
+          <Badge color="sky" label={`BB ${bbPosition}`} />
+        )}
+        {smaGolden && <Badge color="emerald" label="SMA GOLDEN" />}
+        {smaDead && <Badge color="red" label="SMA DEAD" />}
+        {volumeSurge && <Badge color="amber" label="거래량 급증" />}
+        {overall && (
+          <Badge
+            color={overall.includes('BUY') ? 'emerald' : overall.includes('SELL') ? 'red' : 'sub'}
+            label={`종합 ${overall}`}
+          />
+        )}
+      </div>
+
+      {signals.length > 0 && (
+        <div className="pt-2 border-t border-border">
+          <div className="text-[11px] text-sub mb-1">발동된 시그널</div>
+          <div className="flex flex-wrap gap-1">
+            {signals.map((s) => (
+              <span
+                key={s}
+                className="px-2 py-0.5 rounded border border-border bg-surface text-bright font-mono text-[11px]"
+              >
+                {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CustomStrategyContextView({ ctx }: { ctx: Record<string, unknown> }) {
+  const strategyName = str(ctx.strategyName)
+  const strategyTicker = str(ctx.strategyTicker)
+  const logic = str(ctx.logic)
+  const perCondition = Array.isArray(ctx.perCondition)
+    ? (ctx.perCondition as Array<{ condition?: unknown; result?: unknown }>)
+    : []
+  const snapshot = ctx.snapshot && typeof ctx.snapshot === 'object'
+    ? (ctx.snapshot as Record<string, unknown>)
+    : null
+
+  return (
+    <div className="rounded-lg bg-surface-dim border border-border p-3 space-y-3">
+      <div className="text-[11px] text-sub">커스텀 전략 스냅샷</div>
+
+      <div className="text-[13px]">
+        <div className="text-bright font-semibold">{strategyName ?? '(이름 없음)'}</div>
+        <div className="text-sub text-[11px] mt-0.5">
+          티커 <span className="font-mono">{strategyTicker ?? '?'}</span> · 결합 {logic ?? '?'}
+        </div>
+      </div>
+
+      {perCondition.length > 0 && (
+        <div className="border-t border-border pt-2">
+          <div className="text-[11px] text-sub mb-1">조건별 결과</div>
+          <ul className="space-y-1 text-[12px] font-mono">
+            {perCondition.map((p, i) => {
+              const result = p.result === true
+              const label = p.condition ? conditionToString(p.condition as Condition) : '?'
+              return (
+                <li key={i} className="flex items-start gap-2">
+                  <span className={result ? 'text-emerald-400' : 'text-red-400'}>
+                    {result ? '✅' : '❌'}
+                  </span>
+                  <span className={result ? 'text-bright' : 'text-sub'}>{label}</span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+
+      {snapshot && (
+        <StrategySnapshotView snapshot={snapshot} />
+      )}
+    </div>
+  )
+}
+
+function StrategySnapshotView({ snapshot }: { snapshot: Record<string, unknown> }) {
+  const macd = str(snapshot.macdCrossover)
+  const bb = str(snapshot.bbPosition)
+  const rsi = num(snapshot.rsi)
+  return (
+    <div className="border-t border-border pt-2">
+      <div className="text-[11px] text-sub mb-1">평가 시점 시세</div>
+      <div className="grid grid-cols-2 gap-2 text-[12px]">
+        <Stat label="현재가" value={fmtNum(snapshot.price)} />
+        <Stat label="변동률" value={fmtPct(snapshot.changePercent)} />
+        {rsi != null && <Stat label="RSI" value={rsi.toFixed(1)} />}
+        {macd && <Stat label="MACD" value={macd} />}
+        {bb && <Stat label="BB" value={bb} />}
+      </div>
+    </div>
+  )
+}
+
+// ─── UI primitives ──────────────────────────────────
+
+function Stat({
+  label,
+  value,
+  tone = 'bright',
+}: {
+  label: string
+  value: string
+  tone?: 'bright' | 'up' | 'down' | 'sub'
+}) {
+  const toneClass = {
+    bright: 'text-bright',
+    up: 'text-emerald-400',
+    down: 'text-red-400',
+    sub: 'text-sub',
+  }[tone]
+  return (
+    <div>
+      <div className="text-[11px] text-sub">{label}</div>
+      <div className={`${toneClass} font-semibold tabular-nums`}>{value}</div>
+    </div>
+  )
+}
+
+type BadgeColor = 'emerald' | 'red' | 'sky' | 'violet' | 'amber' | 'sub'
+
+function Badge({ color, label }: { color: BadgeColor; label: string }) {
+  const cls: Record<BadgeColor, string> = {
+    emerald: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+    red: 'bg-red-500/15 text-red-400 border-red-500/30',
+    sky: 'bg-sky-500/15 text-sky-400 border-sky-500/30',
+    violet: 'bg-violet-500/15 text-violet-400 border-violet-500/30',
+    amber: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+    sub: 'bg-surface border-border text-sub',
+  }
+  return (
+    <span className={`px-2 py-0.5 rounded border font-semibold ${cls[color]}`}>{label}</span>
+  )
+}
+
+// ─── helpers ──────────────────────────────────
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v ? v : null
+}
+function fmtNum(v: unknown, decimals = 0): string {
+  const n = num(v)
+  if (n == null) return '—'
+  return decimals > 0 ? n.toFixed(decimals) : n.toLocaleString('ko-KR')
+}
+function fmtPct(v: unknown): string {
+  const n = num(v)
+  if (n == null) return '—'
+  return `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`
+}

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -102,7 +102,7 @@ export const SYSTEM_PROMPT = `당신은 myFinance의 가족 자산관리 AI 어�
 - list_budgets / set_budget / delete_budget: 카테고리별 월 예산 관리 (set은 upsert). **쓰기는 사용자 확인 후**
 - list_recurring_transactions / create_recurring_transaction / update_recurring_transaction / delete_recurring_transaction: 반복 거래 CRUD. **쓰기는 사용자 확인 후**
 - list_alert_configs / update_alert_config: 알림 임계값 설정 (기존 키만). **변경은 사용자 확인 후**
-- list_alert_history: 알림 발동 이력 조회. 필터: kind (surge/drop/fx/target_hit/stop_loss/watch_buy/watch_zone/ta_signal/custom_strategy), ticker, from~to (ISO 8601), limit (기본 50, 최대 200)
+- list_alert_history: 알림 발동 이력 조회 + 발동 당시 컨텍스트 (시세/TA/전략 스냅샷) 요약. 필터: kind (surge/drop/fx/target_hit/stop_loss/watch_buy/watch_zone/ta_signal/custom_strategy), ticker, from~to (ISO 8601), limit (기본 50, 최대 200). Phase 37-A 이후 발동 row 는 각 라인 아래 ↳ 요약에 RSI/MACD/BB/기준값 등이 함께 표시.
 - create_rsu_schedule / update_rsu_schedule / delete_rsu_schedule: RSU 베스팅 일정 CRUD (update/delete는 pending만). **쓰기는 사용자 확인 후**
 - vest_rsu: RSU 베스팅 처리 — 종가 자동 조회 후 BUY/SELL Trade + Holding 자동 반영. **사용자의 명시적 동의 후에만 호출**
 - create_stock_option / update_stock_option / delete_stock_option: 스톡옵션 CRUD (update 시 remainingShares 자동 재계산). **쓰기는 사용자 확인 후**

--- a/src/lib/alert-history/__tests__/context.test.ts
+++ b/src/lib/alert-history/__tests__/context.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Phase 37-A (#444) — AlertHistoryContext 빌더 pure test.
+ * 각 kind × 필드 채움/누락 시나리오. hook 회귀 방지용.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  buildPriceContext,
+  buildFxContext,
+  buildTaContext,
+  buildCustomStrategyContext,
+  isValidContext,
+} from '../context'
+import type { TAReport } from '@/lib/ta/types'
+import type { Condition } from '@/lib/custom-strategy/types'
+
+function fakeReport(overrides: Partial<TAReport['indicators']> = {}): TAReport {
+  return {
+    ticker: 'AAPL',
+    period: '6mo',
+    price: {
+      current: 150,
+      change1d: 1.2,
+      change5d: 3.5,
+      change20d: -2.1,
+      high52w: 200,
+      low52w: 100,
+      fromHigh52w: -25,
+    },
+    indicators: {
+      rsi14: { value: 32.1, signal: 'OVERSOLD' },
+      macd: { macd: 0.2, signal: 0.1, histogram: 0.1, trend: 'BULLISH', crossover: 'GOLDEN' },
+      bollingerBands: { upper: 160, middle: 150, lower: 140, position: 'BELOW_LOWER', bandwidth: 0.13 },
+      sma: { sma20: 145, sma50: 140, sma200: 130, priceVsSma20: 3.4, goldenCross: true, deathCross: false },
+      volume: { current: 100_000_000, avg20d: 50_000_000, ratio: 2.0, surge: true },
+      ...overrides,
+    },
+    support: [140, 130],
+    resistance: [160, 180],
+    signalSummary: { overall: 'STRONG_BUY', reasons: ['RSI 과매도', 'MACD 골든크로스'] },
+  }
+}
+
+describe('buildPriceContext', () => {
+  it('surge/drop/target_hit/stop_loss/watch_buy/watch_zone 모두 동일 shape', () => {
+    const types = ['surge', 'drop', 'target_hit', 'stop_loss', 'watch_buy', 'watch_zone'] as const
+    for (const t of types) {
+      const ctx = buildPriceContext({
+        type: t,
+        price: 150,
+        changePercent: -5.2,
+        threshold: 100,
+        marketOpen: true,
+      })
+      expect(ctx.type).toBe(t)
+      expect(ctx.price).toBe(150)
+      expect(ctx.changePercent).toBe(-5.2)
+      expect(ctx.threshold).toBe(100)
+      expect(ctx.marketOpen).toBe(true)
+      expect(isValidContext(ctx)).toBe(true)
+    }
+  })
+
+  it('optional 필드 미지정 시 null 로 정규화', () => {
+    const ctx = buildPriceContext({
+      type: 'surge',
+      price: 150,
+      changePercent: null,
+      marketOpen: null,
+    })
+    expect(ctx.threshold).toBeNull()
+    expect(ctx.marketOpen).toBeNull()
+    expect(ctx.changePercent).toBeNull()
+  })
+})
+
+describe('buildFxContext', () => {
+  it('환율 필드 그대로 저장', () => {
+    const ctx = buildFxContext({ rate: 1330, changeKrw: 55, changePercent: 4.3 })
+    expect(ctx.type).toBe('fx')
+    expect(ctx.rate).toBe(1330)
+    expect(ctx.changeKrw).toBe(55)
+    expect(ctx.changePercent).toBe(4.3)
+    expect(isValidContext(ctx)).toBe(true)
+  })
+
+  it('changeKrw null 허용', () => {
+    const ctx = buildFxContext({ rate: 1330, changeKrw: null, changePercent: null })
+    expect(ctx.changeKrw).toBeNull()
+    expect(ctx.changePercent).toBeNull()
+  })
+})
+
+describe('buildTaContext', () => {
+  it('TAReport 에서 지표 발췌', () => {
+    const report = fakeReport()
+    const ctx = buildTaContext({
+      report,
+      price: 150,
+      changePercent: 1.2,
+      signals: ['RSI_OVERSOLD', 'MACD_GOLDEN'],
+    })
+    expect(ctx.type).toBe('ta_signal')
+    expect(ctx.rsi).toBeCloseTo(32.1)
+    expect(ctx.macdCrossover).toBe('GOLDEN')
+    expect(ctx.bbPosition).toBe('BELOW_LOWER')
+    expect(ctx.smaGoldenCross).toBe(true)
+    expect(ctx.smaDeathCross).toBe(false)
+    expect(ctx.volumeSurge).toBe(true)
+    expect(ctx.signals).toEqual(['RSI_OVERSOLD', 'MACD_GOLDEN'])
+    expect(ctx.overall).toBe('STRONG_BUY')
+    expect(isValidContext(ctx)).toBe(true)
+  })
+
+  it('crossover 없을 때 null', () => {
+    const report = fakeReport({
+      macd: { macd: 0, signal: 0, histogram: 0, trend: 'NEUTRAL' },
+    })
+    const ctx = buildTaContext({ report, price: null, changePercent: null, signals: [] })
+    expect(ctx.macdCrossover).toBeNull()
+    expect(ctx.signals).toEqual([])
+  })
+
+  it('signals 배열은 얕은 복사 (mutation isolation)', () => {
+    const signals = ['RSI_OVERSOLD']
+    const ctx = buildTaContext({ report: fakeReport(), price: 150, changePercent: 1, signals })
+    signals.push('MACD_GOLDEN')
+    expect(ctx.signals).toEqual(['RSI_OVERSOLD']) // 원본 mutation 이 컨텍스트에 반영 X
+  })
+})
+
+describe('buildCustomStrategyContext', () => {
+  const cond1: Condition = { type: 'rsi', operator: '<', value: 30 }
+  const cond2: Condition = { type: 'price', operator: '>', value: 100 }
+
+  it('conditions + perCondition 저장 + snapshot 통과', () => {
+    const ctx = buildCustomStrategyContext({
+      strategyId: 'strat_1',
+      strategyName: 'SOXL 저점',
+      strategyTicker: 'SOXL',
+      logic: 'AND',
+      conditions: [cond1, cond2],
+      perCondition: [
+        { condition: cond1, result: true },
+        { condition: cond2, result: false },
+      ],
+      snapshot: { price: 25.4, changePercent: -1.2, rsi: 28.5 },
+    })
+    expect(ctx.type).toBe('custom_strategy')
+    expect(ctx.strategyId).toBe('strat_1')
+    expect(ctx.strategyTicker).toBe('SOXL')
+    expect(ctx.logic).toBe('AND')
+    expect(ctx.conditions).toHaveLength(2)
+    expect(ctx.perCondition).toHaveLength(2)
+    expect(ctx.perCondition[0].result).toBe(true)
+    expect(ctx.snapshot?.price).toBe(25.4)
+    expect(isValidContext(ctx)).toBe(true)
+  })
+
+  it('conditions 얕은 복사 — 원본 변경이 컨텍스트에 영향 없음', () => {
+    const conds: Condition[] = [{ ...cond1 }]
+    const ctx = buildCustomStrategyContext({
+      strategyId: 'x',
+      strategyName: 'n',
+      strategyTicker: 'X',
+      logic: 'AND',
+      conditions: conds,
+      perCondition: [{ condition: conds[0], result: true }],
+    })
+    conds[0].value = 999
+    expect((ctx.conditions[0] as Condition).value).toBe(30)
+    expect((ctx.perCondition[0].condition as Condition).value).toBe(30)
+  })
+
+  it('snapshot 없이도 유효', () => {
+    const ctx = buildCustomStrategyContext({
+      strategyId: 'x',
+      strategyName: 'n',
+      strategyTicker: 'X',
+      logic: 'OR',
+      conditions: [cond1],
+      perCondition: [{ condition: cond1, result: true }],
+    })
+    expect(ctx.snapshot).toBeUndefined()
+    expect(isValidContext(ctx)).toBe(true)
+  })
+})
+
+describe('isValidContext', () => {
+  it('알려진 type 만 통과', () => {
+    expect(isValidContext({ type: 'surge' })).toBe(true)
+    expect(isValidContext({ type: 'drop' })).toBe(true)
+    expect(isValidContext({ type: 'fx' })).toBe(true)
+    expect(isValidContext({ type: 'ta_signal' })).toBe(true)
+    expect(isValidContext({ type: 'custom_strategy' })).toBe(true)
+    expect(isValidContext({ type: 'watch_buy' })).toBe(true)
+    expect(isValidContext({ type: 'watch_zone' })).toBe(true)
+    expect(isValidContext({ type: 'target_hit' })).toBe(true)
+    expect(isValidContext({ type: 'stop_loss' })).toBe(true)
+  })
+
+  it('알 수 없는 shape 은 거부', () => {
+    expect(isValidContext(null)).toBe(false)
+    expect(isValidContext(undefined)).toBe(false)
+    expect(isValidContext('string')).toBe(false)
+    expect(isValidContext(42)).toBe(false)
+    expect(isValidContext({})).toBe(false)
+    expect(isValidContext({ type: 'unknown_kind' })).toBe(false)
+    expect(isValidContext({ type: 42 })).toBe(false)
+  })
+})

--- a/src/lib/alert-history/context.ts
+++ b/src/lib/alert-history/context.ts
@@ -1,0 +1,197 @@
+/**
+ * Phase 37-A (#444) — AlertHistory.contextJson 스키마 + 순수 빌더.
+ *
+ * 알림 발동 hook 이 이미 확보한 데이터 (priceCache row, TAReport, evaluator 결과 등) 를
+ * 재활용해 최소 스냅샷을 만든다. 추가 fetch 를 유발하지 않는다.
+ *
+ * kind 별 payload shape:
+ *   surge | drop | target_hit | stop_loss | watch_buy | watch_zone
+ *     → { price, prevPrice?, changePercent?, marketOpen? }
+ *   fx  → { rate, prevRate?, changePercent? }
+ *   ta_signal → { rsi?, macdCrossover?, bbPosition?, price?, changePercent?, signals[] }
+ *   custom_strategy → { strategyId, strategyName, logic, conditions[], perCondition[], snapshot? }
+ *
+ * `type` 필드가 kind discriminator 역할. 사후 진단 UI 는 이 필드로 렌더러 분기.
+ */
+
+import type { Condition } from '@/lib/custom-strategy/types'
+import type { TAReport, BBPosition, MACDCrossover } from '@/lib/ta/types'
+
+/** 상세 모달의 kind discriminator. AlertKind 와 값 동일 (`kind` 컬럼과 정합). */
+export type AlertContextKind =
+  | 'surge' | 'drop'
+  | 'target_hit' | 'stop_loss'
+  | 'watch_buy' | 'watch_zone'
+  | 'fx'
+  | 'ta_signal'
+  | 'custom_strategy'
+
+/** 시세 계열 (surge/drop/target_hit/stop_loss/watch_buy/watch_zone) 공통 스냅샷 */
+export interface PriceAlertContext {
+  type: 'surge' | 'drop' | 'target_hit' | 'stop_loss' | 'watch_buy' | 'watch_zone'
+  price: number
+  changePercent: number | null
+  /** 목표가/손절가/구간 등 조건 값 (kind 별 의미 다름). 없으면 null */
+  threshold?: number | null
+  /** 시장 개장 여부 — 사후 진단 시 "장중이었나?" 즉시 확인 */
+  marketOpen: boolean | null
+}
+
+/** 환율 알림 컨텍스트 */
+export interface FxAlertContext {
+  type: 'fx'
+  rate: number
+  /** 전일 대비 KRW 변동 */
+  changeKrw: number | null
+  changePercent: number | null
+}
+
+/** TA 시그널 컨텍스트 — TAReport 에서 핵심 지표만 발췌 */
+export interface TaSignalContext {
+  type: 'ta_signal'
+  price: number | null
+  changePercent: number | null
+  rsi: number | null
+  macdCrossover: MACDCrossover | null
+  bbPosition: BBPosition | null
+  smaGoldenCross: boolean | null
+  smaDeathCross: boolean | null
+  volumeSurge: boolean | null
+  /** 발동된 시그널 id 목록 (예: ['RSI_OVERSOLD', 'MACD_GOLDEN']) */
+  signals: string[]
+  /** 종합 시그널 등급 */
+  overall: string | null
+}
+
+/** 커스텀 전략 컨텍스트 — evaluator 결과 재활용 */
+export interface CustomStrategyContext {
+  type: 'custom_strategy'
+  strategyId: string
+  strategyName: string
+  strategyTicker: string
+  logic: 'AND' | 'OR'
+  conditions: Condition[]
+  /** 각 조건 만족 여부. evaluator 의 perCondition 을 그대로 저장 */
+  perCondition: Array<{ condition: Condition; result: boolean }>
+  /** 스냅샷 요약 — TA 리포트 fetch 를 안 하는 경우 (price only) 대비 옵셔널 */
+  snapshot?: {
+    price: number | null
+    changePercent: number | null
+    rsi?: number | null
+    macdCrossover?: MACDCrossover | null
+    bbPosition?: BBPosition | null
+  }
+}
+
+export type AlertHistoryContext =
+  | PriceAlertContext
+  | FxAlertContext
+  | TaSignalContext
+  | CustomStrategyContext
+
+// ─── 빌더 pure 함수들 ──────────────────────────────────────────────
+
+/**
+ * 시세 계열 (surge/drop/target_hit/stop_loss/watch_buy/watch_zone) 컨텍스트 빌더.
+ * `prevPrice` 는 PriceCache 에 없어 옵셔널 — changePercent 로 회귀 계산 가능.
+ */
+export function buildPriceContext(input: {
+  type: PriceAlertContext['type']
+  price: number
+  changePercent: number | null
+  threshold?: number | null
+  marketOpen: boolean | null
+}): PriceAlertContext {
+  return {
+    type: input.type,
+    price: input.price,
+    changePercent: input.changePercent,
+    threshold: input.threshold ?? null,
+    marketOpen: input.marketOpen,
+  }
+}
+
+/** 환율 컨텍스트 빌더 */
+export function buildFxContext(input: {
+  rate: number
+  changeKrw: number | null
+  changePercent: number | null
+}): FxAlertContext {
+  return {
+    type: 'fx',
+    rate: input.rate,
+    changeKrw: input.changeKrw,
+    changePercent: input.changePercent,
+  }
+}
+
+/**
+ * TA 시그널 컨텍스트 빌더. TAReport 가 필수 (checkSignals 는 report 를 기반으로 판정).
+ * TAReport 는 이미 fetch 된 상태 → 추가 비용 없음.
+ */
+export function buildTaContext(input: {
+  report: TAReport
+  price: number | null
+  changePercent: number | null
+  signals: string[]
+}): TaSignalContext {
+  const { indicators, signalSummary } = input.report
+  return {
+    type: 'ta_signal',
+    price: input.price,
+    changePercent: input.changePercent,
+    rsi: Number.isFinite(indicators.rsi14.value) ? indicators.rsi14.value : null,
+    macdCrossover: indicators.macd.crossover ?? null,
+    bbPosition: indicators.bollingerBands.position ?? null,
+    smaGoldenCross: indicators.sma.goldenCross ?? null,
+    smaDeathCross: indicators.sma.deathCross ?? null,
+    volumeSurge: indicators.volume.surge ?? null,
+    signals: [...input.signals],
+    overall: signalSummary.overall ?? null,
+  }
+}
+
+/**
+ * 커스텀 전략 컨텍스트 빌더. evaluator 의 perCondition 을 그대로 보존해
+ * 사후 진단 시 어느 조건이 만족/미달이었는지 재현.
+ * conditions 는 저장 시점 스냅샷 (편집 후에도 발동 당시 상태 유지).
+ */
+export function buildCustomStrategyContext(input: {
+  strategyId: string
+  strategyName: string
+  strategyTicker: string
+  logic: 'AND' | 'OR'
+  conditions: Condition[]
+  perCondition: Array<{ condition: Condition; result: boolean }>
+  snapshot?: CustomStrategyContext['snapshot']
+}): CustomStrategyContext {
+  return {
+    type: 'custom_strategy',
+    strategyId: input.strategyId,
+    strategyName: input.strategyName,
+    strategyTicker: input.strategyTicker,
+    logic: input.logic,
+    // 깊은 복사 대신 얕은 복사 — Condition 은 primitive 필드 위주.
+    conditions: input.conditions.map((c) => ({ ...c })),
+    perCondition: input.perCondition.map((p) => ({
+      condition: { ...p.condition },
+      result: p.result,
+    })),
+    snapshot: input.snapshot,
+  }
+}
+
+/**
+ * 저장 전 sanity check — 알 수 없는 shape 이 저장되지 않도록.
+ * DB 는 Json? 이라 어떤 값도 통과되지만, evaluator 결과가 예상 밖일 때 저장 방지 목적.
+ */
+export function isValidContext(v: unknown): v is AlertHistoryContext {
+  if (!v || typeof v !== 'object') return false
+  const t = (v as { type?: unknown }).type
+  return (
+    t === 'surge' || t === 'drop' ||
+    t === 'target_hit' || t === 'stop_loss' ||
+    t === 'watch_buy' || t === 'watch_zone' ||
+    t === 'fx' || t === 'ta_signal' || t === 'custom_strategy'
+  )
+}

--- a/src/mcp/tools/__tests__/alert-history.test.ts
+++ b/src/mcp/tools/__tests__/alert-history.test.ts
@@ -113,4 +113,58 @@ describe('listAlertHistory', () => {
     expect(text).toContain('🔴 AAPL 급락')
     expect(text).toContain('2026-07-08')
   })
+
+  // Phase 37-A (#444) — contextJson 요약 라인 노출 (AI 사후 진단용).
+  it('contextJson 이 있으면 요약 라인 포함, 없으면 스킵', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([
+      {
+        id: '1',
+        firedAt: new Date('2026-07-08T02:30:00Z'),
+        kind: 'ta_signal',
+        ticker: 'AAPL',
+        price: 150,
+        changePercent: 1.2,
+        message: 'RSI 과매도',
+        deliveryStatus: 'sent',
+        recipientCount: 1,
+        errorMessage: null,
+        contextJson: {
+          type: 'ta_signal',
+          rsi: 25.3,
+          macdCrossover: 'GOLDEN',
+          bbPosition: 'BELOW_LOWER',
+          signals: ['RSI_OVERSOLD'],
+        },
+      },
+      {
+        id: '2',
+        firedAt: new Date('2026-07-08T02:31:00Z'),
+        kind: 'surge',
+        ticker: 'AAPL',
+        price: 150,
+        changePercent: 5.2,
+        message: '🟢 AAPL 급등',
+        deliveryStatus: 'sent',
+        recipientCount: 1,
+        errorMessage: null,
+        contextJson: null, // v1 row 시뮬레이션
+      },
+    ] as never)
+
+    const result = await listAlertHistory({})
+    const text = result.content[0].text
+    // TA 요약 라인 (RSI 25.3, MACD GOLDEN, BB BELOW_LOWER, RSI_OVERSOLD)
+    expect(text).toContain('RSI 25.3')
+    expect(text).toContain('MACD GOLDEN')
+    expect(text).toContain('BB BELOW_LOWER')
+    // contextJson null 인 두번째 행은 요약 라인 없음 — id 2 라인 뒤에 ↳ 가 없어야
+    const lines = text.split('\n')
+    const surgeIdx = lines.findIndex((l) => l.includes('🟢 AAPL 급등'))
+    expect(surgeIdx).toBeGreaterThan(-1)
+    // 요약 라인은 다음 라인에 '↳' 로 시작. surge (v1) 는 요약 없음
+    if (lines[surgeIdx + 1]) {
+      expect(lines[surgeIdx + 1]).not.toMatch(/^\s*↳/)
+    }
+  })
 })

--- a/src/mcp/tools/alert-history.ts
+++ b/src/mcp/tools/alert-history.ts
@@ -96,10 +96,77 @@ export async function listAlertHistory(args: ListAlertHistoryArgs = {}) {
       const tickerPart = r.ticker ? ` [${r.ticker}]` : ''
       lines.push(`- ${time} · ${kindLabel}${tickerPart} · ${statusLabel}`)
       lines.push(`  ${r.message}`)
+      // Phase 37-A (#444): 컨텍스트 요약 — AI 가 사후 진단할 때 참조.
+      const ctx = summarizeContext(r.contextJson)
+      if (ctx) lines.push(`  ↳ ${ctx}`)
     }
 
     return toolResult(lines.join('\n'))
   } catch (error) {
     return toolError(error)
   }
+}
+
+/**
+ * contextJson 을 한 줄 요약으로 변환 (AI/텔레그램 표시용).
+ * 알 수 없는 shape 이면 null → 라인 스킵.
+ */
+function summarizeContext(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return null
+  const ctx = raw as Record<string, unknown>
+  const type = ctx.type
+
+  if (type === 'fx') {
+    const rate = num(ctx.rate)
+    const changeKrw = num(ctx.changeKrw)
+    if (rate == null) return null
+    return `환율 ${rate.toLocaleString('ko-KR')}원${changeKrw != null ? ` (${changeKrw > 0 ? '+' : ''}${changeKrw.toFixed(0)}원)` : ''}`
+  }
+
+  if (
+    type === 'surge' || type === 'drop' ||
+    type === 'target_hit' || type === 'stop_loss' ||
+    type === 'watch_buy' || type === 'watch_zone'
+  ) {
+    const price = num(ctx.price)
+    const changePct = num(ctx.changePercent)
+    const threshold = num(ctx.threshold)
+    const marketOpen = ctx.marketOpen
+    const parts: string[] = []
+    if (price != null) parts.push(`시세 ${price.toLocaleString('ko-KR')}`)
+    if (changePct != null) parts.push(`${changePct >= 0 ? '+' : ''}${changePct.toFixed(2)}%`)
+    if (threshold != null) parts.push(`기준 ${threshold.toLocaleString('ko-KR')}`)
+    if (typeof marketOpen === 'boolean') parts.push(marketOpen ? '장중' : '장외')
+    return parts.length > 0 ? parts.join(' · ') : null
+  }
+
+  if (type === 'ta_signal') {
+    const rsi = num(ctx.rsi)
+    const macd = str(ctx.macdCrossover)
+    const bb = str(ctx.bbPosition)
+    const signals = Array.isArray(ctx.signals) ? (ctx.signals as unknown[]).map(String) : []
+    const parts: string[] = []
+    if (rsi != null) parts.push(`RSI ${rsi.toFixed(1)}`)
+    if (macd) parts.push(`MACD ${macd}`)
+    if (bb) parts.push(`BB ${bb}`)
+    if (signals.length > 0) parts.push(signals.join(','))
+    return parts.length > 0 ? parts.join(' · ') : null
+  }
+
+  if (type === 'custom_strategy') {
+    const name = str(ctx.strategyName)
+    const logic = str(ctx.logic)
+    const per = Array.isArray(ctx.perCondition) ? (ctx.perCondition as unknown[]) : []
+    const matched = per.filter((p) => p && typeof p === 'object' && (p as { result?: unknown }).result === true).length
+    return `전략 "${name ?? '?'}" ${logic ?? ''} — ${matched}/${per.length} 조건 매칭`
+  }
+
+  return null
+}
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v ? v : null
 }


### PR DESCRIPTION
## Summary
- 알림 이력에 kind 별 컨텍스트 스냅샷 저장 + 상세 모달로 사후 진단 가능하게 만듭니다.
- Master: #443. Spec: `docs/specs/443-milestone-17-master.md` §Phase 37-A
- `AlertHistory.contextJson: Json?` 하위호환 마이그레이션 (`20260714030819_add_alert_history_context`)
- 9개 kind (fx / surge / drop / target_hit / stop_loss / watch_buy / watch_zone / ta_signal / custom_strategy) 별 최소 스냅샷 빌더 + `isValidContext` sanity check (`src/lib/alert-history/context.ts`)
- 상세 모달 `AlertHistoryDetailModal.tsx` — kind 별 렌더러 분기. v1 row (contextJson null) 는 "컨텍스트 없음" 표시
- MCP `list_alert_history` — `↳` 요약 라인 (텔레그램 AI 사후 진단용)
- `Prisma.JsonNull` 정규화 (undefined → Prisma 에러 회피)

## Test plan
- [x] lint / typecheck / test:run (32 files, 516 tests) / build 통과
- [x] self-review (pr-review-toolkit) P0/P1/P2 = 0
- [x] 마이그레이션 적용 확인 (`20260714030819_add_alert_history_context`, 25/25)
- [x] 회귀 방지 테스트 19 케이스 추가 (빌더 15 + hook 3 + MCP summarize 1)
- [ ] 배포 후 `/alerts/history` 행 클릭 → 상세 모달 kind 별 렌더링 확인
- [ ] 배포 후 v1 row (배포 이전 저장) 는 "컨텍스트 없음" 표시 확인
- [ ] 배포 후 텔레그램 `/ai list_alert_history` 조회 시 `↳` 요약 라인 확인
- [ ] 배포 후 텔레그램 `/reset` (system-prompt.ts 갱신 반영)

Closes #444