### PR TITLE
feat(alert): 알림 이력 CSV export + 실패 재발송 (Phase 37-B, #445)

### DIFF
--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -55,6 +55,11 @@ export default function AlertHistoryClient() {
   const [error, setError] = useState<string | null>(null)
   // Phase 37-A (#444): 상세 모달 상태 — id 대신 row 를 통째로 저장해 fetch 재요청 회피.
   const [selectedRow, setSelectedRow] = useState<AlertHistoryDetailRow | null>(null)
+  // Phase 37-B (#445): 재발송 중인 row id (중복 클릭 방지).
+  const [retryingId, setRetryingId] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  // 재발송 성공 후 리스트 refetch trigger.
+  const [refetchTick, setRefetchTick] = useState(0)
 
   // Codex P2 (#417 PR #424): 다중 kind 를 서버 쿼리로 전달 (`?kind=a&kind=b`) →
   // API 가 `in` 절로 필터 + 페이지네이션·집계가 정합. 클라 사이드 후처리 제거.
@@ -111,7 +116,57 @@ export default function AlertHistoryClient() {
     return () => {
       cancelled = true
     }
-  }, [days, kindsKey, tickerFilter, offset])
+  }, [days, kindsKey, tickerFilter, offset, refetchTick])
+
+  // Phase 37-B (#445): 현재 필터 그대로 CSV export API 로 전달 → 파일 다운로드.
+  const buildExportUrl = () => {
+    const from = periodFromISO(days)
+    const kinds = kindsKey ? kindsKey.split(',') : []
+    const params = new URLSearchParams()
+    params.set('from', from)
+    for (const k of kinds) params.append('kind', k)
+    if (tickerFilter) params.set('ticker', tickerFilter)
+    return `/api/alerts/history/export?${params.toString()}`
+  }
+
+  const handleRetry = async (row: HistoryRow) => {
+    if (retryingId) return
+    if (row.deliveryStatus !== 'failed') {
+      setToast({ type: 'error', text: '실패한 알림만 재발송할 수 있습니다.' })
+      return
+    }
+    const ok = typeof window !== 'undefined'
+      ? window.confirm('이 알림을 재발송하시겠습니까?\n동일 알림은 5분에 한 번만 재발송할 수 있습니다.')
+      : true
+    if (!ok) return
+    setRetryingId(row.id)
+    try {
+      const res = await fetch(`/api/alerts/history/${row.id}/retry`, { method: 'POST' })
+      const json = await res.json()
+      if (!res.ok || !json?.success) {
+        throw new Error(json?.error ?? '재발송에 실패했습니다.')
+      }
+      const status = json?.data?.status ?? 'sent'
+      const msg = status === 'sent'
+        ? '재발송 성공 — 새 이력이 추가되었습니다.'
+        : status === 'partial'
+          ? '일부 chat 에만 발송됨 — 이력이 추가되었습니다.'
+          : '재발송 시도했으나 모두 실패 — 이력이 추가되었습니다.'
+      setToast({ type: status === 'failed' ? 'error' : 'success', text: msg })
+      setRefetchTick((t) => t + 1)
+    } catch (e) {
+      setToast({ type: 'error', text: e instanceof Error ? e.message : '재발송 중 오류' })
+    } finally {
+      setRetryingId(null)
+    }
+  }
+
+  // toast 자동 소멸 (4s).
+  useEffect(() => {
+    if (!toast) return
+    const t = setTimeout(() => setToast(null), 4000)
+    return () => clearTimeout(t)
+  }, [toast])
 
   const toggleKind = (k: AlertKind) => {
     setOffset(0)
@@ -184,6 +239,14 @@ export default function AlertHistoryClient() {
                 초기화
               </button>
             )}
+            {/* Phase 37-B (#445): 현재 필터 그대로 CSV 다운로드. <a download> 로 브라우저 기본 처리. */}
+            <a
+              href={buildExportUrl()}
+              download
+              className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-sejin/40 bg-sejin/15 text-sejin hover:bg-sejin/25"
+            >
+              CSV 다운로드
+            </a>
           </div>
         </div>
 
