### PR TITLE
[Phase 37-C] MCP 로그 실시간 tail (SSE) (#446)

### DIFF
--- a/src/app/admin/mcp-logs/LiveTailPanel.tsx
+++ b/src/app/admin/mcp-logs/LiveTailPanel.tsx
@@ -85,6 +85,13 @@ export default function LiveTailPanel({
       return
     }
 
+    // Codex #455 P2: 필터 변경 (또는 fresh 시작) 시 이전 rows 를 초기화.
+    // 이전 필터의 라인이 새 필터 결과와 섞여 보이면 사용자에게 오해 유발
+    // (예: level=error → level=info 로 바꿔도 옛 error 라인이 남음).
+    // Toggle OFF 시에는 early return 하므로 클리어되지 않음 — 사용자가 방금
+    // 본 라인을 유지하고 싶어할 수 있음.
+    setRows([])
+
     const params = new URLSearchParams()
     if (level) params.set('level', level)
     if (msg) params.set('msg', msg)

--- a/src/app/admin/mcp-logs/LiveTailPanel.tsx
+++ b/src/app/admin/mcp-logs/LiveTailPanel.tsx
@@ -203,7 +203,8 @@ export default function LiveTailPanel({
                 return (
                   <li key={`${r.lineNo ?? ''}-${idx}`} className="px-4 py-2 hover:bg-surface transition-colors">
                     <div className="flex flex-wrap items-center gap-2 text-[11px]">
-                      {r.lineNo != null && <span className="text-dim font-mono">L{r.lineNo}</span>}
+                      {/* lineNo 는 poll batch 마다 1 부터 재시작해 스냅샷의 파일 라인
+                          번호 (L{n}) 와 오해 유발 (Codex #454 P1). live tail 은 표시 안함. */}
                       <span className="text-sub tabular-nums">{r.time?.slice(11, 19)}</span>
                       <span className={`px-2 py-0.5 rounded border font-semibold ${levelCls}`}>{r.level}</span>
                       {r.msg && (

--- a/src/app/admin/mcp-logs/LiveTailPanel.tsx
+++ b/src/app/admin/mcp-logs/LiveTailPanel.tsx
@@ -1,0 +1,243 @@
+/**
+ * Phase 37-C (#446) — 실시간 MCP 로그 tail 패널.
+ *
+ * `EventSource` 로 `/api/admin/mcp-logs/stream` 을 구독. 부모 (McpLogsClient) 는
+ * 현재 스냅샷 필터 (date/crash/level/msg/tool/traceId) 를 그대로 전달한다.
+ *
+ * - 오늘 KST 날짜 + 일반 로그만 지원 (서버 스코프와 동일). 다른 값이면 토글을 비활성화.
+ * - 신규 라인은 최상단에 append, 최대 MAX_ROWS 유지.
+ * - 자동 스크롤: 사용자가 컨테이너 top (scrollTop === 0) 근방에 있을 때만 다음
+ *   append 후 top 으로 스냅. 아래로 스크롤한 상태이면 위치 유지 (읽던 라인 방해 X).
+ * - 필터 조합이 변하거나 토글이 OFF 되면 EventSource 를 즉시 close.
+ */
+
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { recentLogDates } from '@/lib/mcp-logs/constants'
+
+interface LiveTailPanelProps {
+  date: string
+  crash: boolean
+  level: string
+  msg: string
+  tool: string
+  traceId: string
+}
+
+interface LogRow {
+  level: string
+  time?: string
+  msg?: string
+  tool?: string
+  latency_ms?: number
+  traceId?: string
+  status?: string
+  err?: unknown
+  raw?: string
+  parseError?: boolean
+  lineNo?: number
+}
+
+const MAX_ROWS = 500
+
+const LEVEL_CLASS: Record<string, string> = {
+  fatal: 'bg-red-500/20 text-red-400 border-red-500/40',
+  error: 'bg-red-500/15 text-red-400 border-red-500/30',
+  warn:  'bg-amber-500/15 text-amber-400 border-amber-500/30',
+  info:  'bg-sky-500/15 text-sky-400 border-sky-500/30',
+  debug: 'bg-sub/15 text-sub border-sub/30',
+  trace: 'bg-sub/10 text-dim border-sub/20',
+  unknown: 'bg-surface text-sub border-border',
+}
+
+function shortJson(v: unknown, max = 160): string {
+  if (v == null) return ''
+  try {
+    const s = JSON.stringify(v)
+    return s.length > max ? s.slice(0, max) + '…' : s
+  } catch {
+    return String(v).slice(0, max)
+  }
+}
+
+export default function LiveTailPanel({
+  date, crash, level, msg, tool, traceId,
+}: LiveTailPanelProps) {
+  const [on, setOn] = useState(false)
+  const [rows, setRows] = useState<LogRow[]>([])
+  const [status, setStatus] = useState<'idle' | 'connecting' | 'open' | 'error'>('idle')
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const stickToTopRef = useRef(true)
+
+  // 서버는 오늘 KST + 일반 로그만 tail. 조건 불충족이면 토글 비활성화.
+  const isToday = useMemo(() => date === recentLogDates(1)[0], [date])
+  const available = isToday && !crash
+
+  // 토글이 사라진 상태 (date 변경 등) 로 진입하면 자동 OFF 처리.
+  useEffect(() => {
+    if (!available && on) setOn(false)
+  }, [available, on])
+
+  useEffect(() => {
+    if (!on || !available) {
+      setStatus('idle')
+      return
+    }
+
+    const params = new URLSearchParams()
+    if (level) params.set('level', level)
+    if (msg) params.set('msg', msg)
+    if (tool) params.set('tool', tool)
+    if (traceId) params.set('traceId', traceId)
+
+    const qs = params.toString()
+    const url = qs
+      ? `/api/admin/mcp-logs/stream?${qs}`
+      : '/api/admin/mcp-logs/stream'
+
+    setStatus('connecting')
+    const es = new EventSource(url)
+
+    es.onopen = () => setStatus('open')
+    es.onerror = () => setStatus('error')
+    es.onmessage = (ev) => {
+      try {
+        const entry = JSON.parse(ev.data) as LogRow
+        setRows((prev) => {
+          const next = [entry, ...prev]
+          return next.length > MAX_ROWS ? next.slice(0, MAX_ROWS) : next
+        })
+      } catch {
+        // JSON 파싱 실패 라인은 무시 (SSE 는 서버가 이미 JSON 화)
+      }
+    }
+
+    return () => {
+      es.close()
+    }
+  }, [on, available, level, msg, tool, traceId])
+
+  // 사용자가 top 근방에 있을 때만 새 라인이 들어오면 top 유지.
+  useEffect(() => {
+    if (!listRef.current) return
+    if (stickToTopRef.current) listRef.current.scrollTop = 0
+  }, [rows])
+
+  const onScroll = () => {
+    if (!listRef.current) return
+    // 8px 미만이면 top 에 붙어있다고 간주.
+    stickToTopRef.current = listRef.current.scrollTop < 8
+  }
+
+  const statusLabel = (() => {
+    switch (status) {
+      case 'connecting': return '연결 중…'
+      case 'open': return '연결됨'
+      case 'error': return '연결 오류 — 재시도 중'
+      default: return '중단'
+    }
+  })()
+  const statusClass = {
+    idle: 'text-dim',
+    connecting: 'text-amber-400',
+    open: 'text-emerald-400',
+    error: 'text-red-400',
+  }[status]
+
+  return (
+    <section className="rounded-[14px] border border-border bg-card p-4 sm:p-5 space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="text-[13px] font-bold text-bright">실시간 tail</div>
+        <div className="text-[11px] text-sub">
+          오늘(KST) 일반 로그의 새 라인만 push합니다. 최대 {MAX_ROWS}건.
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {on && <span className={`text-[11px] font-semibold ${statusClass}`}>● {statusLabel}</span>}
+          {rows.length > 0 && (
+            <button
+              onClick={() => setRows([])}
+              className="px-2.5 py-1 text-[11px] font-semibold rounded-md border border-border bg-surface text-sub hover:text-bright"
+            >
+              지우기
+            </button>
+          )}
+          <button
+            onClick={() => setOn((prev) => !prev)}
+            disabled={!available}
+            className={`px-3 py-1.5 text-[12px] font-semibold rounded-md border transition-colors ${
+              !available
+                ? 'bg-surface border-border text-dim opacity-60 cursor-not-allowed'
+                : on
+                  ? 'bg-sejin/25 text-sejin border-sejin/40'
+                  : 'bg-surface border-border text-sub hover:text-bright'
+            }`}
+            title={!available ? '오늘 KST + 일반 로그에서만 지원됩니다.' : undefined}
+          >
+            {on ? '⏸ 중지' : '▶ 시작'}
+          </button>
+        </div>
+      </div>
+
+      {!available && (
+        <div className="text-[12px] text-amber-400">
+          실시간 tail 은 오늘(KST) 일반 로그에서만 동작합니다. 파일 / 크래시 설정을 변경해 주세요.
+        </div>
+      )}
+
+      {available && on && (
+        <div
+          ref={listRef}
+          onScroll={onScroll}
+          className="max-h-[420px] overflow-y-auto border border-border rounded-md bg-surface-dim"
+        >
+          {rows.length === 0 && (
+            <div className="px-4 py-6 text-center text-dim text-[12px]">
+              새 라인을 기다리는 중…
+            </div>
+          )}
+          {rows.length > 0 && (
+            <ul className="divide-y divide-border">
+              {rows.map((r, idx) => {
+                const levelCls = LEVEL_CLASS[r.level] ?? LEVEL_CLASS.unknown
+                return (
+                  <li key={`${r.lineNo ?? ''}-${idx}`} className="px-4 py-2 hover:bg-surface transition-colors">
+                    <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                      {r.lineNo != null && <span className="text-dim font-mono">L{r.lineNo}</span>}
+                      <span className="text-sub tabular-nums">{r.time?.slice(11, 19)}</span>
+                      <span className={`px-2 py-0.5 rounded border font-semibold ${levelCls}`}>{r.level}</span>
+                      {r.msg && (
+                        <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">
+                          {r.msg}
+                        </span>
+                      )}
+                      {r.tool && (
+                        <span className="px-2 py-0.5 rounded bg-sky-500/10 border border-sky-500/25 text-sky-400 font-mono">
+                          {r.tool}
+                        </span>
+                      )}
+                      {typeof r.latency_ms === 'number' && (
+                        <span className="text-sub text-[11px] tabular-nums">{r.latency_ms} ms</span>
+                      )}
+                      {r.traceId && (
+                        <span className="text-dim text-[11px] font-mono ml-auto">t:{r.traceId}</span>
+                      )}
+                    </div>
+                    {r.err != null && (
+                      <div className="mt-1 text-[12px] text-red-400 font-mono">
+                        err: {shortJson(r.err)}
+                      </div>
+                    )}
+                    {r.parseError && r.raw && (
+                      <div className="mt-1 text-[11px] text-amber-400 font-mono">raw: {r.raw.slice(0, 200)}</div>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/app/admin/mcp-logs/McpLogsClient.tsx
+++ b/src/app/admin/mcp-logs/McpLogsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates } from '@/lib/mcp-logs/constants'
+import LiveTailPanel from './LiveTailPanel'
 
 interface LogRow {
   level: string
@@ -259,6 +260,16 @@ export default function McpLogsClient() {
           })}
         </div>
       </section>
+
+      {/* Live tail (Phase 37-C, #446) */}
+      <LiveTailPanel
+        date={date}
+        crash={crash}
+        level={level}
+        msg={msg}
+        tool={toolFilter}
+        traceId={traceFilter}
+      />
 
       {/* Stats */}
       <section className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/app/api/admin/mcp-logs/stream/__tests__/route.test.ts
+++ b/src/app/api/admin/mcp-logs/stream/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Phase 37-C (#446) — SSE 라우트 헤더 · 필터 검증 테스트.
+ *
+ * 실 poll 흐름 (setInterval + fs) 은 통합테스트 부담이 커 순수 tail 유틸
+ * (splitLinesWithCarryover + readNewBytes) 로 커버하고, 여기서는 헤더 · 400
+ * 응답 · 필터 매칭 로직만 검증한다. `applyFilter` 는 route 가 그대로 위임하는
+ * 필터 코어 이므로 여기서 재사용해 "필터 조건이 route 명세와 일치한다" 는
+ * 계약을 잠금.
+ */
+
+import { NextRequest } from 'next/server'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { applyFilter, parseLines } from '@/lib/mcp-logs/parser'
+
+// 라우트 임포트 전에 로그 디렉토리를 tmp 로 우회 — 실제 프로덕션 파일을 건드리지 않도록.
+const TMP_LOG_DIR = path.join(os.tmpdir(), `mcp-logs-stream-test-${Date.now()}`)
+
+beforeAll(() => {
+  fs.mkdirSync(TMP_LOG_DIR, { recursive: true })
+  process.env.MCP_LOG_DIR = TMP_LOG_DIR
+})
+
+afterAll(() => {
+  try { fs.rmSync(TMP_LOG_DIR, { recursive: true, force: true }) } catch { /* ignore */ }
+})
+
+async function importRoute() {
+  return await import('../route')
+}
+
+function buildReq(query: Record<string, string> = {}): NextRequest {
+  const url = new URL('http://localhost/api/admin/mcp-logs/stream')
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v)
+  return new NextRequest(url)
+}
+
+describe('GET /api/admin/mcp-logs/stream — 응답 헤더', () => {
+  let openStreams: ReadableStreamDefaultReader<Uint8Array>[] = []
+
+  afterEach(async () => {
+    for (const r of openStreams) {
+      try { await r.cancel() } catch { /* ignore */ }
+    }
+    openStreams = []
+  })
+
+  it('SSE 표준 헤더 반환 (text/event-stream, no-cache, X-Accel-Buffering)', async () => {
+    const { GET } = await importRoute()
+    const res = await GET(buildReq())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+    expect(res.headers.get('cache-control')).toContain('no-cache')
+    expect(res.headers.get('cache-control')).toContain('no-transform')
+    expect(res.headers.get('connection')).toBe('keep-alive')
+    expect(res.headers.get('x-accel-buffering')).toBe('no')
+    // Body reader 는 open 상태 → afterEach 에서 정리.
+    if (res.body) openStreams.push(res.body.getReader())
+  })
+
+  it('연결 즉시 초기 comment 라인 (`: connected ...`) 을 flush', async () => {
+    const { GET } = await importRoute()
+    const res = await GET(buildReq())
+    expect(res.body).not.toBeNull()
+    const reader = res.body!.getReader()
+    openStreams.push(reader)
+    const { value } = await reader.read()
+    const decoded = new TextDecoder().decode(value)
+    expect(decoded.startsWith(': connected ')).toBe(true)
+    expect(decoded.endsWith('\n\n')).toBe(true)
+  })
+})
+
+describe('GET /api/admin/mcp-logs/stream — 필터 검증 (400)', () => {
+  it('알 수 없는 level → 400 + envelope error', async () => {
+    const { GET } = await importRoute()
+    const res = await GET(buildReq({ level: 'BOGUS' }))
+    expect(res.status).toBe(400)
+    const body = await res.json() as { success: boolean; error?: string }
+    expect(body.success).toBe(false)
+    expect(body.error).toContain('알 수 없는 level')
+  })
+
+  it('알 수 없는 msg → 400', async () => {
+    const { GET } = await importRoute()
+    const res = await GET(buildReq({ msg: 'nope' }))
+    expect(res.status).toBe(400)
+    const body = await res.json() as { success: boolean; error?: string }
+    expect(body.success).toBe(false)
+    expect(body.error).toContain('알 수 없는 msg')
+  })
+
+  it('알려진 level (info) 는 200 통과', async () => {
+    const { GET } = await importRoute()
+    const res = await GET(buildReq({ level: 'info' }))
+    expect(res.status).toBe(200)
+    if (res.body) await res.body.getReader().cancel()
+  })
+
+  it('알려진 msg (tool_call) 는 200 통과', async () => {
+    const { GET } = await importRoute()
+    const res = await GET(buildReq({ msg: 'tool_call' }))
+    expect(res.status).toBe(200)
+    if (res.body) await res.body.getReader().cancel()
+  })
+})
+
+describe('필터 매칭 계약 (route → applyFilter 위임)', () => {
+  // route 가 SSE 로 push 할 때 실제로 매칭되는 라인만 방출하는지 검증.
+  // route 는 splitLinesWithCarryover → parseLines → applyFilter 를 그대로 조합하므로
+  // 여기서 applyFilter 를 재사용해 "필터 조건이 route 명세와 동일" 함을 잠근다.
+  const SAMPLE = [
+    JSON.stringify({ level: 'info', msg: 'tool_call', tool: 'get_portfolio', traceId: 'a1' }),
+    JSON.stringify({ level: 'warn', msg: 'tool_call_reported_error', tool: 'get_trades', traceId: 'a2' }),
+    JSON.stringify({ level: 'error', msg: 'http_request_error', traceId: 'a3' }),
+  ].join('\n')
+
+  it('level=info → tool_call 라인만 방출', () => {
+    const entries = parseLines(SAMPLE)
+    const filtered = applyFilter(entries, { level: 'info' })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].tool).toBe('get_portfolio')
+  })
+
+  it('tool 부분 매치 (대소문자 무관)', () => {
+    const entries = parseLines(SAMPLE)
+    const filtered = applyFilter(entries, { tool: 'TRADES' })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].msg).toBe('tool_call_reported_error')
+  })
+
+  it('traceId 정확 매치, 미매칭 시 빈 배열', () => {
+    const entries = parseLines(SAMPLE)
+    expect(applyFilter(entries, { traceId: 'a3' })).toHaveLength(1)
+    expect(applyFilter(entries, { traceId: 'z9' })).toHaveLength(0)
+  })
+
+  it('필터 없음 → 전체 (SSE 는 이 경우 매 신규 라인을 모두 push)', () => {
+    const entries = parseLines(SAMPLE)
+    expect(applyFilter(entries, {})).toHaveLength(3)
+  })
+})
+
+describe('client abort → stream cleanup', () => {
+  it('AbortController 로 abort 시 stream 이 close 되고 timer 가 정리된다', async () => {
+    const { GET } = await importRoute()
+    const url = new URL('http://localhost/api/admin/mcp-logs/stream')
+    const controller = new AbortController()
+    const req = new NextRequest(url, { signal: controller.signal })
+    const res = await GET(req)
+    expect(res.body).not.toBeNull()
+    const reader = res.body!.getReader()
+    // 초기 comment 소진
+    await reader.read()
+    // abort → route 내부 cleanup 이 controller.close() 호출 → reader.read() done=true
+    controller.abort()
+    // AbortController abort 이벤트가 flush 될 시간을 살짝 부여
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const r = await reader.read()
+    expect(r.done).toBe(true)
+  })
+})

--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest } from 'next/server'
 import fs from 'node:fs'
+import { StringDecoder } from 'node:string_decoder'
 import { fail } from '@/lib/api-response'
 import {
   KNOWN_LEVELS, KNOWN_MSG_SET, logFilePath, todayKst,
@@ -58,6 +59,10 @@ export async function GET(req: NextRequest) {
       let fd: number | null = null
       let carry = ''
       let closed = false
+      // Codex #455 P2 — StringDecoder 로 UTF-8 partial byte 를 poll 간에 버퍼링.
+      // MAX_CHUNK_BYTES 컷이 멀티바이트 문자 중간에 걸려도 `write()` 가 미완결
+      // 바이트를 내부에 남겨두고 다음 write 와 재조립한다.
+      let decoder = new StringDecoder('utf8')
 
       const openIfNeeded = () => {
         if (fd !== null) return
@@ -102,6 +107,8 @@ export async function GET(req: NextRequest) {
             filePath = logFilePath(currentDate, false)
             position = 0
             carry = ''
+            // 새 파일 → decoder 도 리셋 (기존 partial byte 는 이전 파일 것이라 폐기).
+            decoder = new StringDecoder('utf8')
             safeEnqueue(`: rotated ${currentDate}\n\n`)
           }
 
@@ -114,6 +121,7 @@ export async function GET(req: NextRequest) {
           if (st.size < position) {
             position = 0
             carry = ''
+            decoder = new StringDecoder('utf8')
           }
 
           if (st.size === position) return  // 신규 데이터 없음
@@ -121,9 +129,14 @@ export async function GET(req: NextRequest) {
           const toRead = Math.min(st.size - position, MAX_CHUNK_BYTES)
           // Codex #454 P1: 요청 size 만큼 무조건 전진하면 short-read 시 데이터 유실.
           // bytesRead 만큼만 position 을 전진해 다음 poll 에서 이어 읽는다.
-          const { text: chunk, bytesRead } = readNewBytes(fd, position, position + toRead)
+          const { buf, bytesRead } = readNewBytes(fd, position, position + toRead)
           if (bytesRead <= 0) return
           position += bytesRead
+
+          // Codex #455 P2: decoder.write() 로 partial UTF-8 byte 를 내부 버퍼에
+          // 유지 → 다음 chunk 와 재조립. 미완결 byte 는 이번 turn 에서 output 되지
+          // 않고 그대로 남는다 (U+FFFD 치환 방지).
+          const chunk = decoder.write(buf)
 
           const { lines, carry: nextCarry } = splitLinesWithCarryover(chunk, carry)
           carry = nextCarry
@@ -152,6 +165,12 @@ export async function GET(req: NextRequest) {
         closeFd()
         try { controller.close() } catch { /* already closed */ }
       }
+
+      // Codex #455 P2: 초기 EOF 위치를 연결 시점에 동기 캡처 — 이전에는 첫 poll
+      // (1.5s 후) 에 openIfNeeded 가 position 을 설정해 그 사이 append 된 라인이
+      // 새 라인이 아닌 것으로 판정되어 스킵됐다. 파일이 아직 없으면 그대로 두고
+      // (openIfNeeded 가 poll 마다 재시도) 다음 라인부터 push.
+      openIfNeeded()
 
       // 초기 comment — Nginx 등 프록시가 응답 헤더를 즉시 flush 하도록 유도.
       safeEnqueue(`: connected ${currentDate}\n\n`)

--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -97,19 +97,28 @@ export async function GET(req: NextRequest) {
       const poll = () => {
         if (closed) return
         try {
-          // KST 자정 회전 대응 (Codex #454 P1) — pino 로거는 자정에 새 파일로
-          // 회전하지만 파일명 자체가 다르므로 size 감지로는 잡을 수 없다.
-          // poll 마다 today 를 재계산해 date 가 바뀌면 fd 를 닫고 새 파일을 open.
+          // KST 자정 회전 대응 (Codex #454 P1 + #455 P2) — pino 로거는 자정 감지를
+          // 5분 주기 setInterval 로 하기 때문에 (`src/mcp/logger.ts:113`) 00:00~00:05
+          // 사이의 write 는 여전히 어제 파일로 흘러간다. 따라서 date 가 바뀌었다고
+          // 즉시 오늘 파일로 전환하면 그 grace window 의 로그를 놓친다.
+          //
+          // 실제 회전 신호는 "오늘 파일이 존재하는가" 로 판단 — 로거가 회전 시
+          // openFileStream 이 새 파일을 생성하므로 존재 = 실제 회전 발생.
+          // 그 전까지는 어제 파일을 계속 tail.
           const today = todayKst()
           if (today !== currentDate) {
-            closeFd()
-            currentDate = today
-            filePath = logFilePath(currentDate, false)
-            position = 0
-            carry = ''
-            // 새 파일 → decoder 도 리셋 (기존 partial byte 는 이전 파일 것이라 폐기).
-            decoder = new StringDecoder('utf8')
-            safeEnqueue(`: rotated ${currentDate}\n\n`)
+            const todayFilePath = logFilePath(today, false)
+            if (fs.existsSync(todayFilePath)) {
+              closeFd()
+              currentDate = today
+              filePath = todayFilePath
+              position = 0
+              carry = ''
+              // 새 파일 → decoder 도 리셋 (기존 partial byte 는 이전 파일 것이라 폐기).
+              decoder = new StringDecoder('utf8')
+              safeEnqueue(`: rotated ${currentDate}\n\n`)
+            }
+            // else: 로거가 아직 회전 안 함 → 어제 파일을 계속 tail (누락 방지).
           }
 
           openIfNeeded()

--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -1,0 +1,155 @@
+/**
+ * Phase 37-C (#446) — MCP 로그 실시간 tail (SSE).
+ *
+ * `GET /api/admin/mcp-logs/stream?level=&msg=&tool=&traceId=`
+ *
+ * - 오늘 KST 날짜의 일반 로그 파일만 tail (`logs/mcp-YYYY-MM-DD.log`).
+ *   크래시 로그는 별도 파일이라 스코프 밖.
+ * - 초기 EOF 위치를 기록해 신규 라인만 push (기존 라인 재전송 X).
+ * - 폴링 (POLL_INTERVAL_MS) — `fs.watch` 는 Linux append 이벤트 신뢰성이 낮음.
+ * - keepalive comment (`: ping\n\n`) 로 프록시 idle 타임아웃 방어.
+ * - client abort 시 setInterval / open fd 를 정리한다 (leak 방어).
+ */
+
+import { NextRequest } from 'next/server'
+import fs from 'node:fs'
+import { fail } from '@/lib/api-response'
+import {
+  KNOWN_LEVELS, KNOWN_MSG_SET, logFilePath, todayKst,
+} from '../shared'
+import { parseLines, applyFilter, type Filter, type LogEntry } from '@/lib/mcp-logs/parser'
+import {
+  KEEPALIVE_INTERVAL_MS, MAX_CHUNK_BYTES, POLL_INTERVAL_MS,
+  readNewBytes, splitLinesWithCarryover,
+} from '@/lib/mcp-logs/tail'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function encodeEvent(entry: LogEntry): string {
+  // JSON.stringify 로 안전하게 escape (`\n` → `\\n`) → SSE data 라인 하나로 나감.
+  return `data: ${JSON.stringify(entry)}\n\n`
+}
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl
+  const level = url.searchParams.get('level')?.trim() || undefined
+  const msg = url.searchParams.get('msg')?.trim() || undefined
+  const tool = url.searchParams.get('tool')?.trim() || undefined
+  const traceId = url.searchParams.get('traceId')?.trim() || undefined
+
+  if (level && !KNOWN_LEVELS.has(level)) {
+    return fail(`알 수 없는 level: ${level}`, 400)
+  }
+  if (msg && !KNOWN_MSG_SET.has(msg)) {
+    return fail(`알 수 없는 msg: ${msg}`, 400)
+  }
+
+  const filter: Filter = { level, msg, tool, traceId }
+  const date = todayKst()
+  const filePath = logFilePath(date, false)
+
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream({
+    start(controller) {
+      let position = 0
+      let fd: number | null = null
+      let carry = ''
+      let closed = false
+
+      const openIfNeeded = () => {
+        if (fd !== null) return
+        if (!fs.existsSync(filePath)) return
+        try {
+          const st = fs.statSync(filePath)
+          fd = fs.openSync(filePath, 'r')
+          // 최초 접속 시점 EOF 부터 시작 — 과거 라인 재전송 방지.
+          position = st.size
+        } catch {
+          fd = null
+        }
+      }
+
+      const closeFd = () => {
+        if (fd !== null) {
+          try { fs.closeSync(fd) } catch { /* ignore */ }
+          fd = null
+        }
+      }
+
+      const safeEnqueue = (chunk: string) => {
+        if (closed) return
+        try {
+          controller.enqueue(encoder.encode(chunk))
+        } catch {
+          // controller 가 이미 닫혔거나 클라이언트 disconnect — cleanup 위임.
+          cleanup()
+        }
+      }
+
+      const poll = () => {
+        if (closed) return
+        try {
+          openIfNeeded()
+          if (fd === null) return  // 파일이 아직 없음 → 다음 poll 대기
+
+          const st = fs.fstatSync(fd)
+
+          // 로테이션 등으로 파일 크기가 줄었으면 처음부터.
+          if (st.size < position) {
+            position = 0
+            carry = ''
+          }
+
+          if (st.size === position) return  // 신규 데이터 없음
+
+          const toRead = Math.min(st.size - position, MAX_CHUNK_BYTES)
+          const chunk = readNewBytes(fd, position, position + toRead)
+          position += toRead
+
+          const { lines, carry: nextCarry } = splitLinesWithCarryover(chunk, carry)
+          carry = nextCarry
+          if (lines.length === 0) return
+
+          const parsed = parseLines(lines.join('\n'))
+          const filtered = applyFilter(parsed, filter)
+          for (const entry of filtered) {
+            safeEnqueue(encodeEvent(entry))
+          }
+        } catch {
+          // fs 오류는 다음 poll 에서 재시도. 파일이 rotate/삭제된 경우 openIfNeeded 가
+          // 재시도한다. fd 를 닫아 stale descriptor 를 정리.
+          closeFd()
+        }
+      }
+
+      const pollTimer = setInterval(poll, POLL_INTERVAL_MS)
+      const keepaliveTimer = setInterval(() => safeEnqueue(': ping\n\n'), KEEPALIVE_INTERVAL_MS)
+
+      const cleanup = () => {
+        if (closed) return
+        closed = true
+        clearInterval(pollTimer)
+        clearInterval(keepaliveTimer)
+        closeFd()
+        try { controller.close() } catch { /* already closed */ }
+      }
+
+      // 초기 comment — Nginx 등 프록시가 응답 헤더를 즉시 flush 하도록 유도.
+      safeEnqueue(`: connected ${date}\n\n`)
+
+      req.signal.addEventListener('abort', cleanup)
+    },
+  })
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -94,68 +94,87 @@ export async function GET(req: NextRequest) {
         }
       }
 
+      /**
+       * 현재 fd 에서 한 chunk 만 읽어 lines emit. 반환은 소비한 byte 수 (0 이면 no-op).
+       * 정상 poll + rotation drain 양쪽에서 재사용.
+       */
+      const emitFromCurrentFd = (): number => {
+        if (fd === null) return 0
+        const st = fs.fstatSync(fd)
+        // truncate / 재초기화로 파일 크기가 줄었으면 처음부터.
+        if (st.size < position) {
+          position = 0
+          carry = ''
+          decoder = new StringDecoder('utf8')
+        }
+        if (st.size === position) return 0
+        const toRead = Math.min(st.size - position, MAX_CHUNK_BYTES)
+        // Codex #454 P1: bytesRead 만큼만 position 을 전진 (short-read 방어).
+        const { buf, bytesRead } = readNewBytes(fd, position, position + toRead)
+        if (bytesRead <= 0) return 0
+        position += bytesRead
+        // Codex #455 P2: decoder.write() 로 UTF-8 partial byte 를 내부 버퍼링.
+        const chunk = decoder.write(buf)
+        const { lines, carry: nextCarry } = splitLinesWithCarryover(chunk, carry)
+        carry = nextCarry
+        if (lines.length === 0) return bytesRead
+        const parsed = parseLines(lines.join('\n'))
+        const filtered = applyFilter(parsed, filter)
+        for (const entry of filtered) {
+          safeEnqueue(encodeEvent(entry))
+        }
+        return bytesRead
+      }
+
+      /** Codex #455 P2 — rotation 직전 어제 파일의 미방출 tail 을 drain. */
+      const DRAIN_MAX_ITERS = 20  // 최대 20 * 512KB = 10MB 안전 cap
+      const drainCurrentFd = () => {
+        try {
+          for (let i = 0; i < DRAIN_MAX_ITERS; i++) {
+            if (emitFromCurrentFd() === 0) break
+          }
+        } catch { /* best effort — 회전 후 새 파일 tail 은 계속 진행 */ }
+      }
+
       const poll = () => {
         if (closed) return
         try {
-          // KST 자정 회전 대응 (Codex #454 P1 + #455 P2) — pino 로거는 자정 감지를
+          // KST 자정 회전 대응 (Codex #454 P1 + #455 P2×2) — pino 로거는 자정 감지를
           // 5분 주기 setInterval 로 하기 때문에 (`src/mcp/logger.ts:113`) 00:00~00:05
-          // 사이의 write 는 여전히 어제 파일로 흘러간다. 따라서 date 가 바뀌었다고
-          // 즉시 오늘 파일로 전환하면 그 grace window 의 로그를 놓친다.
+          // 사이의 write 는 여전히 어제 파일로 흘러간다. 실제 회전 신호는 "오늘
+          // 파일이 존재하는가" 로 판단 — 그 전까지는 어제 파일을 계속 tail.
           //
-          // 실제 회전 신호는 "오늘 파일이 존재하는가" 로 판단 — 로거가 회전 시
-          // openFileStream 이 새 파일을 생성하므로 존재 = 실제 회전 발생.
-          // 그 전까지는 어제 파일을 계속 tail.
+          // 회전 시점에는 어제 파일의 미방출 tail 을 먼저 drain (Codex #455 P2 —
+          // 이전에는 즉시 close 로 폐기됐음). 오늘 파일은 EOF 가 아니라 offset 0
+          // 부터 시작 (Codex #455 P2 — 로거 회전 후 이미 write 된 초기 라인 캡처).
           const today = todayKst()
           if (today !== currentDate) {
             const todayFilePath = logFilePath(today, false)
             if (fs.existsSync(todayFilePath)) {
+              drainCurrentFd()
               closeFd()
               currentDate = today
               filePath = todayFilePath
-              position = 0
               carry = ''
               // 새 파일 → decoder 도 리셋 (기존 partial byte 는 이전 파일 것이라 폐기).
               decoder = new StringDecoder('utf8')
               safeEnqueue(`: rotated ${currentDate}\n\n`)
+              // 회전 파일은 head 부터 (openIfNeeded 의 EOF 스타트를 우회).
+              try {
+                fd = fs.openSync(filePath, 'r')
+                position = 0
+              } catch {
+                fd = null
+                position = 0
+              }
             }
             // else: 로거가 아직 회전 안 함 → 어제 파일을 계속 tail (누락 방지).
           }
 
-          openIfNeeded()
+          openIfNeeded()  // 최초 subscribe / fs 오류 재시도. 회전 직후엔 fd 존재 → no-op.
           if (fd === null) return  // 파일이 아직 없음 → 다음 poll 대기
 
-          const st = fs.fstatSync(fd)
-
-          // truncate / 재초기화로 파일 크기가 줄었으면 처음부터.
-          if (st.size < position) {
-            position = 0
-            carry = ''
-            decoder = new StringDecoder('utf8')
-          }
-
-          if (st.size === position) return  // 신규 데이터 없음
-
-          const toRead = Math.min(st.size - position, MAX_CHUNK_BYTES)
-          // Codex #454 P1: 요청 size 만큼 무조건 전진하면 short-read 시 데이터 유실.
-          // bytesRead 만큼만 position 을 전진해 다음 poll 에서 이어 읽는다.
-          const { buf, bytesRead } = readNewBytes(fd, position, position + toRead)
-          if (bytesRead <= 0) return
-          position += bytesRead
-
-          // Codex #455 P2: decoder.write() 로 partial UTF-8 byte 를 내부 버퍼에
-          // 유지 → 다음 chunk 와 재조립. 미완결 byte 는 이번 turn 에서 output 되지
-          // 않고 그대로 남는다 (U+FFFD 치환 방지).
-          const chunk = decoder.write(buf)
-
-          const { lines, carry: nextCarry } = splitLinesWithCarryover(chunk, carry)
-          carry = nextCarry
-          if (lines.length === 0) return
-
-          const parsed = parseLines(lines.join('\n'))
-          const filtered = applyFilter(parsed, filter)
-          for (const entry of filtered) {
-            safeEnqueue(encodeEvent(entry))
-          }
+          emitFromCurrentFd()
         } catch {
           // fs 오류는 다음 poll 에서 재시도. 파일이 rotate/삭제된 경우 openIfNeeded 가
           // 재시도한다. fd 를 닫아 stale descriptor 를 정리.

--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -63,15 +63,28 @@ export async function GET(req: NextRequest) {
       // MAX_CHUNK_BYTES 컷이 멀티바이트 문자 중간에 걸려도 `write()` 가 미완결
       // 바이트를 내부에 남겨두고 다음 write 와 재조립한다.
       let decoder = new StringDecoder('utf8')
+      // Codex #455 P2 — 최초 open 이 아직 안 끝났는지 (position 시딩 대기 중).
+      // true 이면 다음 성공적 open 시점에 position 을 (subscribe 시점 EOF | head 0)
+      // 로 잠근다. false 이면 fs error 재열기 등 subsequent open 이라 position 을
+      // 유지 (중복 방지).
+      let awaitingFirstOpen = true
 
-      const openIfNeeded = () => {
+      /**
+       * @param isSubscribeCall true 이면 start() 의 동기 호출 (파일 존재 시 EOF 캡처
+       *   → 과거 라인 스킵). false 이면 poll 의 후속 호출 (파일이 subscribe 이후
+       *   나타난 케이스는 head(0) 부터 → 로거의 첫 burst 캡처).
+       */
+      const openIfNeeded = (isSubscribeCall = false) => {
         if (fd !== null) return
         if (!fs.existsSync(filePath)) return
         try {
           const st = fs.statSync(filePath)
           fd = fs.openSync(filePath, 'r')
-          // 최초 접속 시점 EOF 부터 시작 — 과거 라인 재전송 방지.
-          position = st.size
+          if (awaitingFirstOpen) {
+            position = isSubscribeCall ? st.size : 0
+            awaitingFirstOpen = false
+          }
+          // else: subsequent open (fs error 재열기 등) → 이전 position 유지.
         } catch {
           fd = null
         }
@@ -196,9 +209,9 @@ export async function GET(req: NextRequest) {
 
       // Codex #455 P2: 초기 EOF 위치를 연결 시점에 동기 캡처 — 이전에는 첫 poll
       // (1.5s 후) 에 openIfNeeded 가 position 을 설정해 그 사이 append 된 라인이
-      // 새 라인이 아닌 것으로 판정되어 스킵됐다. 파일이 아직 없으면 그대로 두고
-      // (openIfNeeded 가 poll 마다 재시도) 다음 라인부터 push.
-      openIfNeeded()
+      // 새 라인이 아닌 것으로 판정되어 스킵됐다. 파일이 아직 없으면 awaitingFirstOpen
+      // 을 true 로 유지 → 다음 poll 에서 openIfNeeded(false) 가 head(0) 부터 open.
+      openIfNeeded(true)
 
       // 초기 comment — Nginx 등 프록시가 응답 헤더를 즉시 flush 하도록 유도.
       safeEnqueue(`: connected ${currentDate}\n\n`)

--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -46,13 +46,14 @@ export async function GET(req: NextRequest) {
   }
 
   const filter: Filter = { level, msg, tool, traceId }
-  const date = todayKst()
-  const filePath = logFilePath(date, false)
+  const initialDate = todayKst()
 
   const encoder = new TextEncoder()
 
   const stream = new ReadableStream({
     start(controller) {
+      let currentDate = initialDate
+      let filePath = logFilePath(currentDate, false)
       let position = 0
       let fd: number | null = null
       let carry = ''
@@ -91,12 +92,25 @@ export async function GET(req: NextRequest) {
       const poll = () => {
         if (closed) return
         try {
+          // KST 자정 회전 대응 (Codex #454 P1) — pino 로거는 자정에 새 파일로
+          // 회전하지만 파일명 자체가 다르므로 size 감지로는 잡을 수 없다.
+          // poll 마다 today 를 재계산해 date 가 바뀌면 fd 를 닫고 새 파일을 open.
+          const today = todayKst()
+          if (today !== currentDate) {
+            closeFd()
+            currentDate = today
+            filePath = logFilePath(currentDate, false)
+            position = 0
+            carry = ''
+            safeEnqueue(`: rotated ${currentDate}\n\n`)
+          }
+
           openIfNeeded()
           if (fd === null) return  // 파일이 아직 없음 → 다음 poll 대기
 
           const st = fs.fstatSync(fd)
 
-          // 로테이션 등으로 파일 크기가 줄었으면 처음부터.
+          // truncate / 재초기화로 파일 크기가 줄었으면 처음부터.
           if (st.size < position) {
             position = 0
             carry = ''
@@ -105,8 +119,11 @@ export async function GET(req: NextRequest) {
           if (st.size === position) return  // 신규 데이터 없음
 
           const toRead = Math.min(st.size - position, MAX_CHUNK_BYTES)
-          const chunk = readNewBytes(fd, position, position + toRead)
-          position += toRead
+          // Codex #454 P1: 요청 size 만큼 무조건 전진하면 short-read 시 데이터 유실.
+          // bytesRead 만큼만 position 을 전진해 다음 poll 에서 이어 읽는다.
+          const { text: chunk, bytesRead } = readNewBytes(fd, position, position + toRead)
+          if (bytesRead <= 0) return
+          position += bytesRead
 
           const { lines, carry: nextCarry } = splitLinesWithCarryover(chunk, carry)
           carry = nextCarry
@@ -137,7 +154,7 @@ export async function GET(req: NextRequest) {
       }
 
       // 초기 comment — Nginx 등 프록시가 응답 헤더를 즉시 flush 하도록 유도.
-      safeEnqueue(`: connected ${date}\n\n`)
+      safeEnqueue(`: connected ${currentDate}\n\n`)
 
       req.signal.addEventListener('abort', cleanup)
     },

--- a/src/lib/mcp-logs/__tests__/tail.test.ts
+++ b/src/lib/mcp-logs/__tests__/tail.test.ts
@@ -61,22 +61,35 @@ describe('readNewBytes', () => {
     try { fs.unlinkSync(tmpFile) } catch { /* deleted */ }
   })
 
-  it('offset 부터 지정 길이만큼 UTF-8 문자열 반환', () => {
+  it('offset 부터 지정 길이만큼 UTF-8 문자열 반환 + bytesRead', () => {
     // "hello world\n" 12바이트 중 [6, 11) → "world"
-    const s = readNewBytes(fd, 6, 11)
-    expect(s).toBe('world')
+    const r = readNewBytes(fd, 6, 11)
+    expect(r.text).toBe('world')
+    expect(r.bytesRead).toBe(5)
   })
 
-  it('to <= from → 빈 문자열', () => {
-    expect(readNewBytes(fd, 5, 5)).toBe('')
-    expect(readNewBytes(fd, 5, 0)).toBe('')
+  it('to <= from → 빈 결과 (bytesRead=0)', () => {
+    expect(readNewBytes(fd, 5, 5)).toEqual({ text: '', bytesRead: 0 })
+    expect(readNewBytes(fd, 5, 0)).toEqual({ text: '', bytesRead: 0 })
   })
 
   it('파일에 append 후 새 offset 부터 읽으면 신규 바이트만 반환', () => {
     const beforeSize = fs.statSync(tmpFile).size
     fs.appendFileSync(tmpFile, 'appended\n')
     const afterSize = fs.statSync(tmpFile).size
-    const s = readNewBytes(fd, beforeSize, afterSize)
-    expect(s).toBe('appended\n')
+    const r = readNewBytes(fd, beforeSize, afterSize)
+    expect(r.text).toBe('appended\n')
+    expect(r.bytesRead).toBe(afterSize - beforeSize)
+  })
+
+  // Codex #454 P1 회귀 방지 — 요청 범위가 실제 파일 크기를 초과하면 short-read.
+  // 이전에는 요청 size 만큼 무조건 전진해 유실됐다. 이제는 bytesRead 로 정확 소비량 노출.
+  it('요청 범위가 파일보다 크면 실제 읽은 바이트만 반환 (short-read)', () => {
+    const size = fs.statSync(tmpFile).size
+    // "hello world\n" = 12 바이트. from=6, to=100 → 실제 파일 잔량 (12-6=6) 만 읽힘.
+    const r = readNewBytes(fd, 6, 100)
+    expect(r.text).toBe('world\n')
+    expect(r.bytesRead).toBe(size - 6)
+    expect(r.bytesRead).toBeLessThan(100 - 6) // 요청보다 작음
   })
 })

--- a/src/lib/mcp-logs/__tests__/tail.test.ts
+++ b/src/lib/mcp-logs/__tests__/tail.test.ts
@@ -61,16 +61,20 @@ describe('readNewBytes', () => {
     try { fs.unlinkSync(tmpFile) } catch { /* deleted */ }
   })
 
-  it('offset 부터 지정 길이만큼 UTF-8 문자열 반환 + bytesRead', () => {
+  it('offset 부터 지정 길이만큼 raw Buffer 반환 + bytesRead', () => {
     // "hello world\n" 12바이트 중 [6, 11) → "world"
     const r = readNewBytes(fd, 6, 11)
-    expect(r.text).toBe('world')
+    expect(r.buf.toString('utf-8')).toBe('world')
     expect(r.bytesRead).toBe(5)
   })
 
   it('to <= from → 빈 결과 (bytesRead=0)', () => {
-    expect(readNewBytes(fd, 5, 5)).toEqual({ text: '', bytesRead: 0 })
-    expect(readNewBytes(fd, 5, 0)).toEqual({ text: '', bytesRead: 0 })
+    const r1 = readNewBytes(fd, 5, 5)
+    expect(r1.bytesRead).toBe(0)
+    expect(r1.buf.length).toBe(0)
+    const r2 = readNewBytes(fd, 5, 0)
+    expect(r2.bytesRead).toBe(0)
+    expect(r2.buf.length).toBe(0)
   })
 
   it('파일에 append 후 새 offset 부터 읽으면 신규 바이트만 반환', () => {
@@ -78,7 +82,7 @@ describe('readNewBytes', () => {
     fs.appendFileSync(tmpFile, 'appended\n')
     const afterSize = fs.statSync(tmpFile).size
     const r = readNewBytes(fd, beforeSize, afterSize)
-    expect(r.text).toBe('appended\n')
+    expect(r.buf.toString('utf-8')).toBe('appended\n')
     expect(r.bytesRead).toBe(afterSize - beforeSize)
   })
 
@@ -88,8 +92,50 @@ describe('readNewBytes', () => {
     const size = fs.statSync(tmpFile).size
     // "hello world\n" = 12 바이트. from=6, to=100 → 실제 파일 잔량 (12-6=6) 만 읽힘.
     const r = readNewBytes(fd, 6, 100)
-    expect(r.text).toBe('world\n')
+    expect(r.buf.toString('utf-8')).toBe('world\n')
     expect(r.bytesRead).toBe(size - 6)
     expect(r.bytesRead).toBeLessThan(100 - 6) // 요청보다 작음
+  })
+})
+
+// Codex #455 P2 회귀 방지 — readNewBytes 는 raw Buffer 를 반환하고 UTF-8 디코딩을
+// 하지 않는다. caller (route) 는 StringDecoder 로 partial byte 를 버퍼링해야 한다.
+describe('UTF-8 chunk 경계 안전성 (StringDecoder 계약 검증)', () => {
+  it('한국어 3바이트 문자를 임의 지점에서 잘라 두 chunk 로 나눠도 decoder 로 재조립', async () => {
+    const { StringDecoder } = await import('node:string_decoder')
+    // "안녕하세요\n" — 각 한글은 UTF-8 3바이트. 총 16바이트 (5*3 + 1).
+    const full = Buffer.from('안녕하세요\n', 'utf-8')
+    expect(full.length).toBe(16)
+
+    // 중간 지점 (예: 4바이트 = "안" 3바이트 + "녕" 첫 1바이트) 에서 절단.
+    const partA = full.subarray(0, 4)
+    const partB = full.subarray(4)
+
+    // 각각 toString('utf-8') 하면 partA 는 "안" + U+FFFD 로 치환 → 손상.
+    expect(partA.toString('utf-8')).not.toBe('안')
+
+    // StringDecoder 는 partial byte 를 내부에 남기고 다음 write 와 합쳐 정상 복원.
+    const dec = new StringDecoder('utf8')
+    const out1 = dec.write(partA)
+    const out2 = dec.write(partB)
+    expect(out1 + out2).toBe('안녕하세요\n')
+  })
+
+  it('splitLinesWithCarryover 는 decoder 출력에 대해서만 안전 — decoder 없이 쪼갠 UTF-8 은 손상', async () => {
+    const { StringDecoder } = await import('node:string_decoder')
+    const full = Buffer.from('한글줄1\n한글줄2\n', 'utf-8')
+    const cut = 5 // "한" (3) + "글" 첫 2 바이트에서 절단 → 두번째 chunk 에 나머지
+    const a = full.subarray(0, cut)
+    const b = full.subarray(cut)
+
+    const dec = new StringDecoder('utf8')
+    const chunkA = dec.write(a)
+    const s1 = splitLinesWithCarryover(chunkA, '')
+    expect(s1.lines).toEqual([])  // 아직 \n 없음
+
+    const chunkB = dec.write(b)
+    const s2 = splitLinesWithCarryover(chunkB, s1.carry)
+    expect(s2.lines).toEqual(['한글줄1', '한글줄2'])
+    expect(s2.carry).toBe('')
   })
 })

--- a/src/lib/mcp-logs/__tests__/tail.test.ts
+++ b/src/lib/mcp-logs/__tests__/tail.test.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readNewBytes, splitLinesWithCarryover } from '../tail'
+
+describe('splitLinesWithCarryover', () => {
+  it('완결된 여러 라인 → 모두 방출, carry 는 빈 문자열', () => {
+    const r = splitLinesWithCarryover('a\nb\nc\n', '')
+    expect(r.lines).toEqual(['a', 'b', 'c'])
+    expect(r.carry).toBe('')
+  })
+
+  it('마지막 라인이 `\\n` 으로 안 끝나면 carry 로 보존', () => {
+    const r = splitLinesWithCarryover('a\nb\npartial', '')
+    expect(r.lines).toEqual(['a', 'b'])
+    expect(r.carry).toBe('partial')
+  })
+
+  it('이전 carry 와 결합해 완결된 라인 방출', () => {
+    const first = splitLinesWithCarryover('{"level":"in', '')
+    expect(first.lines).toEqual([])
+    expect(first.carry).toBe('{"level":"in')
+    const second = splitLinesWithCarryover('fo","msg":"ok"}\n', first.carry)
+    expect(second.lines).toEqual(['{"level":"info","msg":"ok"}'])
+    expect(second.carry).toBe('')
+  })
+
+  it('빈 라인 (`\\n\\n`) 은 skip', () => {
+    const r = splitLinesWithCarryover('a\n\nb\n', '')
+    expect(r.lines).toEqual(['a', 'b'])
+    expect(r.carry).toBe('')
+  })
+
+  it('빈 chunk 는 lines 없음 + carry 유지', () => {
+    const r = splitLinesWithCarryover('', 'leftover')
+    expect(r.lines).toEqual([])
+    expect(r.carry).toBe('leftover')
+  })
+
+  it('carry 만 있는 상태에서 다음 chunk 가 오면 이어붙임', () => {
+    const r1 = splitLinesWithCarryover('half', '')
+    const r2 = splitLinesWithCarryover('-line\nnext\n', r1.carry)
+    expect(r2.lines).toEqual(['half-line', 'next'])
+    expect(r2.carry).toBe('')
+  })
+})
+
+describe('readNewBytes', () => {
+  let tmpFile: string
+  let fd: number
+
+  beforeEach(() => {
+    tmpFile = path.join(os.tmpdir(), `tail-test-${Date.now()}-${Math.random().toString(36).slice(2)}.log`)
+    fs.writeFileSync(tmpFile, 'hello world\n')
+    fd = fs.openSync(tmpFile, 'r')
+  })
+
+  afterEach(() => {
+    try { fs.closeSync(fd) } catch { /* already closed */ }
+    try { fs.unlinkSync(tmpFile) } catch { /* deleted */ }
+  })
+
+  it('offset 부터 지정 길이만큼 UTF-8 문자열 반환', () => {
+    // "hello world\n" 12바이트 중 [6, 11) → "world"
+    const s = readNewBytes(fd, 6, 11)
+    expect(s).toBe('world')
+  })
+
+  it('to <= from → 빈 문자열', () => {
+    expect(readNewBytes(fd, 5, 5)).toBe('')
+    expect(readNewBytes(fd, 5, 0)).toBe('')
+  })
+
+  it('파일에 append 후 새 offset 부터 읽으면 신규 바이트만 반환', () => {
+    const beforeSize = fs.statSync(tmpFile).size
+    fs.appendFileSync(tmpFile, 'appended\n')
+    const afterSize = fs.statSync(tmpFile).size
+    const s = readNewBytes(fd, beforeSize, afterSize)
+    expect(s).toBe('appended\n')
+  })
+})

--- a/src/lib/mcp-logs/tail.ts
+++ b/src/lib/mcp-logs/tail.ts
@@ -46,19 +46,27 @@ export function splitLinesWithCarryover(
 
 /**
  * 파일 descriptor 에서 `[from, to)` 구간을 UTF-8 로 읽는다.
- * `to - from` 이 0 이하이면 빈 문자열.
- * 실제 읽은 바이트 수가 요청보다 작을 수 있으므로 `bytesRead` 만큼만 반환.
+ * `to - from` 이 0 이하이면 빈 결과.
  *
- * ⚠️ UTF-8 멀티바이트 문자가 chunk 경계에 걸리면 마지막 문자가 깨질 수 있으나
- * pino 로그는 대부분 ASCII 이고, 다음 poll 에서 나머지 바이트를 읽어 이어진다.
- * splitLinesWithCarryover 가 `\n` 기준으로만 라인을 확정하므로 파싱 실패 시
- * `parseLines` 가 raw 로 표시해 UX 상 큰 문제는 없다 (완결된 라인은 정상).
+ * 반환 `bytesRead` 는 실제 fs.readSync 가 채운 바이트 수 (요청보다 작을 수 있음).
+ * caller 는 `position += bytesRead` 로 소비한 만큼만 전진해야 데이터 유실이 없다
+ * (Codex #454 P1 — 이전엔 요청 size 만큼 무조건 전진하다 short-read 시 스킵).
+ *
+ * ⚠️ UTF-8 멀티바이트 문자가 chunk 경계에 걸리면 마지막 문자가 깨질 수 있다.
+ * pino 로그는 대부분 ASCII 이나, 한국어 err 메시지 등이 tail 될 때 마지막 문자가
+ * `\n` 앞이 아니면 `splitLinesWithCarryover` 가 carry 로 보내 다음 poll 에서
+ * 이어붙는다. 즉 라인 경계 (`\n`) 가 chunk 안에 있으면 완결된 라인은 정상, 마지막
+ * 잘린 부분만 다음 poll 로 넘어가 UTF-8 재조립이 자연스레 이루어진다.
  */
-export function readNewBytes(fd: number, from: number, to: number): string {
+export function readNewBytes(
+  fd: number,
+  from: number,
+  to: number,
+): { text: string; bytesRead: number } {
   const size = to - from
-  if (size <= 0) return ''
+  if (size <= 0) return { text: '', bytesRead: 0 }
   const buf = Buffer.alloc(size)
   const bytesRead = fs.readSync(fd, buf, 0, size, from)
-  if (bytesRead <= 0) return ''
-  return buf.subarray(0, bytesRead).toString('utf-8')
+  if (bytesRead <= 0) return { text: '', bytesRead: 0 }
+  return { text: buf.subarray(0, bytesRead).toString('utf-8'), bytesRead }
 }

--- a/src/lib/mcp-logs/tail.ts
+++ b/src/lib/mcp-logs/tail.ts
@@ -45,28 +45,27 @@ export function splitLinesWithCarryover(
 }
 
 /**
- * 파일 descriptor 에서 `[from, to)` 구간을 UTF-8 로 읽는다.
+ * 파일 descriptor 에서 `[from, to)` 구간을 raw Buffer 로 읽는다.
  * `to - from` 이 0 이하이면 빈 결과.
  *
  * 반환 `bytesRead` 는 실제 fs.readSync 가 채운 바이트 수 (요청보다 작을 수 있음).
  * caller 는 `position += bytesRead` 로 소비한 만큼만 전진해야 데이터 유실이 없다
  * (Codex #454 P1 — 이전엔 요청 size 만큼 무조건 전진하다 short-read 시 스킵).
  *
- * ⚠️ UTF-8 멀티바이트 문자가 chunk 경계에 걸리면 마지막 문자가 깨질 수 있다.
- * pino 로그는 대부분 ASCII 이나, 한국어 err 메시지 등이 tail 될 때 마지막 문자가
- * `\n` 앞이 아니면 `splitLinesWithCarryover` 가 carry 로 보내 다음 poll 에서
- * 이어붙는다. 즉 라인 경계 (`\n`) 가 chunk 안에 있으면 완결된 라인은 정상, 마지막
- * 잘린 부분만 다음 poll 로 넘어가 UTF-8 재조립이 자연스레 이루어진다.
+ * ⚠️ UTF-8 디코딩은 이 함수에서 수행하지 않는다 (Codex #455 P2). Buffer 를 직접
+ * `.toString('utf-8')` 하면 멀티바이트가 chunk 경계에 걸릴 때 U+FFFD 로 치환되어
+ * 데이터 손실 → 다음 poll 로 이어붙일 수 없다. caller 가 `StringDecoder` 세션을
+ * 유지하며 `decoder.write(buf)` 로 partial byte 를 내부 버퍼에 남기도록 해야 한다.
  */
 export function readNewBytes(
   fd: number,
   from: number,
   to: number,
-): { text: string; bytesRead: number } {
+): { buf: Buffer; bytesRead: number } {
   const size = to - from
-  if (size <= 0) return { text: '', bytesRead: 0 }
+  if (size <= 0) return { buf: Buffer.alloc(0), bytesRead: 0 }
   const buf = Buffer.alloc(size)
   const bytesRead = fs.readSync(fd, buf, 0, size, from)
-  if (bytesRead <= 0) return { text: '', bytesRead: 0 }
-  return { text: buf.subarray(0, bytesRead).toString('utf-8'), bytesRead }
+  if (bytesRead <= 0) return { buf: Buffer.alloc(0), bytesRead: 0 }
+  return { buf: buf.subarray(0, bytesRead), bytesRead }
 }

--- a/src/lib/mcp-logs/tail.ts
+++ b/src/lib/mcp-logs/tail.ts
@@ -1,0 +1,64 @@
+/**
+ * Phase 37-C (#446) — MCP 로그 실시간 tail 유틸.
+ * `route.ts` 는 이 pure util 위에서 SSE stream 을 조립한다.
+ *
+ * 접근: `fs.watch` 는 Linux append 이벤트 신뢰성이 낮아 (드롭·중복) 폴링 기반으로 파일
+ * 사이즈 성장을 감지한다. 신규 바이트만 UTF-8 로 디코드해 라인 분리, 마지막 불완전
+ * 라인은 다음 poll 까지 `carry` 로 유지한다.
+ */
+
+import fs from 'node:fs'
+
+/** poll 간격 (ms). 실서비스 UX 와 CPU 부하 사이 균형. */
+export const POLL_INTERVAL_MS = 1500
+
+/** SSE keepalive (프록시 idle timeout 방어). */
+export const KEEPALIVE_INTERVAL_MS = 25_000
+
+/**
+ * 한 poll 당 읽어들일 최대 바이트. 로그 폭주(스트레스/부트 로그 대량 flush) 시
+ * 이벤트 루프가 오래 블록되지 않도록 컷.
+ */
+export const MAX_CHUNK_BYTES = 512 * 1024
+
+/**
+ * 신규 라인만 방출하기 위한 라인 분리기.
+ * - chunk 는 이번 poll 에서 새로 읽은 텍스트 (UTF-8 조각일 수 있음).
+ * - carry 는 지난 poll 에서 남긴 불완전 라인 (뒤에 `\n` 이 없던 부분).
+ *
+ * 반환: `lines` 는 완결된 라인 배열 (`\n` 제거 후, 공백만 있는 라인은 제외).
+ *      `carry` 는 마지막 `\n` 이후의 나머지 (다음 poll 로 넘김).
+ *
+ * 마지막 문자가 `\n` 이면 carry 는 빈 문자열.
+ */
+export function splitLinesWithCarryover(
+  chunk: string,
+  carry: string,
+): { lines: string[]; carry: string } {
+  if (!chunk) return { lines: [], carry }
+  const combined = carry + chunk
+  const parts = combined.split('\n')
+  // 마지막 원소는 항상 "마지막 \n 이후" 이므로 carry 로 유지.
+  const nextCarry = parts.pop() ?? ''
+  const lines = parts.filter((l) => l.length > 0)
+  return { lines, carry: nextCarry }
+}
+
+/**
+ * 파일 descriptor 에서 `[from, to)` 구간을 UTF-8 로 읽는다.
+ * `to - from` 이 0 이하이면 빈 문자열.
+ * 실제 읽은 바이트 수가 요청보다 작을 수 있으므로 `bytesRead` 만큼만 반환.
+ *
+ * ⚠️ UTF-8 멀티바이트 문자가 chunk 경계에 걸리면 마지막 문자가 깨질 수 있으나
+ * pino 로그는 대부분 ASCII 이고, 다음 poll 에서 나머지 바이트를 읽어 이어진다.
+ * splitLinesWithCarryover 가 `\n` 기준으로만 라인을 확정하므로 파싱 실패 시
+ * `parseLines` 가 raw 로 표시해 UX 상 큰 문제는 없다 (완결된 라인은 정상).
+ */
+export function readNewBytes(fd: number, from: number, to: number): string {
+  const size = to - from
+  if (size <= 0) return ''
+  const buf = Buffer.alloc(size)
+  const bytesRead = fs.readSync(fd, buf, 0, size, from)
+  if (bytesRead <= 0) return ''
+  return buf.subarray(0, bytesRead).toString('utf-8')
+}


### PR DESCRIPTION
## Summary
- `/admin/mcp-logs` 에 실시간 SSE tail 추가. 폴링(1.5s) 방식으로 오늘 KST 일반 로그의 새 라인만 push.
- 신규 파일: pure tail 유틸 (`src/lib/mcp-logs/tail.ts`), SSE route (`src/app/api/admin/mcp-logs/stream/route.ts`), 클라 컴포넌트 (`src/app/admin/mcp-logs/LiveTailPanel.tsx`).
- self-review P1 3종 (자정 회전 / short-read UTF-8 / lineNo 오해) 반영 완료.

## 설계 결정
- **`fs.watch` 대신 폴링 (1.5s)** — Linux append 이벤트 신뢰성 문제 회피. 대신 최대 1.5s latency + poll 당 `fstat` 1회 (부하 미미).
- **오늘 KST + 일반 로그만** — 스펙 명시. 크래시/과거 날짜는 스코프 밖 (클라 토글 자동 비활성).
- **한 poll 당 512KB cap** — 로그 폭주 시 이벤트 루프 블록 방어.
- **자정 회전 대응** — poll 마다 `todayKst()` 재계산해 date 변경 시 fd 재open + `: rotated <new-date>` comment 전송.
- **short-read/UTF-8 안전** — `readNewBytes` 가 `bytesRead` 반환, route 는 실제 소비만큼만 position 전진. UTF-8 멀티바이트가 chunk 경계에 걸리면 `\n` 앞은 완결 라인으로 방출, 뒤 잘린 부분은 다음 poll 로 자연 재조립.
- **SSE envelope 예외** — 스트리밍 응답은 envelope 미적용. 400 에러 응답은 `fail()` envelope 유지.

## 자원 정리
- `req.signal.abort` → `setInterval` clear + `fs.closeSync(fd)` + `controller.close()`.
- fs 오류 시 `closeFd()` → 다음 poll 에서 `openIfNeeded` 로 재시도.

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (595 tests, +20 신규: tail util 9 + SSE route 12)
- [x] `npm run build` 통과 — `/api/admin/mcp-logs/stream` 라우트 확인
- [x] pr-review-toolkit self-review P1/P2 = 0 (P1 3건 → 전부 fix)

## Closes
Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)