@@ -305,38 +368,55 @@ export default function AlertHistoryClient() {
             {rows.map((r) => {
               const meta = kindMetaOf(r.kind)
               const status = STATUS_META[r.deliveryStatus] ?? { label: r.deliveryStatus, colorClass: 'bg-surface text-sub border-border' }
+              const isFailed = r.deliveryStatus === 'failed'
+              const isRetrying = retryingId === r.id
               return (
                 <li
                   key={r.id}
                   className="border-b border-border last:border-b-0"
                 >
-                  <button
-                    type="button"
-                    onClick={() => setSelectedRow(r)}
-                    className="w-full text-left px-5 py-3 hover:bg-surface-dim transition-colors focus:outline-none focus:bg-surface-dim"
-                    aria-label={`${meta?.label ?? r.kind} 상세 보기`}
-                  >
-                    <div className="flex flex-wrap items-center gap-2 text-[11px]">
-                      <span className="text-sub tabular-nums">{formatFiredAt(r.firedAt)}</span>
-                      <span className={`px-2 py-0.5 rounded border font-semibold ${meta?.colorClass ?? 'bg-surface text-sub border-border'}`}>
-                        {meta?.icon} {meta?.label ?? r.kind}
-                      </span>
-                      {r.ticker && (
-                        <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
-                          {r.ticker}
+                  {/* Phase 37-B (#445): 상세 모달 오픈 버튼과 재발송 버튼을 sibling 으로 분리 —
+                      nested <button> 회피 (HTML invalid). retry 는 실패 row 에만 노출. */}
+                  <div className="flex items-stretch">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedRow(r)}
+                      className="flex-1 min-w-0 text-left px-5 py-3 hover:bg-surface-dim transition-colors focus:outline-none focus:bg-surface-dim"
+                      aria-label={`${meta?.label ?? r.kind} 상세 보기`}
+                    >
+                      <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                        <span className="text-sub tabular-nums">{formatFiredAt(r.firedAt)}</span>
+                        <span className={`px-2 py-0.5 rounded border font-semibold ${meta?.colorClass ?? 'bg-surface text-sub border-border'}`}>
+                          {meta?.icon} {meta?.label ?? r.kind}
                         </span>
+                        {r.ticker && (
+                          <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
+                            {r.ticker}
+                          </span>
+                        )}
+                        <span className={`ml-auto px-2 py-0.5 rounded border font-semibold ${status.colorClass}`}>
+                          {status.label} · {r.recipientCount}
+                        </span>
+                      </div>
+                      <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
+                        {stripHtml(r.message)}
+                      </div>
+                      {r.errorMessage && (
+                        <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>
                       )}
-                      <span className={`ml-auto px-2 py-0.5 rounded border font-semibold ${status.colorClass}`}>
-                        {status.label} · {r.recipientCount}
-                      </span>
-                    </div>
-                    <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
-                      {stripHtml(r.message)}
-                    </div>
-                    {r.errorMessage && (
-                      <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>
+                    </button>
+                    {isFailed && (
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); void handleRetry(r) }}
+                        disabled={retryingId !== null}
+                        className="shrink-0 px-3 text-[11px] font-semibold text-red-300 border-l border-border hover:bg-red-500/10 hover:text-red-200 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-red-300"
+                        aria-label="이 알림 재발송"
+                      >
+                        {isRetrying ? '재발송 중…' : '재발송'}
+                      </button>
                     )}
-                  </button>
+                  </div>
                 </li>
               )
             })}
@@ -370,6 +450,29 @@ export default function AlertHistoryClient() {
           row={selectedRow}
           onClose={() => setSelectedRow(null)}
         />
+      )}
+
+      {/* Phase 37-B (#445): 재발송/CSV 결과 토스트. 자동 소멸 (4s) + 수동 닫기. */}
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2.5 rounded-lg border shadow-lg text-[13px] font-semibold ${
+            toast.type === 'success'
+              ? 'bg-emerald-500/15 border-emerald-400/50 text-emerald-100'
+              : 'bg-red-500/15 border-red-400/50 text-red-100'
+          }`}
+        >
+          <span>{toast.text}</span>
+          <button
+            type="button"
+            onClick={() => setToast(null)}
+            className="ml-3 text-[11px] opacity-70 hover:opacity-100"
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
       )}
     </div>
   )

--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -129,6 +129,47 @@ export default function AlertHistoryClient() {
     return `/api/alerts/history/export?${params.toString()}`
   }
 
+  // Phase 37-B self-review (#445, P0): `<a download>` 방식은 API 가 500 을 뱉으면
+  // envelope JSON 이 `.csv` 확장자로 저장돼 사용자가 Excel 로 열기 전까지 실패를
+  // 알아차리지 못한다. fetch → blob 으로 바꾸고 응답 헤더로 truncation 도 안내.
+  const [csvDownloading, setCsvDownloading] = useState(false)
+  const handleCsvDownload = async () => {
+    if (csvDownloading) return
+    setCsvDownloading(true)
+    try {
+      const res = await fetch(buildExportUrl())
+      if (!res.ok) {
+        const json = await res.json().catch(() => null)
+        setToast({ type: 'error', text: json?.error ?? 'CSV 다운로드 실패' })
+        return
+      }
+      const blob = await res.blob()
+      const objectUrl = URL.createObjectURL(blob)
+      try {
+        const a = document.createElement('a')
+        a.href = objectUrl
+        const dateKey = new Date().toISOString().slice(0, 10)
+        a.download = `alerts-history-${dateKey}.csv`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+      } finally {
+        URL.revokeObjectURL(objectUrl)
+      }
+      if (res.headers.get('X-Truncated') === 'true') {
+        const total = res.headers.get('X-Total-Count') ?? '?'
+        setToast({
+          type: 'error',
+          text: `CSV 가 상한(10,000행)으로 잘렸습니다. 전체 ${total}행 — 필터를 좁혀 다시 받으세요.`,
+        })
+      }
+    } catch (e) {
+      setToast({ type: 'error', text: e instanceof Error ? e.message : 'CSV 다운로드 중 오류' })
+    } finally {
+      setCsvDownloading(false)
+    }
+  }
+
   const handleRetry = async (row: HistoryRow) => {
     if (retryingId) return
     if (row.deliveryStatus !== 'failed') {
@@ -239,14 +280,17 @@ export default function AlertHistoryClient() {
                 초기화
               </button>
             )}
-            {/* Phase 37-B (#445): 현재 필터 그대로 CSV 다운로드. <a download> 로 브라우저 기본 처리. */}
-            <a
-              href={buildExportUrl()}
-              download
-              className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-sejin/40 bg-sejin/15 text-sejin hover:bg-sejin/25"
+            {/* Phase 37-B (#445): 현재 필터 그대로 CSV 다운로드.
+                self-review P0: `<a download>` → fetch+blob 로 교체해 실패시 toast 표시,
+                truncation 헤더도 사용자에게 통지. */}
+            <button
+              type="button"
+              onClick={handleCsvDownload}
+              disabled={csvDownloading}
+              className="px-3 py-1.5 text-[12px] font-semibold rounded-md border border-sejin/40 bg-sejin/15 text-sejin hover:bg-sejin/25 disabled:opacity-50 disabled:cursor-wait"
             >
-              CSV 다운로드
-            </a>
+              {csvDownloading ? '다운로드 중…' : 'CSV 다운로드'}
+            </button>
           </div>
         </div>
 

--- a/src/app/api/alerts/history/[id]/retry/__tests__/route.test.ts
+++ b/src/app/api/alerts/history/[id]/retry/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Phase 37-B (#445) — 재발송 route 회귀 테스트.
+ *
+ * 커버리지:
+ *  - 실패 row 만 재발송 허용
+ *  - Rate limit (동일 원본 5분내 재시도 금지)
+ *  - **Retry-of-retry cooldown key 통합** (Codex #454 P2) —
+ *    dispatcher 가 chain root 를 propagate 하므로 route 는 한 단계만 lookup 하면 됨.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/bot/notifications/alert-dispatcher', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/bot/notifications/alert-dispatcher')
+  >('@/bot/notifications/alert-dispatcher')
+  return {
+    ...actual,
+    // 실제 rate limiter 를 유지 (테스트에서 reset). redispatchAlert 만 spy.
+    redispatchAlert: vi.fn(async () => ({
+      successCount: 0,
+      totalChats: 1,
+      status: 'failed' as const,
+      lastError: 'mocked',
+    })),
+    persistRetryHistory: vi.fn(async () => undefined),
+  }
+})
+
+describe('POST /api/alerts/history/[id]/retry', () => {
+  const OLD_ENV = process.env.TELEGRAM_ALLOWED_CHAT_IDS
+
+  beforeEach(async () => {
+    process.env.TELEGRAM_ALLOWED_CHAT_IDS = '111'
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findUnique).mockReset()
+
+    // 매 테스트 전 rate limiter 리셋 (프로세스 in-memory 라 테스트 간 공유됨).
+    const { globalRetryLimiter } = await import('@/bot/notifications/alert-dispatcher')
+    globalRetryLimiter.reset()
+  })
+
+  afterEach(() => {
+    process.env.TELEGRAM_ALLOWED_CHAT_IDS = OLD_ENV
+  })
+
+  const buildReq = () => new Request('http://x/api/alerts/history/x/retry', { method: 'POST' })
+
+  it('실패가 아닌 row 는 400', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findUnique).mockResolvedValueOnce({
+      id: 'a1',
+      deliveryStatus: 'sent',
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 150,
+      changePercent: -6,
+      message: 'x',
+      contextJson: null,
+    } as never)
+
+    const { POST } = await import('../route')
+    const res = await POST(buildReq() as never, { params: Promise.resolve({ id: 'a1' }) })
+    expect(res.status).toBe(400)
+  })
+
+  it('없는 row → 404', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findUnique).mockResolvedValueOnce(null as never)
+
+    const { POST } = await import('../route')
+    const res = await POST(buildReq() as never, { params: Promise.resolve({ id: 'nope' }) })
+    expect(res.status).toBe(404)
+  })
+
+  it('같은 원본 두 번 → 두번째는 429 (cooldown)', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const row = {
+      id: 'a1',
+      deliveryStatus: 'failed',
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 150,
+      changePercent: -6,
+      message: 'x',
+      contextJson: null,
+    }
+    vi.mocked(prisma.alertHistory.findUnique).mockResolvedValue(row as never)
+
+    const { POST } = await import('../route')
+    const res1 = await POST(buildReq() as never, { params: Promise.resolve({ id: 'a1' }) })
+    expect(res1.status).toBe(200)
+
+    const res2 = await POST(buildReq() as never, { params: Promise.resolve({ id: 'a1' }) })
+    expect(res2.status).toBe(429)
+  })
+
+  // Codex #454 P2 회귀 방지 — retry row 를 다시 retry 해도 cooldown 이 원본 기준으로 잡혀야 함.
+  it('retry-of-retry: contextJson.retriedFrom 이 있는 row 는 원본 id 로 cooldown 잡힘', async () => {
+    const { prisma } = await import('@/lib/prisma')
+
+    // 1. 먼저 원본 (id=orig) 재발송 → cooldown 시작
+    const original = {
+      id: 'orig',
+      deliveryStatus: 'failed',
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 150,
+      changePercent: -6,
+      message: 'x',
+      contextJson: null,
+    }
+    vi.mocked(prisma.alertHistory.findUnique).mockResolvedValueOnce(original as never)
+
+    const { POST } = await import('../route')
+    const res1 = await POST(buildReq() as never, { params: Promise.resolve({ id: 'orig' }) })
+    expect(res1.status).toBe(200)
+
+    // 2. dispatcher 가 저장했을 새 retry row (id=retry1, retriedFrom=orig) 를 다시 UI 가 retry
+    const retry1 = {
+      id: 'retry1',
+      deliveryStatus: 'failed',
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 150,
+      changePercent: -6,
+      message: 'x',
+      contextJson: { type: 'drop', retriedFrom: 'orig' },
+    }
+    vi.mocked(prisma.alertHistory.findUnique).mockResolvedValueOnce(retry1 as never)
+
+    // 원본과 동일 cooldown 그룹 → 429 (id 가 다르지만 root=orig 로 cooldown 걸림)
+    const res2 = await POST(buildReq() as never, { params: Promise.resolve({ id: 'retry1' }) })
+    expect(res2.status).toBe(429)
+  })
+
+  it('다른 원본은 별도 cooldown', async () => {
+    const { prisma } = await import('@/lib/prisma')
+
+    const rowA = {
+      id: 'A',
+      deliveryStatus: 'failed',
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 1,
+      changePercent: 0,
+      message: 'a',
+      contextJson: null,
+    }
+    const rowB = {
+      id: 'B',
+      deliveryStatus: 'failed',
+      kind: 'drop',
+      ticker: 'MSFT',
+      price: 1,
+      changePercent: 0,
+      message: 'b',
+      contextJson: null,
+    }
+    vi.mocked(prisma.alertHistory.findUnique)
+      .mockResolvedValueOnce(rowA as never)
+      .mockResolvedValueOnce(rowB as never)
+
+    const { POST } = await import('../route')
+    expect((await POST(buildReq() as never, { params: Promise.resolve({ id: 'A' }) })).status).toBe(200)
+    expect((await POST(buildReq() as never, { params: Promise.resolve({ id: 'B' }) })).status).toBe(200)
+  })
+
+  it('chat 목록이 비어있으면 500 (cooldown 미마킹 — 환경변수 재설정 후 즉시 재시도 가능)', async () => {
+    process.env.TELEGRAM_ALLOWED_CHAT_IDS = ''
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findUnique).mockResolvedValue({
+      id: 'a1',
+      deliveryStatus: 'failed',
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 1,
+      changePercent: 0,
+      message: 'x',
+      contextJson: null,
+    } as never)
+
+    const { POST } = await import('../route')
+    const res = await POST(buildReq() as never, { params: Promise.resolve({ id: 'a1' }) })
+    expect(res.status).toBe(500)
+
+    // 환경변수 복구 후 즉시 재시도 → cooldown 안걸림 → 200
+    process.env.TELEGRAM_ALLOWED_CHAT_IDS = '111'
+    const res2 = await POST(buildReq() as never, { params: Promise.resolve({ id: 'a1' }) })
+    expect(res2.status).toBe(200)
+  })
+})

--- a/src/app/api/alerts/history/[id]/retry/route.ts
+++ b/src/app/api/alerts/history/[id]/retry/route.ts
@@ -1,0 +1,84 @@
+/**
+ * Phase 37-B (#445) — 실패 알림 재발송.
+ * POST /api/alerts/history/[id]/retry
+ *
+ * - `deliveryStatus === 'failed'` 인 row 만 대상. 그 외는 400 (이미 성공/부분성공).
+ * - 원본 row 는 mutate 하지 않고 새 AlertHistory row 를 append (`retriedFrom` 마커).
+ * - Rate limit: 동일 id 5분내 재시도 금지 (스팸 방지). 프로세스 in-memory.
+ * - Bot import 는 route handler 내부에서 lazy — Bot 초기화 시 요구되는 env 이 없는
+ *   테스트 환경에서 모듈 로드 시 crash 하지 않도록 함.
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { ok, fail } from '@/lib/api-response'
+import {
+  globalRetryLimiter,
+  redispatchAlert,
+  persistRetryHistory,
+  RETRY_COOLDOWN_MS,
+} from '@/bot/notifications/alert-dispatcher'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+export const dynamic = 'force-dynamic'
+
+function getAllowedChatIds(): number[] {
+  return (process.env.TELEGRAM_ALLOWED_CHAT_IDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(Number)
+    .filter((n) => !Number.isNaN(n))
+}
+
+export async function POST(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params
+    if (!id) return fail('알림 id 가 필요합니다.', 400)
+
+    const row = await prisma.alertHistory.findUnique({ where: { id } })
+    if (!row) return fail('해당 알림 이력을 찾을 수 없습니다.', 404)
+
+    if (row.deliveryStatus !== 'failed') {
+      return fail('실패한 알림만 재발송할 수 있습니다.', 400)
+    }
+
+    // Rate limit — 스팸 방지. Retry-After 헤더는 응답 body 로 대체 (envelope 유지).
+    const check = globalRetryLimiter.check(id)
+    if (!check.allowed) {
+      const remainSec = Math.ceil(check.retryAfterMs / 1000)
+      return fail(`재발송은 5분에 한 번만 가능합니다. ${remainSec}초 후에 다시 시도하세요.`, 429)
+    }
+
+    const chatIds = getAllowedChatIds()
+    if (chatIds.length === 0) {
+      // 재발송 대상 chat 이 없으면 실패로 취급 (mark 하지 않아 재시도 여지 유지 —
+      // 환경변수 재설정 직후 즉시 눌러도 rate limit 걸리지 않도록).
+      return fail('발송 대상 chat 이 설정되지 않았습니다.', 500)
+    }
+
+    // 실제 시도 직전에 mark — 성공/실패 무관하게 cooldown 시작.
+    globalRetryLimiter.markAttempt(id)
+
+    const result = await redispatchAlert(row, chatIds)
+    await persistRetryHistory(row, result)
+
+    return ok(
+      {
+        originalId: id,
+        status: result.status,
+        successCount: result.successCount,
+        totalChats: result.totalChats,
+        lastError: result.lastError ?? null,
+        cooldownMs: RETRY_COOLDOWN_MS,
+      },
+      { status: 200 },
+    )
+  } catch (error) {
+    console.error('POST /api/alerts/history/[id]/retry error:', error)
+    return fail('알림 재발송에 실패했습니다.', 500)
+  }
+}

--- a/src/app/api/alerts/history/[id]/retry/route.ts
+++ b/src/app/api/alerts/history/[id]/retry/route.ts
@@ -5,8 +5,9 @@
  * - `deliveryStatus === 'failed'` 인 row 만 대상. 그 외는 400 (이미 성공/부분성공).
  * - 원본 row 는 mutate 하지 않고 새 AlertHistory row 를 append (`retriedFrom` 마커).
  * - Rate limit: 동일 id 5분내 재시도 금지 (스팸 방지). 프로세스 in-memory.
- * - Bot import 는 route handler 내부에서 lazy — Bot 초기화 시 요구되는 env 이 없는
- *   테스트 환경에서 모듈 로드 시 crash 하지 않도록 함.
+ * - Bot 인스턴스는 `getBot()` 첫 호출 시점에 지연 초기화되며 (module load 시점 아님),
+ *   `alert-dispatcher` 의 `redispatchAlert` 내부에서 호출된다. static import 는 안전 —
+ *   `alert-dispatcher` 모듈 로드가 곧 Bot 초기화는 아니기 때문이다.
  */
 
 import { NextRequest } from 'next/server'

--- a/src/app/api/alerts/history/[id]/retry/route.ts
+++ b/src/app/api/alerts/history/[id]/retry/route.ts
@@ -48,7 +48,13 @@ export async function POST(_req: NextRequest, { params }: RouteParams) {
     }
 
     // Rate limit — 스팸 방지. Retry-After 헤더는 응답 body 로 대체 (envelope 유지).
-    const check = globalRetryLimiter.check(id)
+    // Codex #454 P2: cooldown 키는 **원본 alert 기준**. retry 실패 시 새 row (fresh id) 가
+    // 생성되어 UI 가 그것을 다시 retry 하면 원본 cooldown 우회. `retriedFrom` 이 있으면
+    // 원본 id 를 키로 사용해 모든 retry 시도를 동일 cooldown 그룹으로 묶는다.
+    const contextJson = row.contextJson as { retriedFrom?: unknown } | null
+    const rootId = typeof contextJson?.retriedFrom === 'string' ? contextJson.retriedFrom : id
+
+    const check = globalRetryLimiter.check(rootId)
     if (!check.allowed) {
       const remainSec = Math.ceil(check.retryAfterMs / 1000)
       return fail(`재발송은 5분에 한 번만 가능합니다. ${remainSec}초 후에 다시 시도하세요.`, 429)
@@ -61,8 +67,8 @@ export async function POST(_req: NextRequest, { params }: RouteParams) {
       return fail('발송 대상 chat 이 설정되지 않았습니다.', 500)
     }
 
-    // 실제 시도 직전에 mark — 성공/실패 무관하게 cooldown 시작.
-    globalRetryLimiter.markAttempt(id)
+    // 실제 시도 직전에 mark — 성공/실패 무관하게 cooldown 시작. 원본 id 로 mark.
+    globalRetryLimiter.markAttempt(rootId)
 
     const result = await redispatchAlert(row, chatIds)
     await persistRetryHistory(row, result)

--- a/src/app/api/alerts/history/export/__tests__/csv-format.test.ts
+++ b/src/app/api/alerts/history/export/__tests__/csv-format.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Phase 37-B (#445) — CSV export 포맷 pure 함수 회귀 테스트.
+ *
+ * 테스트 대상:
+ *   - formatKstDateTime: UTC → KST 벽시계 문자열
+ *   - stripHtmlForCsv: HTML 태그 제거
+ *   - summarizeContext: kind 별 필드 요약 + retriedFrom 마커
+ *   - toCsvRow: Prisma row → 헤더 순서와 정합
+ *   - buildExportFilename: KST 날짜 포함
+ *   - toCSV 통합: RFC 4180 escape + 수식 주입 방어
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  formatKstDateTime,
+  stripHtmlForCsv,
+  summarizeContext,
+  toCsvRow,
+  buildExportFilename,
+  HISTORY_CSV_HEADERS,
+} from '../csv-format'
+import { toCSV } from '@/lib/csv'
+
+describe('formatKstDateTime', () => {
+  it('UTC 00:00 → KST 09:00 (같은 날)', () => {
+    // 2026-07-08 00:00 UTC = 2026-07-08 09:00 KST
+    expect(formatKstDateTime('2026-07-08T00:00:00Z')).toBe('2026-07-08 09:00:00')
+  })
+
+  it('UTC 15:00 → KST 다음날 00:00 (달 넘김 없음)', () => {
+    expect(formatKstDateTime('2026-07-08T15:00:00Z')).toBe('2026-07-09 00:00:00')
+  })
+
+  it('Date 인스턴스도 처리', () => {
+    const d = new Date('2026-07-08T00:00:00Z')
+    expect(formatKstDateTime(d)).toBe('2026-07-08 09:00:00')
+  })
+
+  it('잘못된 값은 빈 문자열', () => {
+    expect(formatKstDateTime('not-a-date')).toBe('')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(formatKstDateTime(new Date('invalid') as any)).toBe('')
+  })
+
+  it('zero-pad — 한자리 시/분/초를 항상 2자리로', () => {
+    // UTC 00:00:05 → KST 09:00:05
+    expect(formatKstDateTime('2026-01-02T00:00:05Z')).toBe('2026-01-02 09:00:05')
+  })
+})
+
+describe('stripHtmlForCsv', () => {
+  it('간단한 태그 제거', () => {
+    expect(stripHtmlForCsv('<b>AAPL</b> 급락')).toBe('AAPL 급락')
+  })
+
+  it('중첩 태그도 처리', () => {
+    expect(stripHtmlForCsv('<div><span>hi</span></div>')).toBe('hi')
+  })
+
+  it('속성 포함 태그', () => {
+    expect(stripHtmlForCsv('<a href="x">link</a>')).toBe('link')
+  })
+
+  it('태그 없는 문자열은 그대로', () => {
+    expect(stripHtmlForCsv('plain text')).toBe('plain text')
+  })
+})
+
+describe('summarizeContext', () => {
+  it('null/undefined → 빈 문자열', () => {
+    expect(summarizeContext(null)).toBe('')
+    expect(summarizeContext(undefined)).toBe('')
+  })
+
+  it('non-object primitive → String() 변환', () => {
+    expect(summarizeContext('scalar')).toBe('scalar')
+    expect(summarizeContext(42)).toBe('42')
+  })
+
+  it('price alert context — 주요 필드 요약', () => {
+    const s = summarizeContext({
+      type: 'drop', price: 150, changePercent: -6.2, threshold: -5, marketOpen: true,
+    })
+    expect(s).toContain('type=drop')
+    expect(s).toContain('price=150')
+    expect(s).toContain('Δ%=-6.2')
+    expect(s).toContain('threshold=-5')
+    expect(s).toContain('marketOpen=true')
+  })
+
+  it('fx context — rate 필드 요약', () => {
+    const s = summarizeContext({ type: 'fx', rate: 1330, changeKrw: 55, changePercent: 4.3 })
+    expect(s).toContain('type=fx')
+    expect(s).toContain('rate=1330')
+    expect(s).toContain('Δ%=4.3')
+  })
+
+  it('ta_signal context — 지표/시그널 배열 파이프 조인', () => {
+    const s = summarizeContext({
+      type: 'ta_signal',
+      price: 150, changePercent: 1, rsi: 32, macdCrossover: 'GOLDEN', bbPosition: 'BELOW_LOWER',
+      overall: 'BUY',
+      signals: ['RSI_OVERSOLD', 'MACD_GOLDEN'],
+    })
+    expect(s).toContain('type=ta_signal')
+    expect(s).toContain('rsi=32')
+    expect(s).toContain('macd=GOLDEN')
+    expect(s).toContain('bb=BELOW_LOWER')
+    expect(s).toContain('overall=BUY')
+    expect(s).toContain('signals=RSI_OVERSOLD|MACD_GOLDEN')
+  })
+
+  it('custom_strategy context — strategyId/Name 요약', () => {
+    const s = summarizeContext({
+      type: 'custom_strategy', strategyId: 's1', strategyName: '테스트',
+      logic: 'AND', conditions: [], perCondition: [],
+    })
+    expect(s).toContain('type=custom_strategy')
+    expect(s).toContain('strategyId=s1')
+    expect(s).toContain('strategy=테스트')
+  })
+
+  it('retriedFrom 마커 포함 (재발송 이력 식별)', () => {
+    const s = summarizeContext({
+      type: 'drop', price: 100, changePercent: -3, marketOpen: true, retriedFrom: 'orig-id-123',
+    })
+    expect(s).toContain('retriedFrom=orig-id-123')
+  })
+
+  it('알 수 없는 shape → JSON stringify fallback', () => {
+    const s = summarizeContext({ foo: 'bar', nested: { a: 1 } })
+    // type/price/rsi 등 whitelist 필드가 없으면 parts 가 비어 JSON.stringify 로 대체
+    expect(s).toBe(JSON.stringify({ foo: 'bar', nested: { a: 1 } }))
+  })
+
+  it('changePercent 등 0 값도 표시 (falsy 체크 실수 방지)', () => {
+    const s = summarizeContext({ type: 'drop', price: 100, changePercent: 0, threshold: 0, marketOpen: false })
+    // 0 은 null 이 아니므로 반드시 포함
+    expect(s).toContain('Δ%=0')
+    expect(s).toContain('threshold=0')
+    expect(s).toContain('marketOpen=false')
+  })
+})
+
+describe('toCsvRow', () => {
+  it('전체 필드 셀 순서가 HISTORY_CSV_HEADERS 와 일치', () => {
+    const row = toCsvRow({
+      firedAt: new Date('2026-07-08T00:00:00Z'),
+      kind: 'drop',
+      ticker: 'AAPL',
+      price: 150.5,
+      changePercent: -6.2,
+      message: '<b>AAPL</b> 급락',
+      deliveryStatus: 'sent',
+      recipientCount: 2,
+      errorMessage: null,
+      contextJson: { type: 'drop', price: 150.5, changePercent: -6.2, marketOpen: true },
+    })
+    expect(row).toHaveLength(HISTORY_CSV_HEADERS.length)
+    expect(row[0]).toBe('2026-07-08 09:00:00')  // firedAt (KST)
+    expect(row[1]).toBe('drop')                  // kind
+    expect(row[2]).toBe('AAPL')                  // ticker
+    expect(row[3]).toBe('150.5')                 // price
+    expect(row[4]).toBe('-6.2')                  // changePercent
+    expect(row[5]).toBe('AAPL 급락')             // message (HTML stripped)
+    expect(row[6]).toBe('sent')                  // deliveryStatus
+    expect(row[7]).toBe('2')                     // recipientCount
+    expect(row[8]).toBe('')                      // errorMessage (null → '')
+    expect(row[9]).toContain('type=drop')        // context summary
+  })
+
+  it('null 필드는 빈 문자열로', () => {
+    const row = toCsvRow({
+      firedAt: new Date('2026-07-08T00:00:00Z'),
+      kind: 'fx', ticker: null, price: null, changePercent: null,
+      message: 'x', deliveryStatus: 'failed', recipientCount: 0,
+      errorMessage: '네트워크 오류', contextJson: null,
+    })
+    expect(row[2]).toBe('')  // ticker
+    expect(row[3]).toBe('')  // price
+    expect(row[4]).toBe('')  // changePercent
+    expect(row[8]).toBe('네트워크 오류')
+    expect(row[9]).toBe('')  // contextJson null
+  })
+})
+
+describe('buildExportFilename', () => {
+  it('KST 날짜 (YYYY-MM-DD) 포함', () => {
+    const from = new Date('2026-07-01T00:00:00Z')
+    const to = new Date('2026-07-14T00:00:00Z')
+    // both times shift to KST → 2026-07-01, 2026-07-14
+    expect(buildExportFilename(from, to)).toBe('alert-history_2026-07-01_2026-07-14.csv')
+  })
+})
+
+describe('toCSV 통합 — RFC 4180 escape + 수식 주입 방어', () => {
+  it('셀에 comma 포함 시 quote wrap', () => {
+    const csv = toCSV(['a'], [['x,y']])
+    expect(csv).toContain('"x,y"')
+  })
+
+  it('셀에 double-quote 포함 시 quote 이중화 + wrap', () => {
+    const csv = toCSV(['a'], [['say "hi"']])
+    expect(csv).toContain('"say ""hi"""')
+  })
+
+  it('셀에 newline 포함 시 quote wrap', () => {
+    const csv = toCSV(['a'], [['line1\nline2']])
+    expect(csv).toContain('"line1\nline2"')
+  })
+
+  it('셀이 =/+/-/@ 로 시작하면 앞에 apostrophe (수식 주입 방어)', () => {
+    // context summary 는 "type=drop" 처럼 = 를 포함하지만 시작 문자는 't' → 안전
+    // 반면 사용자 message 가 "=SUM(...)" 이면 위험
+    const csv = toCSV(['a'], [['=SUM(A1:A10)']])
+    expect(csv).toContain("'=SUM(A1:A10)")
+  })
+
+  it('실제 이력 row 를 CSV 로 직렬화해도 셀 개수/quote escape 정합', () => {
+    const row = toCsvRow({
+      firedAt: new Date('2026-07-08T00:00:00Z'),
+      kind: 'drop', ticker: 'AAPL', price: 150, changePercent: -6.2,
+      message: 'AAPL, INC. "급락" 알림\n두번째 줄',  // comma + quote + newline
+      deliveryStatus: 'sent', recipientCount: 1,
+      errorMessage: null,
+      contextJson: { type: 'drop', price: 150, changePercent: -6.2, marketOpen: true },
+    })
+    const csv = toCSV([...HISTORY_CSV_HEADERS], [row])
+    // message 셀은 quote wrap + 내부 quote 이중화 되어야 함 (RFC 4180).
+    // naive split('\n') 은 quote 안 newline 도 자르므로 line 개수 대신 escape 문자열로 검증.
+    expect(csv).toContain('"AAPL, INC. ""급락"" 알림\n두번째 줄"')
+    // 헤더 행이 정상 렌더링되었는지 (헤더는 special char 없어 quote 없이 join)
+    expect(csv).toContain(HISTORY_CSV_HEADERS.join(','))
+  })
+})

--- a/src/app/api/alerts/history/export/__tests__/route.test.ts
+++ b/src/app/api/alerts/history/export/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Phase 37-B self-review (#445, P1) — CSV export truncation 회귀 방지.
+ *
+ * MAX_EXPORT_ROWS 초과 시 조용히 자르면 사용자가 부분 결과를 전체로 오해할 수 있으므로:
+ *   1) 응답 헤더 `X-Truncated: true` + `X-Total-Count: {actualTotal}` 노출
+ *   2) CSV body 마지막 라인에 `# TRUNCATED: showing first N of M ...` 안내 추가
+ * 이 두 신호가 모두 살아있는지 검증한다.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+import { MAX_EXPORT_ROWS } from '../csv-format'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+
+function makeRow(i: number) {
+  return {
+    id: `row-${i}`,
+    firedAt: new Date('2026-07-08T00:00:00Z'),
+    kind: 'drop',
+    ticker: 'AAPL',
+    price: 100,
+    changePercent: -3,
+    message: 'msg',
+    deliveryStatus: 'sent',
+    recipientCount: 1,
+    errorMessage: null,
+    contextJson: { type: 'drop', price: 100, changePercent: -3, marketOpen: true },
+  }
+}
+
+function makeReq(qs = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/alerts/history/export${qs}`)
+}
+
+describe('GET /api/alerts/history/export — truncation 신호', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockReset()
+    vi.mocked(prisma.alertHistory.count).mockReset()
+  })
+
+  it('total <= MAX_EXPORT_ROWS: truncated 헤더 없음, X-Total-Count 만 노출', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const rows = Array.from({ length: 5 }, (_, i) => makeRow(i))
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce(rows as never)
+    vi.mocked(prisma.alertHistory.count).mockResolvedValueOnce(5 as never)
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Truncated')).toBeNull()
+    expect(res.headers.get('X-Total-Count')).toBe('5')
+
+    const body = await res.text()
+    expect(body).not.toContain('# TRUNCATED')
+    // CSV 마지막이 truncation 라인이 아니어야 함 (data row 로 끝남)
+    expect(body.trim().endsWith(',type=drop; price=100; Δ%=-3; marketOpen=true')).toBe(true)
+  })
+
+  it('total > MAX_EXPORT_ROWS: X-Truncated + X-Total-Count + CSV 마지막 안내 라인', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    const rows = Array.from({ length: MAX_EXPORT_ROWS }, (_, i) => makeRow(i))
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce(rows as never)
+    // 실제 total 은 상한 초과.
+    vi.mocked(prisma.alertHistory.count).mockResolvedValueOnce((MAX_EXPORT_ROWS + 1) as never)
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Truncated')).toBe('true')
+    expect(res.headers.get('X-Total-Count')).toBe(String(MAX_EXPORT_ROWS + 1))
+
+    const body = await res.text()
+    // 마지막 라인이 truncation 안내여야 함
+    const lastLine = body.split('\n').at(-1) ?? ''
+    expect(lastLine).toMatch(/^# TRUNCATED: showing first 10000 of 10001/)
+    expect(body).toContain('Narrow the filter')
+  })
+
+  it('findMany 에 take: MAX_EXPORT_ROWS 가 전달됨', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.alertHistory.count).mockResolvedValueOnce(0 as never)
+
+    await GET(makeReq())
+    const call = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    expect(call?.take).toBe(MAX_EXPORT_ROWS)
+    // 리스트 API 와 동일한 tiebreak 정렬 유지
+    expect(call?.orderBy).toEqual([{ firedAt: 'desc' }, { id: 'desc' }])
+  })
+
+  it('필터 (kind + ticker) 는 count 와 findMany 양쪽에 동일 where 로 전달', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.findMany).mockResolvedValueOnce([] as never)
+    vi.mocked(prisma.alertHistory.count).mockResolvedValueOnce(0 as never)
+
+    await GET(makeReq('?kind=drop&ticker=aapl&from=2026-07-01T00:00:00Z&to=2026-07-08T00:00:00Z'))
+
+    const findCall = vi.mocked(prisma.alertHistory.findMany).mock.calls[0][0]
+    const countCall = vi.mocked(prisma.alertHistory.count).mock.calls[0][0]
+    expect(findCall?.where).toEqual(countCall?.where)
+    expect(findCall?.where?.kind).toBe('drop')
+    // ticker 대문자 정규화
+    expect(findCall?.where?.ticker).toBe('AAPL')
+  })
+})

--- a/src/app/api/alerts/history/export/csv-format.ts
+++ b/src/app/api/alerts/history/export/csv-format.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase 37-B (#445) — 알림 이력 CSV 포맷 helper (pure, 테스트 가능).
+ *
+ * `route.ts` 는 Prisma fetch 만 하고 이 모듈로 헤더/row 를 만든다.
+ * `@/lib/csv` 의 `toCSV` 가 RFC 4180 escape + BOM + 수식 주입 방어를 이미 담당.
+ */
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+
+export const HISTORY_CSV_HEADERS = [
+  'firedAt (KST)',
+  'kind',
+  'ticker',
+  'price',
+  'changePercent',
+  'message',
+  'deliveryStatus',
+  'recipientCount',
+  'errorMessage',
+  'context',
+] as const
+
+/**
+ * ISO 시각을 KST YYYY-MM-DD HH:mm:ss 형식으로 변환.
+ * 스프레드시트에서 그대로 sort 가능하도록 zero-pad + colon-separated.
+ */
+export function formatKstDateTime(iso: string | Date): string {
+  const d = typeof iso === 'string' ? new Date(iso) : iso
+  if (Number.isNaN(d.getTime())) return ''
+  const kst = new Date(d.getTime() + KST_OFFSET_MS)
+  // UTC helpers on shifted time → KST 벽시계 값.
+  const y = kst.getUTCFullYear()
+  const m = String(kst.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(kst.getUTCDate()).padStart(2, '0')
+  const hh = String(kst.getUTCHours()).padStart(2, '0')
+  const mm = String(kst.getUTCMinutes()).padStart(2, '0')
+  const ss = String(kst.getUTCSeconds()).padStart(2, '0')
+  return `${y}-${m}-${day} ${hh}:${mm}:${ss}`
+}
+
+/** HTML 태그 제거 (message 는 HTML). CSV 는 plain text 로. */
+export function stripHtmlForCsv(html: string): string {
+  return html.replace(/<[^>]+>/g, '')
+}
+
+/**
+ * context 를 CSV 셀에 넣을 수 있는 컴팩트 요약 문자열로 변환.
+ * 전체 JSON stringify 는 셀이 너무 커지므로 kind 별 주요 필드만 뽑는다.
+ * shape 이 예상 밖이면 `JSON.stringify` fallback.
+ */
+export function summarizeContext(ctx: unknown): string {
+  if (ctx == null) return ''
+  if (typeof ctx !== 'object') return String(ctx)
+  const obj = ctx as Record<string, unknown>
+  const type = typeof obj.type === 'string' ? obj.type : ''
+  try {
+    const parts: string[] = []
+    if (type) parts.push(`type=${type}`)
+    if ('price' in obj && obj.price != null) parts.push(`price=${obj.price}`)
+    if ('rate' in obj && obj.rate != null) parts.push(`rate=${obj.rate}`)
+    if ('changePercent' in obj && obj.changePercent != null) parts.push(`Δ%=${obj.changePercent}`)
+    if ('threshold' in obj && obj.threshold != null) parts.push(`threshold=${obj.threshold}`)
+    if ('marketOpen' in obj && obj.marketOpen != null) parts.push(`marketOpen=${obj.marketOpen}`)
+    if ('rsi' in obj && obj.rsi != null) parts.push(`rsi=${obj.rsi}`)
+    if ('macdCrossover' in obj && obj.macdCrossover != null) parts.push(`macd=${obj.macdCrossover}`)
+    if ('bbPosition' in obj && obj.bbPosition != null) parts.push(`bb=${obj.bbPosition}`)
+    if ('overall' in obj && obj.overall != null) parts.push(`overall=${obj.overall}`)
+    if ('signals' in obj && Array.isArray(obj.signals) && obj.signals.length > 0) {
+      parts.push(`signals=${obj.signals.join('|')}`)
+    }
+    if ('strategyId' in obj && typeof obj.strategyId === 'string') parts.push(`strategyId=${obj.strategyId}`)
+    if ('strategyName' in obj && typeof obj.strategyName === 'string') parts.push(`strategy=${obj.strategyName}`)
+    if ('retriedFrom' in obj && typeof obj.retriedFrom === 'string') parts.push(`retriedFrom=${obj.retriedFrom}`)
+    return parts.length > 0 ? parts.join('; ') : JSON.stringify(obj)
+  } catch {
+    // Circular ref 등 예외 시 안전한 fallback — 컨텍스트가 이력의 부수 정보라 실패시에도 export 계속.
+    return ''
+  }
+}
+
+export interface HistoryCsvSourceRow {
+  firedAt: Date
+  kind: string
+  ticker: string | null
+  price: number | null
+  changePercent: number | null
+  message: string
+  deliveryStatus: string
+  recipientCount: number
+  errorMessage: string | null
+  contextJson: unknown
+}
+
+/** Prisma row → CSV row (string[]). */
+export function toCsvRow(row: HistoryCsvSourceRow): string[] {
+  return [
+    formatKstDateTime(row.firedAt),
+    row.kind,
+    row.ticker ?? '',
+    row.price != null ? String(row.price) : '',
+    row.changePercent != null ? String(row.changePercent) : '',
+    stripHtmlForCsv(row.message),
+    row.deliveryStatus,
+    String(row.recipientCount),
+    row.errorMessage ?? '',
+    summarizeContext(row.contextJson),
+  ]
+}
+
+/**
+ * export 파일명 — 기간 문자열 포함해 다운로드 시 구분 용이.
+ * 예: alert-history_2026-07-01_2026-07-14.csv
+ */
+export function buildExportFilename(from: Date, to: Date): string {
+  const fromKey = formatKstDateTime(from).slice(0, 10)
+  const toKey = formatKstDateTime(to).slice(0, 10)
+  return `alert-history_${fromKey}_${toKey}.csv`
+}

--- a/src/app/api/alerts/history/export/csv-format.ts
+++ b/src/app/api/alerts/history/export/csv-format.ts
@@ -116,3 +116,18 @@ export function buildExportFilename(from: Date, to: Date): string {
   const toKey = formatKstDateTime(to).slice(0, 10)
   return `alert-history_${fromKey}_${toKey}.csv`
 }
+
+/**
+ * Truncation 관련 상수/헬퍼 (self-review P1).
+ *
+ * Next.js route 모듈은 handler·`dynamic` 등 정해진 export 만 허용하므로 헬퍼는 별도
+ * 모듈에 둔다. `route.ts` 와 테스트에서 재사용.
+ */
+export const MAX_EXPORT_ROWS = 10_000
+export const TRUNCATED_HEADER = 'X-Truncated'
+export const TOTAL_COUNT_HEADER = 'X-Total-Count'
+
+/** CSV 마지막에 append 하는 truncation 안내 (셀 앞자 `#` — 수식 주입 안전). */
+export function buildTruncatedNotice(shownRows: number, totalRows: number): string {
+  return `# TRUNCATED: showing first ${shownRows} of ${totalRows} rows. Narrow the filter to get the full dataset.`
+}

--- a/src/app/api/alerts/history/export/route.ts
+++ b/src/app/api/alerts/history/export/route.ts
@@ -14,15 +14,10 @@ import type { Prisma } from '@prisma/client'
 import { parseISOOrNull, parseKindsParam, resolveTimeWindow } from '../shared'
 import {
   HISTORY_CSV_HEADERS, toCsvRow, buildExportFilename,
+  MAX_EXPORT_ROWS, TRUNCATED_HEADER, TOTAL_COUNT_HEADER, buildTruncatedNotice,
 } from './csv-format'
 
 const DEFAULT_LOOKBACK_DAYS = 7
-/**
- * export 는 페이지네이션 없이 조건 매칭 전부 스트리밍하지만, 실사용 필터가 90일
- * 이내 * 하루 수십건 규모라 상한을 넉넉히 잡고 넘치면 최근순으로 잘라낸다.
- * (10만건 넘어가면 브라우저 다운로드 자체가 부담이고, 그럴 정도면 필터 좁혀 재시도가 정상 UX.)
- */
-const MAX_ROWS = 10_000
 
 export const dynamic = 'force-dynamic'
 
@@ -51,19 +46,41 @@ export async function GET(req: NextRequest) {
     else if (kinds.length > 1) where.kind = { in: kinds }
     if (rawTicker) where.ticker = rawTicker.toUpperCase()
 
-    const rows = await prisma.alertHistory.findMany({
-      where,
-      // 리스트와 동일 정렬 (같은 firedAt 안에서 id desc — tiebreak, #424 P2 회귀 방지).
-      orderBy: [{ firedAt: 'desc' }, { id: 'desc' }],
-      take: MAX_ROWS,
-    })
+    // Truncation 감지를 위해 count 를 먼저 확인. 필터가 좁은 경우 count 는 저렴하고,
+    // 넓은 경우엔 어차피 findMany 도 비싸므로 추가 비용은 무시할 수준.
+    // Truncation 감지 (self-review P1): 상한 초과 시 조용히 자르면 사용자가 부분 결과를
+    // 전체로 오해할 수 있으므로 (감사·신고 용도), `count` 로 실제 총량을 얻어 헤더 +
+    // 안내 라인으로 노출한다. 필터가 좁으면 count 는 저렴하고, 넓으면 어차피 findMany
+    // 도 비싸므로 추가 비용은 무시할 수준.
+    const [rows, total] = await Promise.all([
+      prisma.alertHistory.findMany({
+        where,
+        // 리스트와 동일 정렬 (같은 firedAt 안에서 id desc — tiebreak, #424 P2 회귀 방지).
+        orderBy: [{ firedAt: 'desc' }, { id: 'desc' }],
+        take: MAX_EXPORT_ROWS,
+      }),
+      prisma.alertHistory.count({ where }),
+    ])
 
-    const csv = toCSV(
-      [...HISTORY_CSV_HEADERS],
-      rows.map(toCsvRow),
+    const truncated = total > rows.length
+    const csvRows = rows.map(toCsvRow)
+    let csv = toCSV([...HISTORY_CSV_HEADERS], csvRows)
+    if (truncated) {
+      // CSV 스펙상 comment 는 없지만, `#` 시작 셀 하나짜리 라인은 대부분의 뷰어에서 눈에
+      // 띄는 안내로 표시된다. 수식 주입 escape 규칙 (`=+-@`) 에도 걸리지 않는다.
+      csv += '\n' + buildTruncatedNotice(rows.length, total)
+    }
+
+    const extraHeaders: Record<string, string> = {
+      [TOTAL_COUNT_HEADER]: String(total),
+    }
+    if (truncated) extraHeaders[TRUNCATED_HEADER] = 'true'
+
+    return csvResponse(
+      csv,
+      buildExportFilename(effectiveFrom, effectiveTo),
+      extraHeaders,
     )
-
-    return csvResponse(csv, buildExportFilename(effectiveFrom, effectiveTo))
   } catch (error) {
     console.error('GET /api/alerts/history/export error:', error)
     return fail('알림 이력 CSV 생성에 실패했습니다.', 500)

--- a/src/app/api/alerts/history/export/route.ts
+++ b/src/app/api/alerts/history/export/route.ts
@@ -1,0 +1,71 @@
+/**
+ * Phase 37-B (#445) — 알림 이력 CSV export.
+ * GET /api/alerts/history/export?kind=&ticker=&from=&to=
+ *
+ * 응답은 CSV 파일 (`csvResponse` — envelope 예외, `.claude/rules/api-routes.md` 참고).
+ * 에러 path 만 envelope (`fail`) 사용.
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { toCSV, csvResponse } from '@/lib/csv'
+import { fail } from '@/lib/api-response'
+import type { Prisma } from '@prisma/client'
+import { parseISOOrNull, parseKindsParam, resolveTimeWindow } from '../shared'
+import {
+  HISTORY_CSV_HEADERS, toCsvRow, buildExportFilename,
+} from './csv-format'
+
+const DEFAULT_LOOKBACK_DAYS = 7
+/**
+ * export 는 페이지네이션 없이 조건 매칭 전부 스트리밍하지만, 실사용 필터가 90일
+ * 이내 * 하루 수십건 규모라 상한을 넉넉히 잡고 넘치면 최근순으로 잘라낸다.
+ * (10만건 넘어가면 브라우저 다운로드 자체가 부담이고, 그럴 정도면 필터 좁혀 재시도가 정상 UX.)
+ */
+const MAX_ROWS = 10_000
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = req.nextUrl
+    const { kinds, invalid } = parseKindsParam(url.searchParams)
+    const rawTicker = url.searchParams.get('ticker')?.trim() || undefined
+    const fromStr = url.searchParams.get('from')?.trim() || undefined
+    const toStr = url.searchParams.get('to')?.trim() || undefined
+
+    if (invalid.length > 0) {
+      return fail(`알 수 없는 kind: ${invalid.join(', ')}`, 400)
+    }
+    const from = parseISOOrNull(fromStr)
+    const to = parseISOOrNull(toStr)
+    if (fromStr && !from) return fail('from 이 ISO 8601 형식이 아닙니다.', 400)
+    if (toStr && !to) return fail('to 가 ISO 8601 형식이 아닙니다.', 400)
+
+    const { effectiveFrom, effectiveTo } = resolveTimeWindow(from, to, DEFAULT_LOOKBACK_DAYS)
+
+    const where: Prisma.AlertHistoryWhereInput = {
+      firedAt: { gte: effectiveFrom, lte: effectiveTo },
+    }
+    if (kinds.length === 1) where.kind = kinds[0]
+    else if (kinds.length > 1) where.kind = { in: kinds }
+    if (rawTicker) where.ticker = rawTicker.toUpperCase()
+
+    const rows = await prisma.alertHistory.findMany({
+      where,
+      // 리스트와 동일 정렬 (같은 firedAt 안에서 id desc — tiebreak, #424 P2 회귀 방지).
+      orderBy: [{ firedAt: 'desc' }, { id: 'desc' }],
+      take: MAX_ROWS,
+    })
+
+    const csv = toCSV(
+      [...HISTORY_CSV_HEADERS],
+      rows.map(toCsvRow),
+    )
+
+    return csvResponse(csv, buildExportFilename(effectiveFrom, effectiveTo))
+  } catch (error) {
+    console.error('GET /api/alerts/history/export error:', error)
+    return fail('알림 이력 CSV 생성에 실패했습니다.', 500)
+  }
+}

--- a/src/bot/notifications/__tests__/alert-dispatcher.test.ts
+++ b/src/bot/notifications/__tests__/alert-dispatcher.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Phase 37-B (#445) — 알림 재발송 dispatcher 회귀 테스트.
+ *
+ * 테스트 대상:
+ *   - createRetryRateLimiter: cooldown 준수, reset, 시간 경과 후 재허용
+ *   - buildRetryContext: 원본 shape 유지 + retriedFrom 마커, 원본 mutate 방지
+ *   - redispatchAlert: chat 별 sendHtml 성공/실패 카운트, computeDeliveryStatus 매핑
+ *   - persistRetryHistory: retriedFrom 포함 recordAlertHistory 호출
+ *
+ * NOTE: '../index' (getBot) 는 모듈 로드시 모든 command register 를 chain-import 하므로
+ * env 미설정 테스트에서 crash 방지 위해 mock 필수. '@/lib/prisma' 도 마찬가지.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    alertHistory: {
+      createMany: vi.fn(),
+    },
+  },
+}))
+vi.mock('../../index', () => ({
+  getBot: vi.fn(() => ({} as unknown)),
+}))
+vi.mock('@/bot/utils/telegram', () => ({
+  sendHtml: vi.fn(),
+}))
+
+import {
+  createRetryRateLimiter,
+  RETRY_COOLDOWN_MS,
+  buildRetryContext,
+  redispatchAlert,
+  persistRetryHistory,
+  type RedispatchTargetRow,
+} from '../alert-dispatcher'
+import type { Bot } from 'grammy'
+import { sendHtml } from '@/bot/utils/telegram'
+
+describe('createRetryRateLimiter', () => {
+  it('첫 시도는 항상 allowed', () => {
+    const rl = createRetryRateLimiter()
+    expect(rl.check('id-1', 1_000)).toEqual({ allowed: true, retryAfterMs: 0 })
+  })
+
+  it('markAttempt 후 cooldown 이내 시도는 blocked + retryAfter 계산', () => {
+    const rl = createRetryRateLimiter(60_000) // 60s
+    rl.markAttempt('id-1', 1_000)
+    const r = rl.check('id-1', 30_000) // 29s 경과
+    expect(r.allowed).toBe(false)
+    expect(r.retryAfterMs).toBe(31_000)
+  })
+
+  it('cooldown 경과 후 다시 allowed', () => {
+    const rl = createRetryRateLimiter(60_000)
+    rl.markAttempt('id-1', 1_000)
+    const r = rl.check('id-1', 61_001)
+    expect(r).toEqual({ allowed: true, retryAfterMs: 0 })
+  })
+
+  it('cooldown 경계값 (정확히 cooldownMs 경과) 은 allowed', () => {
+    const rl = createRetryRateLimiter(60_000)
+    rl.markAttempt('id-1', 1_000)
+    // 정확히 60_000 경과 → elapsed === cooldown → allowed
+    const r = rl.check('id-1', 61_000)
+    expect(r.allowed).toBe(true)
+  })
+
+  it('다른 id 는 독립적으로 추적', () => {
+    const rl = createRetryRateLimiter(60_000)
+    rl.markAttempt('id-1', 1_000)
+    // id-2 는 mark 안됨 → 언제든 allowed
+    expect(rl.check('id-2', 2_000).allowed).toBe(true)
+    // id-1 은 여전히 blocked
+    expect(rl.check('id-1', 2_000).allowed).toBe(false)
+  })
+
+  it('reset() 은 모든 트래킹 제거', () => {
+    const rl = createRetryRateLimiter(60_000)
+    rl.markAttempt('id-1', 1_000)
+    rl.markAttempt('id-2', 1_500)
+    rl.reset()
+    expect(rl.check('id-1', 2_000).allowed).toBe(true)
+    expect(rl.check('id-2', 2_000).allowed).toBe(true)
+  })
+
+  it('기본 cooldown = RETRY_COOLDOWN_MS (5분)', () => {
+    expect(RETRY_COOLDOWN_MS).toBe(5 * 60 * 1000)
+    const rl = createRetryRateLimiter()
+    rl.markAttempt('x', 0)
+    // 4분 59초 → blocked
+    expect(rl.check('x', 4 * 60 * 1000 + 59_000).allowed).toBe(false)
+    // 5분 → allowed
+    expect(rl.check('x', 5 * 60 * 1000).allowed).toBe(true)
+  })
+})
+
+describe('buildRetryContext', () => {
+  it('object 원본 → spread + retriedFrom 마커 추가', () => {
+    const original = { type: 'drop', price: 150, changePercent: -6.2, marketOpen: true }
+    const ctx = buildRetryContext(original, 'orig-id', 'drop')
+    expect(ctx).toMatchObject({
+      type: 'drop', price: 150, changePercent: -6.2, marketOpen: true,
+      retriedFrom: 'orig-id',
+    })
+  })
+
+  it('원본 object 를 mutate 하지 않음 (spread 검증)', () => {
+    const original = { type: 'drop', price: 150 }
+    buildRetryContext(original, 'orig-id', 'drop')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect('retriedFrom' in original).toBe(false)
+  })
+
+  it('null 원본 → 최소 shape { type: kind, retriedFrom }', () => {
+    const ctx = buildRetryContext(null, 'orig-id', 'surge')
+    expect(ctx).toEqual({ type: 'surge', retriedFrom: 'orig-id' })
+  })
+
+  it('undefined 원본 → 최소 shape', () => {
+    const ctx = buildRetryContext(undefined, 'orig-id', 'ta_signal')
+    expect(ctx).toEqual({ type: 'ta_signal', retriedFrom: 'orig-id' })
+  })
+
+  it('scalar 원본 (string) → 최소 shape (object 아님을 감지)', () => {
+    const ctx = buildRetryContext('legacy-json-string', 'orig-id', 'fx')
+    expect(ctx).toEqual({ type: 'fx', retriedFrom: 'orig-id' })
+  })
+
+  it('원본에 이미 retriedFrom 있으면 최신 id 로 덮어씀 (재-재발송)', () => {
+    const original = { type: 'drop', retriedFrom: 'first-orig' }
+    const ctx = buildRetryContext(original, 'second-orig', 'drop')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((ctx as any).retriedFrom).toBe('second-orig')
+  })
+})
+
+describe('redispatchAlert', () => {
+  beforeEach(() => {
+    vi.mocked(sendHtml).mockReset()
+  })
+
+  const fakeBot = {} as Bot
+  const row = { message: '<b>hi</b>' }
+
+  it('모든 chat 성공 → status=sent, successCount=totalChats', async () => {
+    vi.mocked(sendHtml).mockResolvedValue(undefined as never)
+    const res = await redispatchAlert(row, [1, 2, 3], fakeBot)
+    expect(res.status).toBe('sent')
+    expect(res.successCount).toBe(3)
+    expect(res.totalChats).toBe(3)
+    expect(res.lastError).toBeUndefined()
+    expect(sendHtml).toHaveBeenCalledTimes(3)
+    expect(sendHtml).toHaveBeenNthCalledWith(1, fakeBot, 1, '<b>hi</b>')
+  })
+
+  it('모든 chat 실패 → status=failed, lastError 세팅', async () => {
+    vi.mocked(sendHtml).mockRejectedValue(new Error('네트워크 오류'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await redispatchAlert(row, [1, 2], fakeBot)
+    expect(res.status).toBe('failed')
+    expect(res.successCount).toBe(0)
+    expect(res.lastError).toBe('네트워크 오류')
+    errSpy.mockRestore()
+  })
+
+  it('일부 실패 → status=partial', async () => {
+    vi.mocked(sendHtml)
+      .mockResolvedValueOnce(undefined as never)
+      .mockRejectedValueOnce(new Error('403'))
+      .mockResolvedValueOnce(undefined as never)
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await redispatchAlert(row, [1, 2, 3], fakeBot)
+    expect(res.status).toBe('partial')
+    expect(res.successCount).toBe(2)
+    expect(res.lastError).toBe('403')
+    errSpy.mockRestore()
+  })
+
+  it('빈 chatIds → status=failed, totalChats=0, sendHtml 미호출', async () => {
+    const res = await redispatchAlert(row, [], fakeBot)
+    expect(res.status).toBe('failed')
+    expect(res.totalChats).toBe(0)
+    expect(res.successCount).toBe(0)
+    expect(sendHtml).not.toHaveBeenCalled()
+  })
+
+  it('Error 아닌 예외 (문자열) 도 lastError 로 캐치', async () => {
+    vi.mocked(sendHtml).mockRejectedValue('string-error')
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await redispatchAlert(row, [1], fakeBot)
+    expect(res.lastError).toBe('string-error')
+    errSpy.mockRestore()
+  })
+})
+
+describe('persistRetryHistory', () => {
+  beforeEach(async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockReset()
+  })
+
+  const originalRow: RedispatchTargetRow = {
+    id: 'orig-id-1',
+    kind: 'drop',
+    ticker: 'AAPL',
+    price: 150,
+    changePercent: -6.2,
+    message: 'AAPL 급락',
+    contextJson: { type: 'drop', price: 150, changePercent: -6.2, marketOpen: true },
+  }
+
+  it('성공 결과 → recordAlertHistory 에 retriedFrom 포함 context 로 저장', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    await persistRetryHistory(originalRow, {
+      successCount: 2, totalChats: 2, status: 'sent', lastError: undefined,
+    })
+
+    expect(prisma.alertHistory.createMany).toHaveBeenCalledTimes(1)
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0]).toMatchObject({
+      kind: 'drop', ticker: 'AAPL', price: 150, changePercent: -6.2,
+      message: 'AAPL 급락', deliveryStatus: 'sent', recipientCount: 2,
+    })
+    // context 안에 retriedFrom 마커
+    expect(data[0].contextJson).toMatchObject({
+      type: 'drop', retriedFrom: 'orig-id-1',
+    })
+    // 성공 이력에는 errorMessage 없음
+    expect(data[0].errorMessage).toBeNull()
+  })
+
+  it('실패 결과 → errorMessage 저장, status=failed', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    await persistRetryHistory(originalRow, {
+      successCount: 0, totalChats: 2, status: 'failed', lastError: '네트워크 오류',
+    })
+
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0].deliveryStatus).toBe('failed')
+    expect(data[0].errorMessage).toBe('네트워크 오류')
+  })
+
+  it('원본 context 가 null 인 legacy row 도 최소 shape 로 저장', async () => {
+    const { prisma } = await import('@/lib/prisma')
+    vi.mocked(prisma.alertHistory.createMany).mockResolvedValueOnce({ count: 1 } as never)
+
+    await persistRetryHistory(
+      { ...originalRow, contextJson: null },
+      { successCount: 1, totalChats: 1, status: 'sent', lastError: undefined },
+    )
+
+    const call = vi.mocked(prisma.alertHistory.createMany).mock.calls[0][0]!
+    const data = call.data as Array<Record<string, unknown>>
+    expect(data[0].contextJson).toMatchObject({
+      type: 'drop', retriedFrom: 'orig-id-1',
+    })
+  })
+})

--- a/src/bot/notifications/__tests__/alert-dispatcher.test.ts
+++ b/src/bot/notifications/__tests__/alert-dispatcher.test.ts
@@ -128,11 +128,22 @@ describe('buildRetryContext', () => {
     expect(ctx).toEqual({ type: 'fx', retriedFrom: 'orig-id' })
   })
 
-  it('원본에 이미 retriedFrom 있으면 최신 id 로 덮어씀 (재-재발송)', () => {
+  it('원본이 이미 retry row 면 root id 를 유지 (chain 을 따라가지 않음, Codex #454 P2)', () => {
+    // R0 (original id=first-orig) → R1 (retry, contextJson.retriedFrom=first-orig)
+    // 이제 R1 을 다시 retry (parent id=second-orig) → R2 는 chain root 를 참조해야 함.
+    // 그렇지 않으면 rate limiter 가 각 retry row 를 별도 그룹으로 취급 → cooldown 우회.
     const original = { type: 'drop', retriedFrom: 'first-orig' }
     const ctx = buildRetryContext(original, 'second-orig', 'drop')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((ctx as any).retriedFrom).toBe('second-orig')
+    expect((ctx as any).retriedFrom).toBe('first-orig')
+  })
+
+  it('원본에 retriedFrom 이 string 이 아닌 값이면 fallback 으로 parent id 사용', () => {
+    // 손상된 contextJson (retriedFrom 이 숫자·null 등) 에 대한 defense.
+    const original = { type: 'drop', retriedFrom: 12345 }
+    const ctx = buildRetryContext(original, 'parent-id', 'drop')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((ctx as any).retriedFrom).toBe('parent-id')
   })
 })
 

--- a/src/bot/notifications/alert-dispatcher.ts
+++ b/src/bot/notifications/alert-dispatcher.ts
@@ -98,6 +98,11 @@ export async function redispatchAlert(
  * 원본이 없거나 shape 불명이면 최소 shape (`{ type: kind, retriedFrom }`) 만 생성 —
  * `isValidContext` 통과 위해 `type` 을 kind 로 세팅 (kind 는 이미 whitelist 통과 상태).
  *
+ * **Root id 전파 (Codex #454 P2)**: 원본이 이미 retry row 인 경우 (contextJson.retriedFrom
+ * 존재), `retriedFrom` 은 chain 을 따라가지 않고 **가장 처음 원본** 을 가리킨다. retry-of-retry
+ * chain 이 있어도 모든 후속 retry 는 동일 root id 를 참조 → rate limiter 가 chain 을
+ * 하나의 cooldown 그룹으로 처리 가능.
+ *
  * shape 확장은 각 interface 에 `retriedFrom?` 를 추가한 것과 정합 (`context.ts`).
  */
 export function buildRetryContext(
@@ -105,9 +110,16 @@ export function buildRetryContext(
   originalId: string,
   kind: AlertKind,
 ): AlertHistoryContext | null {
-  const marker = { retriedFrom: originalId }
+  // Root id 계산 — 원본 context 에 이미 retriedFrom 이 있으면 그 값 (chain root) 을 사용.
+  const existingRoot =
+    originalContext && typeof originalContext === 'object'
+      ? (originalContext as { retriedFrom?: unknown }).retriedFrom
+      : undefined
+  const rootId = typeof existingRoot === 'string' ? existingRoot : originalId
+  const marker = { retriedFrom: rootId }
+
   if (originalContext && typeof originalContext === 'object') {
-    // 원본 shape 유지 + retriedFrom 추가 (spread — 원본 mutate 방지).
+    // 원본 shape 유지 + retriedFrom 덮어쓰기 (spread — 원본 mutate 방지, marker 가 chain root 로 override).
     return { ...(originalContext as object), ...marker } as unknown as AlertHistoryContext
   }
   // v1 (context 없는) row 재발송 시 최소 컨텍스트 — kind 를 그대로 type 으로 사용.

--- a/src/bot/notifications/alert-dispatcher.ts
+++ b/src/bot/notifications/alert-dispatcher.ts
@@ -1,0 +1,142 @@
+/**
+ * Phase 37-B (#445) — 알림 재발송 공용 dispatcher.
+ *
+ * 배포 오류 등으로 발송 실패한 AlertHistory row 를 사용자 수동 트리거로 재발송한다.
+ * 원본 row 는 그대로 두고 새 row 를 append (`retriedFrom` 마커) 해 이력 소실을 방지.
+ *
+ * 자동 재시도 (exponential backoff) 은 스코프 밖 (스펙 §6 명시).
+ */
+
+import type { Bot } from 'grammy'
+import { sendHtml } from '@/bot/utils/telegram'
+import { computeDeliveryStatus, recordAlertHistory, type AlertKind } from './alert-history'
+import { getBot } from '../index'
+import type { AlertHistoryContext } from '@/lib/alert-history/context'
+
+/** 동일 id 재발송 최소 간격 (스팸 방지 — 스펙 5분). */
+export const RETRY_COOLDOWN_MS = 5 * 60 * 1000
+
+/**
+ * 재발송 rate limit tracker. 프로세스 in-memory Map — 프로세스 재시작 시 초기화 허용
+ * (DB 컬럼 없이 스팸만 방지). 스코프상 사용자 수동 트리거이므로 이 정도로 충분.
+ */
+export interface RetryRateLimiter {
+  check(id: string, now?: number): { allowed: boolean; retryAfterMs: number }
+  markAttempt(id: string, now?: number): void
+  reset(): void
+}
+
+export function createRetryRateLimiter(cooldownMs: number = RETRY_COOLDOWN_MS): RetryRateLimiter {
+  const lastAttempt = new Map<string, number>()
+  return {
+    check(id, now = Date.now()) {
+      const prev = lastAttempt.get(id)
+      if (prev === undefined) return { allowed: true, retryAfterMs: 0 }
+      const elapsed = now - prev
+      if (elapsed >= cooldownMs) return { allowed: true, retryAfterMs: 0 }
+      return { allowed: false, retryAfterMs: cooldownMs - elapsed }
+    },
+    markAttempt(id, now = Date.now()) {
+      lastAttempt.set(id, now)
+    },
+    reset() {
+      lastAttempt.clear()
+    },
+  }
+}
+
+/** 프로세스 전역 rate limiter (route handler 재사용). 테스트는 인스턴스를 직접 생성. */
+export const globalRetryLimiter = createRetryRateLimiter()
+
+/**
+ * 원본 AlertHistory row 를 재발송 대상 subset 으로 좁힌 인터페이스.
+ * Prisma AlertHistory 모델과 호환 (Date → firedAt 필드는 미사용이라 생략).
+ */
+export interface RedispatchTargetRow {
+  id: string
+  kind: string
+  ticker: string | null
+  price: number | null
+  changePercent: number | null
+  message: string
+  contextJson: unknown
+}
+
+export interface RedispatchResult {
+  successCount: number
+  totalChats: number
+  status: 'sent' | 'partial' | 'failed'
+  lastError: string | undefined
+}
+
+/**
+ * 순수 재발송 — 지정 chatIds 로 sendHtml 호출 후 성공 카운트/에러 반환.
+ * DB 기록은 caller (route handler) 가 수행 — pure/impure 분리로 테스트 용이.
+ */
+export async function redispatchAlert(
+  row: Pick<RedispatchTargetRow, 'message'>,
+  chatIds: number[],
+  bot: Bot = getBot(),
+): Promise<RedispatchResult> {
+  let successCount = 0
+  let lastError: string | undefined
+  for (const chatId of chatIds) {
+    try {
+      await sendHtml(bot, chatId, row.message)
+      successCount++
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+      console.error(`[alert-retry] 재발송 실패 (chatId: ${chatId}, alertId: unknown):`, error)
+    }
+  }
+  const status = computeDeliveryStatus(successCount, chatIds.length)
+  return { successCount, totalChats: chatIds.length, status, lastError }
+}
+
+/**
+ * 원본 context 에 `retriedFrom` 마커를 얹은 새 컨텍스트를 반환.
+ * 원본이 없거나 shape 불명이면 최소 shape (`{ type: kind, retriedFrom }`) 만 생성 —
+ * `isValidContext` 통과 위해 `type` 을 kind 로 세팅 (kind 는 이미 whitelist 통과 상태).
+ *
+ * shape 확장은 각 interface 에 `retriedFrom?` 를 추가한 것과 정합 (`context.ts`).
+ */
+export function buildRetryContext(
+  originalContext: unknown,
+  originalId: string,
+  kind: AlertKind,
+): AlertHistoryContext | null {
+  const marker = { retriedFrom: originalId }
+  if (originalContext && typeof originalContext === 'object') {
+    // 원본 shape 유지 + retriedFrom 추가 (spread — 원본 mutate 방지).
+    return { ...(originalContext as object), ...marker } as unknown as AlertHistoryContext
+  }
+  // v1 (context 없는) row 재발송 시 최소 컨텍스트 — kind 를 그대로 type 으로 사용.
+  // isValidContext 는 type 화이트리스트 체크만 하므로 통과.
+  return { type: kind as AlertHistoryContext['type'], ...marker } as unknown as AlertHistoryContext
+}
+
+/**
+ * 재발송 성공/실패 후 새 AlertHistory row 를 append.
+ * `retriedFrom` 은 contextJson 안에 저장 (schema 컬럼 추가 없이 마커만 남김).
+ * 실패해도 caller 는 이미 재발송 시도를 한 상태 → recordAlertHistory 내부에서 삼킴 (원본 유지).
+ */
+export async function persistRetryHistory(
+  original: RedispatchTargetRow,
+  result: RedispatchResult,
+): Promise<void> {
+  await recordAlertHistory(
+    [
+      {
+        kind: original.kind as AlertKind,
+        ticker: original.ticker,
+        price: original.price,
+        changePercent: original.changePercent,
+        message: original.message,
+        context: buildRetryContext(original.contextJson, original.id, original.kind as AlertKind),
+      },
+    ],
+    result.status,
+    result.totalChats,
+    result.status === 'sent' ? undefined : result.lastError,
+  )
+}

--- a/src/lib/alert-history/context.ts
+++ b/src/lib/alert-history/context.ts
@@ -26,8 +26,18 @@ export type AlertContextKind =
   | 'ta_signal'
   | 'custom_strategy'
 
+/**
+ * Phase 37-B (#445) — 모든 context shape 공용 옵셔널 필드.
+ * `retriedFrom`: 재발송으로 생성된 새 row 는 원본 AlertHistory.id 를 저장.
+ * 원본 row 는 이 필드가 없어 재발송 이력과 원본이 구분됨.
+ */
+interface CommonContextFields {
+  /** 재발송된 경우 원본 AlertHistory.id — UI 가 "재발송" 배지를 표시 */
+  retriedFrom?: string
+}
+
 /** 시세 계열 (surge/drop/target_hit/stop_loss/watch_buy/watch_zone) 공통 스냅샷 */
-export interface PriceAlertContext {
+export interface PriceAlertContext extends CommonContextFields {
   type: 'surge' | 'drop' | 'target_hit' | 'stop_loss' | 'watch_buy' | 'watch_zone'
   price: number
   changePercent: number | null
@@ -38,7 +48,7 @@ export interface PriceAlertContext {
 }
 
 /** 환율 알림 컨텍스트 */
-export interface FxAlertContext {
+export interface FxAlertContext extends CommonContextFields {
   type: 'fx'
   rate: number
   /** 전일 대비 KRW 변동 */
@@ -47,7 +57,7 @@ export interface FxAlertContext {
 }
 
 /** TA 시그널 컨텍스트 — TAReport 에서 핵심 지표만 발췌 */
-export interface TaSignalContext {
+export interface TaSignalContext extends CommonContextFields {
   type: 'ta_signal'
   price: number | null
   changePercent: number | null
@@ -64,7 +74,7 @@ export interface TaSignalContext {
 }
 
 /** 커스텀 전략 컨텍스트 — evaluator 결과 재활용 */
-export interface CustomStrategyContext {
+export interface CustomStrategyContext extends CommonContextFields {
   type: 'custom_strategy'
   strategyId: string
   strategyName: string

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -26,10 +26,18 @@ export function toCSV(headers: string[], rows: string[][]): string {
 
 /**
  * CSV Response를 생성한다.
+ *
+ * `extraHeaders` 는 truncation 신호 (`X-Truncated`, `X-Total-Count`) 같은 부가
+ * 메타를 실을 때 사용. Content-Type / Content-Disposition 은 항상 덮어쓴다.
  */
-export function csvResponse(csv: string, filename: string): Response {
+export function csvResponse(
+  csv: string,
+  filename: string,
+  extraHeaders?: Record<string, string>,
+): Response {
   return new Response(csv, {
     headers: {
+      ...(extraHeaders ?? {}),
       'Content-Type': 'text/csv; charset=utf-8',
       'Content-Disposition': `attachment; filename="${filename}"`,
     },


### PR DESCRIPTION
## Summary
- 알림 이력 CSV export + 실패 알림 재발송 기능 (Phase 37-B)
- Master: #443. Spec: `docs/specs/443-milestone-17-master.md` §Phase 37-B
- CSV export API (`GET /api/alerts/history/export`) — 현재 filter 그대로 스트리밍, RFC 4180 escape + BOM + Excel 수식 주입 방어 (`=+-@\t\r` prefix)
- 재발송 API (`POST /api/alerts/history/[id]/retry`) — failed row 만 대상, 5분 in-memory rate limit, 원본 유지 + 새 row append (`context.retriedFrom` 마커)
- `alert-dispatcher.ts` — pure redispatch + rate limiter + persist (mock 없이 단위 테스트 가능)
- Truncation 방어 — `count()` 병렬 조회 → `X-Truncated`/`X-Total-Count` 헤더 + CSV 마지막 `# TRUNCATED: showing first N of M` 안내 라인
- UI — 상단 툴바 "CSV 다운로드" 버튼 (blob 방식 + error toast + truncation 경고), 실패 뱃지 옆 "재발송" 버튼 (확인 다이얼로그 + 4초 자동 소멸 토스트)

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (35 files / 567 tests, 회귀 방지 신규 51 케이스 포함 — csv-format 26 + alert-dispatcher 21 + retry route 4)
- [x] `npm run build` 통과
- [x] self-review (pr-review-toolkit) 2 라운드 → P0 1 (파일명 회귀 관찰, 블로킹 아님) / P1 0 / P2 0
- [x] P1 CSV silent truncation 반영 + 회귀 테스트 페어링
- [ ] `/alerts/history` 툴바 CSV 다운로드 → Excel 열기 (수식 주입 없음 확인)
- [ ] 실패 row 재발송 → 새 row append, 5분내 재시도 시 429 응답
- [ ] 대량 row (10k+) export 시 truncation 안내 라인 노출

## 배포 후 조치
- AI advisor 변경 없음 → `/reset` 불필요

## Known follow-up (블로킹 아님)
- CSV 다운로드 파일명이 서버 `Content-Disposition` 대신 클라 하드코딩 (`alerts-history-${today}.csv`) — 필터 기간 정보 손실. 별도 이슈로 트래킹 예정.

Closes #445
