### PR TITLE
[Phase 38-A] cross_ticker TA metric 지원 (#448)

### DIFF
--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -25,7 +25,10 @@ import { buildCustomStrategyContext } from '@/lib/alert-history/context'
 import {
   evaluateStrategy,
   requiresTA,
+  requiresTAForCrossTickers,
   collectCrossTickers,
+  buildCrossTickerSnapshot,
+  type CrossTickerSnapshot,
   type MarketSnapshot,
 } from '@/lib/custom-strategy/evaluator'
 import {
@@ -135,20 +138,15 @@ async function runScan(chatIds: number[]): Promise<void> {
   })
   if (strategies.length === 0) return
 
-  // Phase 34-B (#420): 전략들이 참조하는 크로스 티커도 함께 조회 (같은 쿼리에 병합).
+  // Phase 34-B (#420) / Phase 38-A (#448):
+  // 전략들이 참조하는 크로스 티커까지 통합 조회 + TA 필요 시 TA 리포트도 함께.
   const strategyTickers = Array.from(new Set(strategies.map((s) => s.ticker)))
   const crossSet = collectCrossTickers(strategies)
-  const tickers = strategyTickers
   const allPriceTickers = Array.from(new Set([...strategyTickers, ...crossSet]))
   const prices = await prisma.priceCache.findMany({
     where: { ticker: { in: allPriceTickers } },
   })
   const priceMap = new Map(prices.map((p) => [p.ticker, p]))
-  const crossTickersMap = new Map<string, { price: number; changePercent: number | null }>()
-  for (const t of crossSet) {
-    const p = priceMap.get(t)
-    if (p) crossTickersMap.set(t, { price: p.price, changePercent: p.changePercent })
-  }
 
   // 보유 티커 조회 — holding_status 조건 평가용 (Phase 31-A v2).
   // shares > 0 만 홀딩으로 간주. 여러 계좌에서 같은 티커 보유해도 Set 이므로 중복 무관.
@@ -160,20 +158,23 @@ async function runScan(chatIds: number[]): Promise<void> {
 
   // Phase 34-A (#419): 어닝 캐시 (전략 전체 티커 대상 미리 조회).
   // 캐시 없으면 evaluator 가 자동으로 false 처리 → 안전.
-  const earningsMap = await getEarningsMany(tickers)
+  const earningsMap = await getEarningsMany(strategyTickers)
 
-  // TA 필요한 ticker 만 리포트 생성 (병렬 + 실패 허용)
-  const taByTicker = new Map<string, TAReport | null>()
-
-  // 어느 티커에 TA 가 필요한지 그루핑
+  // Phase 38-A (#448): TA 필요 티커를 자기 + 크로스 티커 모두 합집합으로 수집 → 중복 fetch 방지.
+  // 크로스 티커가 다른 전략의 자기 티커와 동일할 수 있어 Set dedupe 필수.
   const tickersNeedingTA = new Set<string>()
   for (const s of strategies) {
     const raw = Array.isArray(s.conditions) ? (s.conditions as unknown[]) : []
-    const conds = raw.filter(validateCondition)
+    const conds = raw.filter(validateCondition) as Condition[]
     if (conds.length === 0) continue
     if (requiresTA(conds)) tickersNeedingTA.add(s.ticker)
+    for (const t of requiresTAForCrossTickers(conds)) {
+      tickersNeedingTA.add(t)
+    }
   }
 
+  // TA 리포트 병렬 fetch (실패는 null 로 기록해 조건 evaluator 가 false 처리하도록).
+  const taByTicker = new Map<string, TAReport | null>()
   await Promise.all(
     Array.from(tickersNeedingTA).map(async (ticker) => {
       try {
@@ -185,6 +186,15 @@ async function runScan(chatIds: number[]): Promise<void> {
       }
     }),
   )
+
+  // 크로스 티커 스냅샷 구성 — price + (있으면) TA 병합. TA 없는 티커도 price 조건은 여전히 평가 가능.
+  const crossTickersMap = new Map<string, CrossTickerSnapshot>()
+  for (const t of crossSet) {
+    const p = priceMap.get(t)
+    if (!p) continue
+    const ta = taByTicker.get(t) ?? null
+    crossTickersMap.set(t, buildCrossTickerSnapshot({ price: p.price, changePercent: p.changePercent }, ta))
+  }
 
   const now = new Date()
   const alerts: string[] = []

--- a/src/lib/custom-strategy/__tests__/diff.test.ts
+++ b/src/lib/custom-strategy/__tests__/diff.test.ts
@@ -179,6 +179,71 @@ describe('computeStrategyDiff (Phase 35-B / #434)', () => {
     expect(conditionsEqual(a, b)).toBe(false)
   })
 
+  // ── Phase 38-A (#448): cross_ticker TA metric 확장 canonical key 정합
+  it('conditionsEqual — cross_ticker.rsi 같은 값 순서·필드 무관 → true', () => {
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '>=', value: 70,
+      crossTicker: 'SPY', metric: 'rsi',
+    }]
+    const b: Condition[] = [{
+      value: 70, operator: '>=', type: 'cross_ticker',
+      metric: 'rsi', crossTicker: 'spy',
+    } as Condition]
+    expect(conditionsEqual(a, b)).toBe(true)
+  })
+
+  it('conditionsEqual — cross_ticker.macd_signal GOLDEN vs DEAD 다름', () => {
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    }]
+    const b: Condition[] = [{
+      type: 'cross_ticker', operator: '==', value: -1,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('conditionsEqual — cross_ticker.sma_cross vs bb_position 다름 (같은 value 1)', () => {
+    const a: Condition[] = [{
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'sma_cross',
+    }]
+    const b: Condition[] = [{
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'bb_position',
+    }]
+    expect(conditionsEqual(a, b)).toBe(false)
+  })
+
+  it('computeStrategyDiff — cross_ticker rsi 조건 추가 감지', () => {
+    const after: ParsedStrategy = {
+      ...base,
+      conditions: [
+        ...base.conditions,
+        { type: 'cross_ticker', operator: '>=', value: 70, crossTicker: 'SPY', metric: 'rsi' },
+      ],
+    }
+    const d = computeStrategyDiff(base, after)
+    expect(d.conditionsAdded).toHaveLength(1)
+    expect(d.conditionsAdded[0]).toMatchObject({
+      type: 'cross_ticker', metric: 'rsi', value: 70,
+    })
+    expect(d.conditionsRemoved).toEqual([])
+  })
+
+  it('컨텐츠 동일 순서만 다른 여러 cross_ticker TA 조건 → hasDiff false', () => {
+    const conds: Condition[] = [
+      { type: 'cross_ticker', operator: '==', value: 1, crossTicker: 'SPY', metric: 'macd_signal' },
+      { type: 'cross_ticker', operator: '==', value: -1, crossTicker: 'SPY', metric: 'bb_position' },
+      { type: 'cross_ticker', operator: '>=', value: 70, crossTicker: 'SPY', metric: 'rsi' },
+    ]
+    const before: ParsedStrategy = { ...base, conditions: conds }
+    // 순서만 뒤바꿈
+    const after: ParsedStrategy = { ...base, conditions: [conds[2], conds[0], conds[1]] }
+    expect(hasDiff(computeStrategyDiff(before, after))).toBe(false)
+  })
+
   it('복합 변경 (logic + 조건 추가 + 조건 제거)', () => {
     const after: ParsedStrategy = {
       name: base.name,

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -623,16 +623,18 @@ describe('buildCrossTickerSnapshot (Phase 38-A / #448)', () => {
     expect(snap.rsi).toBeUndefined()
     expect(snap.macdCrossover).toBeUndefined()
     expect(snap.bbPosition).toBeUndefined()
-    expect(snap.smaCross).toBeUndefined()
+    expect(snap.smaGoldenCross).toBeUndefined()
+    expect(snap.smaDeathCross).toBeUndefined()
   })
 
-  it('TA 있음 → RSI / MACD 없음(NONE) / BB 축약 / SMA NONE', () => {
+  it('TA 있음 → RSI / MACD 없음(NONE) / BB 축약 / SMA 둘 다 false', () => {
     const ta = makeTAReport() // 기본 = 중립 지표 (crossover 없음, position=MIDDLE)
     const snap = buildCrossTickerSnapshot(price, ta)
     expect(snap.rsi).toBe(50)
     expect(snap.macdCrossover).toBe('NONE') // crossover undefined → NONE
     expect(snap.bbPosition).toBe('WITHIN')  // MIDDLE → WITHIN
-    expect(snap.smaCross).toBe('NONE')      // golden/dead 모두 false
+    expect(snap.smaGoldenCross).toBe(false)
+    expect(snap.smaDeathCross).toBe(false)
   })
 
   it('TA GOLDEN 크로스오버 + BB ABOVE_UPPER 반영', () => {
@@ -648,7 +650,8 @@ describe('buildCrossTickerSnapshot (Phase 38-A / #448)', () => {
     const snap = buildCrossTickerSnapshot(price, ta)
     expect(snap.macdCrossover).toBe('GOLDEN')
     expect(snap.bbPosition).toBe('ABOVE_UPPER')
-    expect(snap.smaCross).toBe('GOLDEN')
+    expect(snap.smaGoldenCross).toBe(true)
+    expect(snap.smaDeathCross).toBe(false)
   })
 
   it('TA DEAD 크로스오버 + BB BELOW_LOWER 반영', () => {
@@ -664,7 +667,23 @@ describe('buildCrossTickerSnapshot (Phase 38-A / #448)', () => {
     const snap = buildCrossTickerSnapshot(price, ta)
     expect(snap.macdCrossover).toBe('DEAD')
     expect(snap.bbPosition).toBe('BELOW_LOWER')
-    expect(snap.smaCross).toBe('DEAD')
+    expect(snap.smaGoldenCross).toBe(false)
+    expect(snap.smaDeathCross).toBe(true)
+  })
+
+  // Codex #457 P2 회귀 방지 — whipsaw 시 두 flag 동시 true 는 각각 보존되어야
+  // `sma_cross == -1` 조건이 death 를 감지할 수 있음.
+  it('TA whipsaw (goldenCross + deathCross 동시 true) → 두 flag 모두 true 로 보존', () => {
+    const base = makeTAReport()
+    const ta = makeTAReport({
+      indicators: {
+        ...base.indicators,
+        sma: { ...base.indicators.sma, goldenCross: true, deathCross: true },
+      },
+    })
+    const snap = buildCrossTickerSnapshot(price, ta)
+    expect(snap.smaGoldenCross).toBe(true)
+    expect(snap.smaDeathCross).toBe(true)
   })
 
   it('rsi 값 NaN → rsi undefined (defense in depth)', () => {
@@ -766,11 +785,13 @@ describe('evaluateCondition — v3.1 cross_ticker TA metric (Phase 38-A / #448)'
     expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
   })
 
-  // sma_cross
+  // sma_cross — Codex #457 P2: golden/death 는 독립 flag 로 저장, whipsaw 방어.
   it('sma_cross == 1 (GOLDEN) 매치', () => {
     const ctx = makeContext({
       strategyTicker,
-      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, smaCross: 'GOLDEN' }]]),
+      crossTickers: new Map([['SPY', {
+        price: 400, changePercent: 0, smaGoldenCross: true, smaDeathCross: false,
+      }]]),
     })
     const cond: Condition = {
       type: 'cross_ticker', operator: '==', value: 1,
@@ -779,10 +800,12 @@ describe('evaluateCondition — v3.1 cross_ticker TA metric (Phase 38-A / #448)'
     expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
   })
 
-  it('sma_cross == -1 (DEAD) & NONE → false', () => {
+  it('sma_cross == -1 (DEAD) & 둘 다 false → false', () => {
     const ctx = makeContext({
       strategyTicker,
-      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, smaCross: 'NONE' }]]),
+      crossTickers: new Map([['SPY', {
+        price: 400, changePercent: 0, smaGoldenCross: false, smaDeathCross: false,
+      }]]),
     })
     const cond: Condition = {
       type: 'cross_ticker', operator: '==', value: -1,
@@ -791,7 +814,7 @@ describe('evaluateCondition — v3.1 cross_ticker TA metric (Phase 38-A / #448)'
     expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
   })
 
-  it('sma_cross undefined → false', () => {
+  it('sma_cross flag 미주입 (undefined) → false', () => {
     const ctx = makeContext({
       strategyTicker,
       crossTickers: new Map([['SPY', { price: 400, changePercent: 0 }]]),
@@ -801,6 +824,28 @@ describe('evaluateCondition — v3.1 cross_ticker TA metric (Phase 38-A / #448)'
       crossTicker: 'SPY', metric: 'sma_cross',
     }
     expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  // Codex #457 P2 회귀 방지 — whipsaw (goldenCross + deathCross 동시 true) 에서
+  // 이전 축약 enum (`smaCross`) 은 GOLDEN 우선 → DEAD 조건 방출 실패했음.
+  // 이제 두 flag 를 독립 검사 → death 조건도 정확히 매치.
+  it('sma_cross whipsaw: 두 flag 모두 true 이면 == 1, == -1 모두 매치', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', {
+        price: 400, changePercent: 0, smaGoldenCross: true, smaDeathCross: true,
+      }]]),
+    })
+    const golden: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'sma_cross',
+    }
+    const dead: Condition = {
+      type: 'cross_ticker', operator: '==', value: -1,
+      crossTicker: 'SPY', metric: 'sma_cross',
+    }
+    expect(evaluateCondition(golden, makeSnapshot(), ctx)).toBe(true)
+    expect(evaluateCondition(dead, makeSnapshot(), ctx)).toBe(true)  // 이전 버그: false 였음
   })
 
   // bb_position

--- a/src/lib/custom-strategy/__tests__/evaluator.test.ts
+++ b/src/lib/custom-strategy/__tests__/evaluator.test.ts
@@ -3,8 +3,11 @@ import {
   evaluateCondition,
   evaluateStrategy,
   requiresTA,
+  requiresTAForCrossTickers,
   daysUntilEarnings,
   collectCrossTickers,
+  buildCrossTickerSnapshot,
+  mapCrossTickerBBPosition,
   type MarketSnapshot,
   type EvaluationContext,
 } from '../evaluator'
@@ -538,5 +541,326 @@ describe('requiresTA', () => {
       type: 'cross_ticker', operator: '<=', value: -2,
       crossTicker: 'SPY', metric: 'change_percent',
     }])).toBe(false)
+  })
+
+  // Phase 38-A (#448): 자기 티커 requiresTA 는 크로스 TA 조건에 반응하지 않음.
+  // 크로스 티커 TA 는 별도 requiresTAForCrossTickers 로 관리.
+  it('v3.1 cross_ticker.rsi → 자기 티커 TA 필요 아님 (requiresTA=false)', () => {
+    expect(requiresTA([{
+      type: 'cross_ticker', operator: '>=', value: 70,
+      crossTicker: 'SPY', metric: 'rsi',
+    }])).toBe(false)
+  })
+})
+
+// ─── Phase 38-A (#448) —
+describe('requiresTAForCrossTickers (Phase 38-A / #448)', () => {
+  it('price/change_percent 만 있는 cross_ticker → 빈 Set', () => {
+    expect(requiresTAForCrossTickers([
+      { type: 'cross_ticker', operator: '<=', value: -2, crossTicker: 'SPY', metric: 'change_percent' },
+      { type: 'cross_ticker', operator: '>', value: 25, crossTicker: 'VIX', metric: 'price' },
+    ])).toEqual(new Set())
+  })
+
+  it('rsi/macd_signal/sma_cross/bb_position 각각 TA 필요 티커 반환', () => {
+    const conds: Condition[] = [
+      { type: 'cross_ticker', operator: '>=', value: 70, crossTicker: 'spy', metric: 'rsi' },
+      { type: 'cross_ticker', operator: '==', value: 1, crossTicker: 'QQQ', metric: 'macd_signal' },
+      { type: 'cross_ticker', operator: '==', value: -1, crossTicker: 'iwm', metric: 'sma_cross' },
+      { type: 'cross_ticker', operator: '==', value: -1, crossTicker: 'DIA', metric: 'bb_position' },
+    ]
+    // 대문자 정규화 확인
+    expect(requiresTAForCrossTickers(conds)).toEqual(new Set(['SPY', 'QQQ', 'IWM', 'DIA']))
+  })
+
+  it('여러 cross_ticker 가 같은 티커 참조 시 dedupe', () => {
+    const conds: Condition[] = [
+      { type: 'cross_ticker', operator: '>=', value: 70, crossTicker: 'SPY', metric: 'rsi' },
+      { type: 'cross_ticker', operator: '==', value: 1, crossTicker: 'SPY', metric: 'macd_signal' },
+    ]
+    expect(requiresTAForCrossTickers(conds)).toEqual(new Set(['SPY']))
+  })
+
+  it('비-cross_ticker 조건 무시', () => {
+    const conds: Condition[] = [
+      { type: 'price', operator: '<=', value: 100 },
+      { type: 'rsi', operator: '<=', value: 30 }, // 자기 티커 TA
+    ]
+    expect(requiresTAForCrossTickers(conds)).toEqual(new Set())
+  })
+
+  it('crossTicker 누락/공백은 무시', () => {
+    // as unknown 를 통한 손상된 payload 방어 확인
+    const conds = [
+      { type: 'cross_ticker', operator: '>=', value: 70, metric: 'rsi' },
+      { type: 'cross_ticker', operator: '>=', value: 70, crossTicker: '   ', metric: 'rsi' },
+      { type: 'cross_ticker', operator: '>=', value: 70, crossTicker: 'SPY', metric: 'rsi' },
+    ] as unknown as Condition[]
+    expect(requiresTAForCrossTickers(conds)).toEqual(new Set(['SPY']))
+  })
+})
+
+describe('mapCrossTickerBBPosition (Phase 38-A / #448)', () => {
+  it('ABOVE_UPPER → ABOVE_UPPER', () => {
+    expect(mapCrossTickerBBPosition('ABOVE_UPPER')).toBe('ABOVE_UPPER')
+  })
+  it('BELOW_LOWER → BELOW_LOWER', () => {
+    expect(mapCrossTickerBBPosition('BELOW_LOWER')).toBe('BELOW_LOWER')
+  })
+  it('NEAR_UPPER / MIDDLE / NEAR_LOWER 모두 WITHIN 으로 축약', () => {
+    expect(mapCrossTickerBBPosition('NEAR_UPPER')).toBe('WITHIN')
+    expect(mapCrossTickerBBPosition('MIDDLE')).toBe('WITHIN')
+    expect(mapCrossTickerBBPosition('NEAR_LOWER')).toBe('WITHIN')
+  })
+})
+
+describe('buildCrossTickerSnapshot (Phase 38-A / #448)', () => {
+  const price = { price: 400, changePercent: -1.5 }
+
+  it('TA 없음 → price 필드만 채움 (TA 필드 undefined)', () => {
+    const snap = buildCrossTickerSnapshot(price, null)
+    expect(snap).toEqual({ price: 400, changePercent: -1.5 })
+    expect(snap.rsi).toBeUndefined()
+    expect(snap.macdCrossover).toBeUndefined()
+    expect(snap.bbPosition).toBeUndefined()
+    expect(snap.smaCross).toBeUndefined()
+  })
+
+  it('TA 있음 → RSI / MACD 없음(NONE) / BB 축약 / SMA NONE', () => {
+    const ta = makeTAReport() // 기본 = 중립 지표 (crossover 없음, position=MIDDLE)
+    const snap = buildCrossTickerSnapshot(price, ta)
+    expect(snap.rsi).toBe(50)
+    expect(snap.macdCrossover).toBe('NONE') // crossover undefined → NONE
+    expect(snap.bbPosition).toBe('WITHIN')  // MIDDLE → WITHIN
+    expect(snap.smaCross).toBe('NONE')      // golden/dead 모두 false
+  })
+
+  it('TA GOLDEN 크로스오버 + BB ABOVE_UPPER 반영', () => {
+    const base = makeTAReport()
+    const ta = makeTAReport({
+      indicators: {
+        ...base.indicators,
+        macd: { ...base.indicators.macd, crossover: 'GOLDEN' },
+        bollingerBands: { ...base.indicators.bollingerBands, position: 'ABOVE_UPPER' },
+        sma: { ...base.indicators.sma, goldenCross: true },
+      },
+    })
+    const snap = buildCrossTickerSnapshot(price, ta)
+    expect(snap.macdCrossover).toBe('GOLDEN')
+    expect(snap.bbPosition).toBe('ABOVE_UPPER')
+    expect(snap.smaCross).toBe('GOLDEN')
+  })
+
+  it('TA DEAD 크로스오버 + BB BELOW_LOWER 반영', () => {
+    const base = makeTAReport()
+    const ta = makeTAReport({
+      indicators: {
+        ...base.indicators,
+        macd: { ...base.indicators.macd, crossover: 'DEAD' },
+        bollingerBands: { ...base.indicators.bollingerBands, position: 'BELOW_LOWER' },
+        sma: { ...base.indicators.sma, deathCross: true },
+      },
+    })
+    const snap = buildCrossTickerSnapshot(price, ta)
+    expect(snap.macdCrossover).toBe('DEAD')
+    expect(snap.bbPosition).toBe('BELOW_LOWER')
+    expect(snap.smaCross).toBe('DEAD')
+  })
+
+  it('rsi 값 NaN → rsi undefined (defense in depth)', () => {
+    const base = makeTAReport()
+    const ta = makeTAReport({
+      indicators: { ...base.indicators, rsi14: { value: NaN, signal: 'NEUTRAL' } },
+    })
+    const snap = buildCrossTickerSnapshot(price, ta)
+    expect(snap.rsi).toBeUndefined()
+  })
+})
+
+describe('evaluateCondition — v3.1 cross_ticker TA metric (Phase 38-A / #448)', () => {
+  const strategyTicker = 'QQQ'
+
+  // rsi
+  it('rsi >= 70 & 크로스 티커 RSI 75 → true', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, rsi: 75 }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>=', value: 70,
+      crossTicker: 'SPY', metric: 'rsi',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('rsi >= 70 & 크로스 티커 RSI 50 → false', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, rsi: 50 }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>=', value: 70,
+      crossTicker: 'SPY', metric: 'rsi',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('rsi 필드 undefined (TA 미주입/fetch 실패) → false', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0 }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '>=', value: 70,
+      crossTicker: 'SPY', metric: 'rsi',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  // macd_signal
+  it('macd_signal == 1 (GOLDEN) & 크로스 티커 GOLDEN → true', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, macdCrossover: 'GOLDEN' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('macd_signal == -1 (DEAD) & 크로스 티커 GOLDEN → false', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, macdCrossover: 'GOLDEN' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: -1,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('macd_signal == 0 (NONE) & 크로스 티커 NONE → true', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, macdCrossover: 'NONE' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 0,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('macd_signal 필드 undefined → false (TA 미주입)', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0 }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  // sma_cross
+  it('sma_cross == 1 (GOLDEN) 매치', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, smaCross: 'GOLDEN' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'sma_cross',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('sma_cross == -1 (DEAD) & NONE → false', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, smaCross: 'NONE' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: -1,
+      crossTicker: 'SPY', metric: 'sma_cross',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('sma_cross undefined → false', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0 }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'sma_cross',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  // bb_position
+  it('bb_position == 1 (ABOVE_UPPER) 매치', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, bbPosition: 'ABOVE_UPPER' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'bb_position',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('bb_position == 0 (WITHIN) 매치', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, bbPosition: 'WITHIN' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 0,
+      crossTicker: 'SPY', metric: 'bb_position',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('bb_position == -1 (BELOW_LOWER) 매치', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, bbPosition: 'BELOW_LOWER' }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: -1,
+      crossTicker: 'SPY', metric: 'bb_position',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(true)
+  })
+
+  it('bb_position undefined → false', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0 }]]),
+    })
+    const cond: Condition = {
+      type: 'cross_ticker', operator: '==', value: 1,
+      crossTicker: 'SPY', metric: 'bb_position',
+    }
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
+  })
+
+  it('macd_signal != == (>=) → false (evaluator 방어)', () => {
+    const ctx = makeContext({
+      strategyTicker,
+      crossTickers: new Map([['SPY', { price: 400, changePercent: 0, macdCrossover: 'GOLDEN' }]]),
+    })
+    const cond = {
+      type: 'cross_ticker', operator: '>=', value: 1,
+      crossTicker: 'SPY', metric: 'macd_signal',
+    } as unknown as Condition
+    expect(evaluateCondition(cond, makeSnapshot(), ctx)).toBe(false)
   })
 })

--- a/src/lib/custom-strategy/__tests__/parser.test.ts
+++ b/src/lib/custom-strategy/__tests__/parser.test.ts
@@ -43,4 +43,19 @@ describe('PROMPT_HEADER — cross_ticker 신규 metric 문서화 (Phase 38-A #44
     expect(PROMPT_HEADER).toMatch(/"metric":"sma_cross"/)
     expect(PROMPT_HEADER).toMatch(/"metric":"bb_position"/)
   })
+
+  // Codex #457 P2 회귀 방지 — RSI 예시가 사용자 자연어와 방향 일치해야 함.
+  // 조건 = 알림 발동 조건. "SPY RSI 70 이상 과매수면 회피 알림" → operator=`>=`, value=70.
+  // 이전에는 `<` 로 잘못 적혀 저장 시 반대 상황 (RSI 70 미만) 에서 알림 발동됐음.
+  it('RSI 크로스 티커 예시가 "이상 과매수" 자연어와 일치하는 operator 사용 (>= 아닌 <)', () => {
+    // RSI 예시 JSON 전체를 추출 — "metric":"rsi" 를 포함하는 최소 { ... } 블록.
+    // v1 예시의 `{"type":"rsi","operator":"<=","value":30}` 는 metric 필드가 없으므로
+    // 매칭되지 않음 → cross_ticker 예시만 선택됨.
+    const rsiExampleMatch = PROMPT_HEADER.match(/\{[^{}]*"metric":"rsi"[^{}]*\}/)
+    expect(rsiExampleMatch).not.toBeNull()
+    const rsiExample = rsiExampleMatch![0]
+    // ">=" 여야 함 (사용자 "이상" 표현과 일치). "<" 이면 방향 반전 회귀.
+    expect(rsiExample).toContain('"operator":">="')
+    expect(rsiExample).not.toContain('"operator":"<"')
+  })
 })

--- a/src/lib/custom-strategy/__tests__/parser.test.ts
+++ b/src/lib/custom-strategy/__tests__/parser.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Phase 38-A (#448) — parser 프롬프트 문서화 회귀 방지.
+ *
+ * Codex #457 P2: 스키마 확장 (types.ts 의 CrossTickerMetric) 만으로는 자연어 진입
+ * 경로 (parseStrategyText / editStrategyByNL) 가 새 metric 을 생성할 수 없다.
+ * AI 프롬프트가 metric 목록·인코딩·예시를 명시해야 사용자가 실제로 활용 가능.
+ *
+ * PROMPT_HEADER 는 등록/편집 양쪽에서 재사용되므로 여기서 한번 검증하면 두 경로
+ * 모두 커버.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { PROMPT_HEADER } from '../parser'
+
+describe('PROMPT_HEADER — cross_ticker 신규 metric 문서화 (Phase 38-A #448 회귀)', () => {
+  it('metric 4종 이름을 모두 언급', () => {
+    expect(PROMPT_HEADER).toContain('"rsi"')
+    expect(PROMPT_HEADER).toContain('"macd_signal"')
+    expect(PROMPT_HEADER).toContain('"sma_cross"')
+    expect(PROMPT_HEADER).toContain('"bb_position"')
+  })
+
+  it('카테고리컬 metric 은 == operator 만 허용됨을 명시', () => {
+    // 3종 모두 "==" 로만 쓸 수 있음을 언급 — AI 가 다른 operator 를 생성하지 않도록.
+    expect(PROMPT_HEADER).toContain('operator 는 "==" 만')
+  })
+
+  it('정수 인코딩 컨벤션 (1=GOLDEN, 0=NONE/WITHIN, -1=DEAD/BELOW) 명시', () => {
+    expect(PROMPT_HEADER).toMatch(/1=GOLDEN/)
+    expect(PROMPT_HEADER).toMatch(/-1=DEAD/)
+    expect(PROMPT_HEADER).toMatch(/1=ABOVE_UPPER/)
+    expect(PROMPT_HEADER).toMatch(/-1=BELOW_LOWER/)
+  })
+
+  it('rsi 값 범위 (0~100) 명시', () => {
+    expect(PROMPT_HEADER).toContain('0~100')
+  })
+
+  it('cross_ticker v3 예시에 각 신규 metric 이 실제 JSON 으로 등장', () => {
+    // 예시 없이 목록만 보면 AI 가 필드명을 유추 실패할 수 있음 — 실 JSON 예시 필수.
+    expect(PROMPT_HEADER).toMatch(/"metric":"rsi"/)
+    expect(PROMPT_HEADER).toMatch(/"metric":"macd_signal"/)
+    expect(PROMPT_HEADER).toMatch(/"metric":"sma_cross"/)
+    expect(PROMPT_HEADER).toMatch(/"metric":"bb_position"/)
+  })
+})

--- a/src/lib/custom-strategy/__tests__/types.test.ts
+++ b/src/lib/custom-strategy/__tests__/types.test.ts
@@ -274,9 +274,11 @@ describe('cross_ticker (v3, Phase 34-B / #420)', () => {
   })
 
   it('metric 화이트리스트 외 → false', () => {
+    // Phase 38-A (#448) 이후 rsi/macd_signal/sma_cross/bb_position 도 유효.
+    // 여전히 무효인 임의 문자열 metric 으로 확인.
     expect(validateCondition({
       type: 'cross_ticker', operator: '<=', value: 0,
-      crossTicker: 'SPY', metric: 'rsi',
+      crossTicker: 'SPY', metric: 'volume',
     })).toBe(false)
     expect(validateCondition({
       type: 'cross_ticker', operator: '<=', value: 0, crossTicker: 'SPY',
@@ -297,5 +299,183 @@ describe('conditionToString — cross_ticker', () => {
       type: 'cross_ticker', operator: '<=', value: -2,
       crossTicker: 'SPY', metric: 'change_percent',
     })).toBe('SPY.change_percent <= -2')
+  })
+})
+
+describe('cross_ticker TA metric (Phase 38-A / #448)', () => {
+  describe('validateCondition — rsi', () => {
+    it('SPY.rsi >= 70 유효 (숫자 op + 0~100)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '>=', value: 70,
+        crossTicker: 'SPY', metric: 'rsi',
+      })).toBe(true)
+    })
+
+    it('rsi 값 -1 → false (0 미만)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '<=', value: -1,
+        crossTicker: 'SPY', metric: 'rsi',
+      })).toBe(false)
+    })
+
+    it('rsi 값 101 → false (100 초과)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '>=', value: 101,
+        crossTicker: 'SPY', metric: 'rsi',
+      })).toBe(false)
+    })
+
+    it('rsi 임의 numeric op 모두 허용 (< / <= / > / >= / ==)', () => {
+      for (const op of ['<', '<=', '>', '>=', '==']) {
+        expect(validateCondition({
+          type: 'cross_ticker', operator: op, value: 50,
+          crossTicker: 'SPY', metric: 'rsi',
+        })).toBe(true)
+      }
+    })
+  })
+
+  describe('validateCondition — macd_signal (== 만, threshold ∈ {-1,0,1})', () => {
+    it('== 1 (GOLDEN) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 1,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe(true)
+    })
+    it('== 0 (NONE) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 0,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe(true)
+    })
+    it('== -1 (DEAD) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: -1,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe(true)
+    })
+    it('== 2 → 무효 (허용 집합 밖)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 2,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe(false)
+    })
+    it('>= 1 → 무효 (== 만 허용)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '>=', value: 1,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe(false)
+    })
+    it('== 0.5 → 무효 (정수만)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 0.5,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe(false)
+    })
+  })
+
+  describe('validateCondition — sma_cross (== 만, threshold ∈ {-1,1})', () => {
+    it('== 1 (GOLDEN) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 1,
+        crossTicker: 'SPY', metric: 'sma_cross',
+      })).toBe(true)
+    })
+    it('== -1 (DEAD) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: -1,
+        crossTicker: 'SPY', metric: 'sma_cross',
+      })).toBe(true)
+    })
+    it('== 0 → 무효 (sma_cross 는 NONE 없음)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 0,
+        crossTicker: 'SPY', metric: 'sma_cross',
+      })).toBe(false)
+    })
+    it('< -1 → 무효 (== 아님)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '<', value: -1,
+        crossTicker: 'SPY', metric: 'sma_cross',
+      })).toBe(false)
+    })
+  })
+
+  describe('validateCondition — bb_position (== 만, threshold ∈ {-1,0,1})', () => {
+    it('== 1 (ABOVE_UPPER) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 1,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe(true)
+    })
+    it('== 0 (WITHIN) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 0,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe(true)
+    })
+    it('== -1 (BELOW_LOWER) 유효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: -1,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe(true)
+    })
+    it('== 3 → 무효', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '==', value: 3,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe(false)
+    })
+    it('> 0 → 무효 (== 만)', () => {
+      expect(validateCondition({
+        type: 'cross_ticker', operator: '>', value: 0,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe(false)
+    })
+  })
+
+  describe('conditionToString — 카테고리컬 metric 은 라벨로 렌더', () => {
+    it('macd_signal 1 → GOLDEN', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '==', value: 1,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe('SPY.macd_signal == GOLDEN')
+    })
+    it('macd_signal -1 → DEAD', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '==', value: -1,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe('SPY.macd_signal == DEAD')
+    })
+    it('macd_signal 0 → NONE', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '==', value: 0,
+        crossTicker: 'SPY', metric: 'macd_signal',
+      })).toBe('SPY.macd_signal == NONE')
+    })
+    it('sma_cross 1 → GOLDEN', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '==', value: 1,
+        crossTicker: 'SPY', metric: 'sma_cross',
+      })).toBe('SPY.sma_cross == GOLDEN')
+    })
+    it('bb_position -1 → BELOW_LOWER', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '==', value: -1,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe('SPY.bb_position == BELOW_LOWER')
+    })
+    it('bb_position 0 → WITHIN', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '==', value: 0,
+        crossTicker: 'SPY', metric: 'bb_position',
+      })).toBe('SPY.bb_position == WITHIN')
+    })
+    it('rsi 는 라벨링 없음 — 원본 숫자', () => {
+      expect(conditionToString({
+        type: 'cross_ticker', operator: '>=', value: 70,
+        crossTicker: 'SPY', metric: 'rsi',
+      })).toBe('SPY.rsi >= 70')
+    })
   })
 })

--- a/src/lib/custom-strategy/diff.ts
+++ b/src/lib/custom-strategy/diff.ts
@@ -27,6 +27,9 @@ export interface StrategyDiff {
  *     타입에 timeframe 이 붙어 와도 evaluator 는 무시 → canonical 에서도 배제
  *     (#440 재재재재리뷰 P2). conditionToString 이 timeframe 을 어느 타입에나 렌더
  *     하는 것이 문제 원인.
+ *   - Phase 38-A (#448) — cross_ticker.metric 확장 (rsi/macd_signal/sma_cross/bb_position).
+ *     canonical key 는 raw 숫자값을 사용하므로 metric 별 카테고리컬 라벨링 (`GOLDEN`/`DEAD` 등)
+ *     이 conditionToString 에서만 렌더되고 diff 판정에는 영향 없음 (evaluator 도 raw 숫자로 비교).
  */
 function condKey(c: Condition): string {
   if (c.type === 'weekday' && Array.isArray(c.value)) {

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -42,7 +42,11 @@ export interface MarketSnapshot {
  * - `macdCrossover`: TA 의 optional `crossover` 를 `NONE` 으로 정규화해 "이벤트 없음" 도 표현.
  * - `bbPosition`  : TA 의 5-값 (NEAR_UPPER, MIDDLE, NEAR_LOWER 포함) 을 3-값
  *   (ABOVE_UPPER / WITHIN / BELOW_LOWER) 로 축약 — 사용자 조건 어휘 (극단/중간) 와 정합.
- * - `smaCross`    : TA 의 goldenCross/deathCross boolean 을 단일 enum 으로 표준화.
+ * - `smaGoldenCross` / `smaDeathCross`: TA 엔진의 5거래일 창 안에서는 whipsaw
+ *   케이스로 두 flag 가 동시에 true 가 될 수 있음 (`src/lib/ta/engine.ts:134-138`).
+ *   단일 enum 으로 축약하면 GOLDEN 우선 판정 → `sma_cross == -1` 조건이 실제 death
+ *   가 있어도 방출 못함 (Codex #457 P2). self-ticker evaluator 처럼 두 flag 를
+ *   독립 저장 → 조건별로 정확한 flag 검사.
  */
 export interface CrossTickerSnapshot {
   price: number
@@ -50,7 +54,8 @@ export interface CrossTickerSnapshot {
   rsi?: number
   macdCrossover?: 'GOLDEN' | 'DEAD' | 'NONE'
   bbPosition?: 'ABOVE_UPPER' | 'WITHIN' | 'BELOW_LOWER'
-  smaCross?: 'GOLDEN' | 'DEAD' | 'NONE'
+  smaGoldenCross?: boolean
+  smaDeathCross?: boolean
 }
 
 /**
@@ -256,9 +261,10 @@ export function evaluateCondition(
         }
         case 'sma_cross': {
           if (cond.operator !== '==') return false
-          if (cross.smaCross === undefined) return false
-          if (cond.value === 1) return cross.smaCross === 'GOLDEN'
-          if (cond.value === -1) return cross.smaCross === 'DEAD'
+          // Codex #457 P2: whipsaw 상황에서 golden/death 두 flag 가 동시에 true 일 수
+          // 있음. 조건별로 정확한 flag 를 검사 (self-ticker case 167-172 와 동일 규칙).
+          if (cond.value === 1) return cross.smaGoldenCross === true
+          if (cond.value === -1) return cross.smaDeathCross === true
           return false
         }
         case 'bb_position': {
@@ -355,16 +361,16 @@ export function buildCrossTickerSnapshot(
     return { price: price.price, changePercent: price.changePercent }
   }
   const { rsi14, macd, bollingerBands, sma } = ta.indicators
-  const smaCross: 'GOLDEN' | 'DEAD' | 'NONE' =
-    sma.goldenCross === true ? 'GOLDEN' :
-    sma.deathCross === true ? 'DEAD' : 'NONE'
+  // Codex #457 P2: golden/death 두 flag 를 독립 저장 (whipsaw 시 동시 true 케이스
+  // 방어). 이전에는 GOLDEN 우선 축약 → DEAD 조건 방출 실패.
   return {
     price: price.price,
     changePercent: price.changePercent,
     rsi: Number.isFinite(rsi14.value) ? rsi14.value : undefined,
     macdCrossover: macd.crossover ?? 'NONE',
     bbPosition: mapCrossTickerBBPosition(bollingerBands.position),
-    smaCross,
+    smaGoldenCross: sma.goldenCross === true,
+    smaDeathCross: sma.deathCross === true,
   }
 }
 

--- a/src/lib/custom-strategy/evaluator.ts
+++ b/src/lib/custom-strategy/evaluator.ts
@@ -3,18 +3,20 @@
  *
  * v1 (Phase 29-E): price/rsi/macd_signal/sma_cross/bb_position/change_pct
  * v2 (Phase 31-A): time_window/weekday/holding_status
+ * v3 (Phase 34-A/B): earnings_within_days + cross_ticker (price/change_percent)
+ * v3.1 (Phase 38-A #448): cross_ticker metric 을 TA 지표 (rsi/macd_signal/sma_cross/bb_position) 로 확장
  *
  * 입력:
  *   - Condition[]: 사용자 정의 조건 (parser 로 자연어 파싱된 결과)
  *   - MarketSnapshot: priceCache + (필요 시) TAReport
- *   - EvaluationContext: 시각 + 보유 티커 (v2 조건 대비)
+ *   - EvaluationContext: 시각 + 보유 티커 (v2 조건 대비) + 크로스-티커 스냅샷 (v3)
  *
  * 출력: 각 조건 만족 여부 boolean[] → logic (AND/OR) 결합 → 최종 만족 여부
  */
 
 import type { Condition, WeekdayCode } from './types'
 import { TIME_WINDOW_RE } from './types'
-import type { TAReport } from '@/lib/ta/types'
+import type { TAReport, BBPosition } from '@/lib/ta/types'
 import { kstDayDiff } from '@/lib/kst-date'
 
 export interface PriceSnapshot {
@@ -33,6 +35,25 @@ export interface MarketSnapshot {
 }
 
 /**
+ * Phase 38-A (#448) — 크로스-티커 스냅샷 shape.
+ * 기존 price/changePercent 는 항상 채워짐 (PriceCache 에 있을 때).
+ * TA 필드는 해당 티커의 TA 리포트가 필요/성공 시에만 채워짐 (미채움 = undefined → 조건 false).
+ *
+ * - `macdCrossover`: TA 의 optional `crossover` 를 `NONE` 으로 정규화해 "이벤트 없음" 도 표현.
+ * - `bbPosition`  : TA 의 5-값 (NEAR_UPPER, MIDDLE, NEAR_LOWER 포함) 을 3-값
+ *   (ABOVE_UPPER / WITHIN / BELOW_LOWER) 로 축약 — 사용자 조건 어휘 (극단/중간) 와 정합.
+ * - `smaCross`    : TA 의 goldenCross/deathCross boolean 을 단일 enum 으로 표준화.
+ */
+export interface CrossTickerSnapshot {
+  price: number
+  changePercent: number | null
+  rsi?: number
+  macdCrossover?: 'GOLDEN' | 'DEAD' | 'NONE'
+  bbPosition?: 'ABOVE_UPPER' | 'WITHIN' | 'BELOW_LOWER'
+  smaCross?: 'GOLDEN' | 'DEAD' | 'NONE'
+}
+
+/**
  * v2 조건 평가에 필요한 런타임 컨텍스트.
  * 호출자 (custom-strategy-alert.ts) 가 준비해서 주입.
  */
@@ -44,11 +65,12 @@ export interface EvaluationContext {
   /** 평가 대상 티커 — holding_status 판정용 (Strategy.ticker 주입) */
   strategyTicker: string
   /**
-   * Phase 34-B (#420): 크로스-티커 조건 참조용 스냅샷 맵.
+   * Phase 34-B (#420) / Phase 38-A (#448): 크로스-티커 조건 참조용 스냅샷 맵.
    * key = 대문자 정규화된 티커. 호출자가 전략들의 모든 crossTicker 를 미리 조회해 주입.
    * 미주입 or 특정 티커 없음 → cross_ticker 조건 false (안전측).
+   * TA metric 조건은 스냅샷에 해당 TA 필드가 채워져 있어야 참 판정 가능.
    */
-  crossTickers?: Map<string, { price: number; changePercent: number | null }>
+  crossTickers?: Map<string, CrossTickerSnapshot>
 }
 
 /** 지원 조건 타입 중 TA 필요 여부 판단 — 평가 전에 TAReport fetch 여부 결정 */
@@ -201,19 +223,55 @@ export function evaluateCondition(
       if (days == null) return false
       return compareNumeric(days, cond.operator, cond.value)
     }
-    // ── v3 (Phase 34-B #420) —
+    // ── v3 (Phase 34-B #420) / Phase 38-A (#448) —
     case 'cross_ticker': {
       if (typeof cond.value !== 'number') return false
       if (typeof cond.crossTicker !== 'string' || !cond.crossTicker.trim()) return false
-      if (cond.metric !== 'price' && cond.metric !== 'change_percent') return false
-      const target = cond.crossTicker.trim().toUpperCase()
+      const metric = cond.metric
       // 자기 자신 참조 방지 — 사용자가 실수로 등록해도 무의미한 tautology 회피.
+      const target = cond.crossTicker.trim().toUpperCase()
       if (target === context.strategyTicker) return false
       const cross = context.crossTickers?.get(target)
       if (!cross) return false
-      const actual = cond.metric === 'price' ? cross.price : cross.changePercent
-      if (actual == null || !Number.isFinite(actual)) return false
-      return compareNumeric(actual, cond.operator, cond.value)
+
+      switch (metric) {
+        case 'price':
+        case 'change_percent': {
+          const actual = metric === 'price' ? cross.price : cross.changePercent
+          if (actual == null || !Number.isFinite(actual)) return false
+          return compareNumeric(actual, cond.operator, cond.value)
+        }
+        case 'rsi': {
+          // TA 필드가 채워지지 않았으면 (TA fetch 스킵/실패) 안전측 false.
+          if (cross.rsi == null || !Number.isFinite(cross.rsi)) return false
+          return compareNumeric(cross.rsi, cond.operator, cond.value)
+        }
+        case 'macd_signal': {
+          if (cond.operator !== '==') return false
+          if (cross.macdCrossover === undefined) return false
+          if (cond.value === 1) return cross.macdCrossover === 'GOLDEN'
+          if (cond.value === -1) return cross.macdCrossover === 'DEAD'
+          if (cond.value === 0) return cross.macdCrossover === 'NONE'
+          return false
+        }
+        case 'sma_cross': {
+          if (cond.operator !== '==') return false
+          if (cross.smaCross === undefined) return false
+          if (cond.value === 1) return cross.smaCross === 'GOLDEN'
+          if (cond.value === -1) return cross.smaCross === 'DEAD'
+          return false
+        }
+        case 'bb_position': {
+          if (cond.operator !== '==') return false
+          if (cross.bbPosition === undefined) return false
+          if (cond.value === 1) return cross.bbPosition === 'ABOVE_UPPER'
+          if (cond.value === -1) return cross.bbPosition === 'BELOW_LOWER'
+          if (cond.value === 0) return cross.bbPosition === 'WITHIN'
+          return false
+        }
+        default:
+          return false
+      }
     }
     default:
       return false
@@ -243,6 +301,71 @@ export function collectCrossTickers(
     }
   }
   return out
+}
+
+/**
+ * Phase 38-A (#448) — TA 리포트가 필요한 크로스 티커 metric 여부.
+ */
+const CROSS_TICKER_TA_METRICS = new Set<string>(['rsi', 'macd_signal', 'sma_cross', 'bb_position'])
+
+/**
+ * Phase 38-A (#448) — Pure — 조건 배열에서 크로스-티커 TA 리포트가 필요한 티커 집합.
+ * `requiresTA(conditions)` 는 자기 티커의 TA 필요 여부만 판단.
+ * 이 함수는 별도 — 자기 티커 조건과 크로스 티커 조건의 TA 필요성을 분리해
+ * 호출자가 fetch 티커 집합을 dedupe (union) 하도록 지원.
+ *
+ * 반환값의 티커는 `trim().toUpperCase()` 정규화. 자기 자신 참조 티커는 excluded X
+ * (evaluator 가 false 처리하지만 collectCrossTickers 와 동일하게 필터하지 않음 —
+ * 호출자가 self-loop 여부를 이미 알고 있어 이중 필터 불필요, semantic 는 collectCrossTickers 참고).
+ */
+export function requiresTAForCrossTickers(conditions: Condition[]): Set<string> {
+  const out = new Set<string>()
+  for (const c of conditions) {
+    if (c.type !== 'cross_ticker') continue
+    if (typeof c.crossTicker !== 'string') continue
+    if (typeof c.metric !== 'string') continue
+    if (!CROSS_TICKER_TA_METRICS.has(c.metric)) continue
+    const t = c.crossTicker.trim().toUpperCase()
+    if (!t) continue
+    out.add(t)
+  }
+  return out
+}
+
+/**
+ * Phase 38-A (#448) — TA report 의 5-값 BB position 을 크로스-티커용 3-값으로 축약.
+ * NEAR_UPPER / MIDDLE / NEAR_LOWER 는 모두 `WITHIN` — 사용자 조건 어휘 (극단/중간) 와 정합.
+ */
+export function mapCrossTickerBBPosition(pos: BBPosition): 'ABOVE_UPPER' | 'WITHIN' | 'BELOW_LOWER' {
+  if (pos === 'ABOVE_UPPER') return 'ABOVE_UPPER'
+  if (pos === 'BELOW_LOWER') return 'BELOW_LOWER'
+  return 'WITHIN'
+}
+
+/**
+ * Phase 38-A (#448) — 크로스-티커 스냅샷 빌더 (pure).
+ * PriceCache 최소 정보 + (있으면) TAReport 를 병합해 evaluator 가 소비하는 shape 로 축소.
+ * TA 리포트가 null 이면 TA 필드는 undefined 로 남겨 evaluator 가 false 처리.
+ */
+export function buildCrossTickerSnapshot(
+  price: { price: number; changePercent: number | null },
+  ta: TAReport | null,
+): CrossTickerSnapshot {
+  if (!ta) {
+    return { price: price.price, changePercent: price.changePercent }
+  }
+  const { rsi14, macd, bollingerBands, sma } = ta.indicators
+  const smaCross: 'GOLDEN' | 'DEAD' | 'NONE' =
+    sma.goldenCross === true ? 'GOLDEN' :
+    sma.deathCross === true ? 'DEAD' : 'NONE'
+  return {
+    price: price.price,
+    changePercent: price.changePercent,
+    rsi: Number.isFinite(rsi14.value) ? rsi14.value : undefined,
+    macdCrossover: macd.crossover ?? 'NONE',
+    bbPosition: mapCrossTickerBBPosition(bollingerBands.position),
+    smaCross,
+  }
 }
 
 export interface EvaluationResult {

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -10,7 +10,7 @@
 import { askAdvisor } from '@/lib/ai/claude-advisor'
 import { validateParsedStrategy, type ParsedStrategy } from './types'
 
-const PROMPT_HEADER = `
+export const PROMPT_HEADER = `
 사용자 입력을 아래 JSON schema 로 정확히 파싱해줘. 오직 JSON 오브젝트만 출력 — 다른 설명/코드블록 없이.
 
 ## 지원 조건 타입 (v1)
@@ -28,11 +28,14 @@ const PROMPT_HEADER = `
 
 ## 지원 조건 타입 (v3 — 어닝 캘린더 / 크로스-티커)
 - earnings_within_days (숫자 정수, 0 이상, 다음 어닝까지 남은 일수 — Yahoo Finance 캘린더)
-- cross_ticker — 다른 티커의 price / change_percent 비교. 필수 필드:
+- cross_ticker — 다른 티커의 지표 비교. 필수 필드:
   - crossTicker: 참조 티커 (대문자 정규화). 자기 자신 참조 금지
-  - metric: "price" 또는 "change_percent"
-  - operator: 숫자 연산자 (< / <= / > / >= / ==)
-  - value: 숫자
+  - metric: 아래 6종
+    - "price" / "change_percent" — 숫자 비교. operator 는 < / <= / > / >= / ==. value 는 숫자
+    - "rsi" — 0~100 숫자. operator 는 < / <= / > / >= / ==. value 는 0~100
+    - "macd_signal" — value 는 정수 (1=GOLDEN, 0=NONE, -1=DEAD). operator 는 "==" 만
+    - "sma_cross" — value 는 정수 (1=GOLDEN, -1=DEAD). operator 는 "==" 만
+    - "bb_position" — value 는 정수 (1=ABOVE_UPPER, 0=WITHIN, -1=BELOW_LOWER). operator 는 "==" 만
 
 ## 연산자
 - 숫자 타입: < <= > >= ==
@@ -88,6 +91,18 @@ const PROMPT_HEADER = `
   ], "logic":"AND"
 - "VIX 25 초과 시 QQQ 콜 스캘핑" — ticker: "QQQ", conditions: [
     {"type":"cross_ticker","operator":">","value":25,"crossTicker":"VIX","metric":"price"}
+  ]
+- "SPY RSI 70 이상 과매수면 QQQ 매수 회피" — ticker: "QQQ", conditions: [
+    {"type":"cross_ticker","operator":"<","value":70,"crossTicker":"SPY","metric":"rsi"}
+  ]
+- "SPY MACD 골든크로스 발생 시 SOXL 진입" — ticker: "SOXL", conditions: [
+    {"type":"cross_ticker","operator":"==","value":1,"crossTicker":"SPY","metric":"macd_signal"}
+  ]
+- "VIX SMA 골든크로스 (=변동성 상승 국면) 시 방어형 TLT 매수" — ticker: "TLT", conditions: [
+    {"type":"cross_ticker","operator":"==","value":1,"crossTicker":"VIX","metric":"sma_cross"}
+  ]
+- "SPY 볼밴 상단 이탈 시 QQQ 진입 회피" — ticker: "QQQ", conditions: [
+    {"type":"cross_ticker","operator":"==","value":1,"crossTicker":"SPY","metric":"bb_position"}
   ]
 
 ## 규칙

--- a/src/lib/custom-strategy/parser.ts
+++ b/src/lib/custom-strategy/parser.ts
@@ -92,9 +92,10 @@ export const PROMPT_HEADER = `
 - "VIX 25 초과 시 QQQ 콜 스캘핑" — ticker: "QQQ", conditions: [
     {"type":"cross_ticker","operator":">","value":25,"crossTicker":"VIX","metric":"price"}
   ]
-- "SPY RSI 70 이상 과매수면 QQQ 매수 회피" — ticker: "QQQ", conditions: [
-    {"type":"cross_ticker","operator":"<","value":70,"crossTicker":"SPY","metric":"rsi"}
+- "SPY RSI 70 이상 과매수면 QQQ 회피 알림" — ticker: "QQQ", conditions: [
+    {"type":"cross_ticker","operator":">=","value":70,"crossTicker":"SPY","metric":"rsi"}
   ]
+  * 조건 = 알림 발동 조건. 사용자가 "X 상황이면 알림" 이라고 하면 X 를 그대로 조건으로 씀 (부정하지 않음).
 - "SPY MACD 골든크로스 발생 시 SOXL 진입" — ticker: "SOXL", conditions: [
     {"type":"cross_ticker","operator":"==","value":1,"crossTicker":"SPY","metric":"macd_signal"}
   ]

--- a/src/lib/custom-strategy/types.ts
+++ b/src/lib/custom-strategy/types.ts
@@ -1,6 +1,8 @@
 /**
  * Phase 29-E — 커스텀 전략 조건 스펙.
  * Phase 31-A (v2) — 시간/요일/보유 필터 추가.
+ * Phase 34-A/B — 어닝 조건 + 크로스-티커 (change_percent / price) 추가.
+ * Phase 38-A (#448) — 크로스-티커 metric 을 TA 지표 (rsi / macd_signal / sma_cross / bb_position) 로 확장.
  *
  * 사용자 자연어 → AI 파싱 → Condition[] JSON 으로 CustomStrategy.conditions 저장.
  * cron 이 evaluator 로 순수 코드 평가 (매번 AI 호출 X).
@@ -26,8 +28,23 @@ export type Operator = '<' | '<=' | '>' | '>=' | '==' | 'is'
 /** timeframe 지원 조건 타입 (change_pct 전용) */
 export type Timeframe = '1d' | '5d' | '20d'
 
-/** cross_ticker 조건에서 비교할 지표 */
-export type CrossTickerMetric = 'price' | 'change_percent'
+/**
+ * cross_ticker 조건에서 비교할 지표.
+ * - `price` / `change_percent`: 숫자 (기존 34-B).
+ * - `rsi`: 0~100 숫자.
+ * - `macd_signal` / `sma_cross` / `bb_position`: 카테고리컬 → 정수 코드로 표준화.
+ *   parser JSON / UI 폼이 단일 스키마 (`metric` + `operator` + `value:number`) 로 통일.
+ *   * `macd_signal`: 1 = GOLDEN, 0 = NONE (크로스 이벤트 없음), -1 = DEAD. `==` 만.
+ *   * `sma_cross`  : 1 = GOLDEN cross true, -1 = DEAD cross true. `==` 만.
+ *   * `bb_position`: 1 = ABOVE_UPPER, 0 = WITHIN (near/middle), -1 = BELOW_LOWER. `==` 만.
+ */
+export type CrossTickerMetric =
+  | 'price'
+  | 'change_percent'
+  | 'rsi'
+  | 'macd_signal'
+  | 'sma_cross'
+  | 'bb_position'
 
 /** 요일 코드 (KST 기준) */
 export type WeekdayCode = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN'
@@ -71,7 +88,27 @@ const VALID_WEEKDAYS_SET = new Set<WeekdayCode>(VALID_WEEKDAYS)
 export const TIME_WINDOW_RE = /^([01]\d|2[0-3]):([0-5]\d)~([01]\d|2[0-3]):([0-5]\d)$/
 
 const NUMERIC_TYPES = new Set<ConditionType>(['price', 'rsi', 'change_pct', 'earnings_within_days', 'cross_ticker'])
-const VALID_CROSS_METRICS = new Set<CrossTickerMetric>(['price', 'change_percent'])
+const VALID_CROSS_METRICS = new Set<CrossTickerMetric>([
+  'price', 'change_percent',
+  // Phase 38-A (#448) — TA metric 확장
+  'rsi', 'macd_signal', 'sma_cross', 'bb_position',
+])
+/** Phase 38-A: `==` 만 허용되는 cross_ticker 카테고리컬 metric */
+const CROSS_TICKER_CATEGORICAL_METRICS = new Set<CrossTickerMetric>([
+  'macd_signal', 'sma_cross', 'bb_position',
+])
+/**
+ * Phase 38-A: 카테고리컬 metric 별 허용 threshold 정수 집합.
+ * 이 밖의 값은 evaluator 에 도달하기 전 validate 단계에서 거부.
+ */
+const CROSS_TICKER_CATEGORICAL_VALUES: Record<
+  'macd_signal' | 'sma_cross' | 'bb_position',
+  ReadonlySet<number>
+> = {
+  macd_signal: new Set([-1, 0, 1]),
+  sma_cross: new Set([-1, 1]),
+  bb_position: new Set([-1, 0, 1]),
+}
 const SINGLE_STRING_TYPES = new Set<ConditionType>(['macd_signal', 'sma_cross', 'bb_position', 'holding_status'])
 const NUMERIC_OPS = new Set<Operator>(['<', '<=', '>', '>=', '=='])
 const IS_OP: Operator = 'is'
@@ -109,6 +146,18 @@ export function validateCondition(c: unknown): c is Condition {
       if (typeof cond.crossTicker !== 'string' || cond.crossTicker.trim() === '') return false
       // metric: 화이트리스트
       if (!VALID_CROSS_METRICS.has(cond.metric as CrossTickerMetric)) return false
+      const metric = cond.metric as CrossTickerMetric
+      // Phase 38-A: metric 별 세부 검증.
+      if (metric === 'rsi') {
+        // RSI14 값은 0~100. 소수 허용 (엔진이 소수 반환).
+        if (cond.value < 0 || cond.value > 100) return false
+      } else if (CROSS_TICKER_CATEGORICAL_METRICS.has(metric)) {
+        // == 만 + 제한된 정수 집합.
+        if (cond.operator !== '==') return false
+        const allowed = CROSS_TICKER_CATEGORICAL_VALUES[metric as 'macd_signal' | 'sma_cross' | 'bb_position']
+        if (!Number.isInteger(cond.value) || !allowed.has(cond.value)) return false
+      }
+      // price / change_percent 는 기존 그대로 (숫자 op + 유한 숫자).
     }
     return true
   }
@@ -154,13 +203,37 @@ export function validateParsedStrategy(p: unknown): p is ParsedStrategy {
   return s.conditions.every(validateCondition)
 }
 
+/** Phase 38-A: 카테고리컬 cross_ticker metric 의 정수 코드 → 사람 친화 라벨 */
+function crossTickerCategoricalLabel(metric: CrossTickerMetric, value: number): string | null {
+  if (metric === 'macd_signal') {
+    if (value === 1) return 'GOLDEN'
+    if (value === -1) return 'DEAD'
+    if (value === 0) return 'NONE'
+  } else if (metric === 'sma_cross') {
+    if (value === 1) return 'GOLDEN'
+    if (value === -1) return 'DEAD'
+  } else if (metric === 'bb_position') {
+    if (value === 1) return 'ABOVE_UPPER'
+    if (value === 0) return 'WITHIN'
+    if (value === -1) return 'BELOW_LOWER'
+  }
+  return null
+}
+
 export function conditionToString(c: Condition): string {
   const timeframe = c.timeframe ? `(${c.timeframe})` : ''
   if (c.type === 'weekday' && Array.isArray(c.value)) {
     return `weekday ${c.operator} [${c.value.join(',')}]`
   }
   if (c.type === 'cross_ticker') {
-    return `${c.crossTicker ?? '?'}.${c.metric ?? '?'} ${c.operator} ${c.value}`
+    const metric = c.metric ?? '?'
+    // 카테고리컬 metric 은 라벨로 렌더링 (사람이 읽기 쉽게).
+    // canonical key (diff.condKey) 는 여전히 원본 숫자값을 사용 → 여기서만 라벨링.
+    if (typeof c.value === 'number' && (metric === 'macd_signal' || metric === 'sma_cross' || metric === 'bb_position')) {
+      const label = crossTickerCategoricalLabel(metric, c.value)
+      if (label) return `${c.crossTicker ?? '?'}.${metric} ${c.operator} ${label}`
+    }
+    return `${c.crossTicker ?? '?'}.${metric} ${c.operator} ${c.value}`
   }
   return `${c.type}${timeframe} ${c.operator} ${c.value}`
 }


### PR DESCRIPTION
## Summary
- `cross_ticker` 조건에 TA metric 4종 추가 (rsi / macd_signal / sma_cross / bb_position)
- 벤치마크 TA 게이트 표현 가능: "SPY RSI 70 과매수 시 QQQ 회피", "VIX SMA 골든크로스 시 방어형 전환" 등
- TA fetch dedupe: 자기 티커 + 크로스 티커 union → 동일 티커 여러 전략에서 참조돼도 1회 fetch

## 설계 결정

**카테고리컬 metric threshold 정수 표준화**
`macd_signal` / `sma_cross` / `bb_position` 은 threshold 를 정수 (-1/0/1) 로 저장:
- `macd_signal`: 1=GOLDEN, 0=NONE, -1=DEAD
- `sma_cross`: 1=GOLDEN, -1=DEAD
- `bb_position`: 1=ABOVE_UPPER, 0=WITHIN, -1=BELOW_LOWER

parser JSON / UI 폼이 단일 스키마 (`metric` + `operator` + `value:number`) 로 통일. 사람 라벨은 `conditionToString` 이 담당. operator 는 카테고리컬 metric 에 `==` 만 강제.

**SMA period / BB band 파라미터 스킵**
엔진 기본 (SMA20 / BB20) 사용. 확장 시 스키마 + parser + validate + evaluator + condKey 5곳 갱신 필요 → 별도 이슈로 분리. 현재 스코프 최소화.

**self-ticker vs cross-ticker macd_signal**
- self-ticker (기존 v1): `is` operator + `'GOLDEN'/'DEAD'` 문자열
- cross-ticker (신규): `==` + 정수 (0=NONE 포함)

경로 격리 — validateCondition 이 `type === 'cross_ticker'` 분기와 `SINGLE_STRING_TYPES` 분기를 분리 처리.

## Canonical Key 정합
16차 학습 원칙 준수: `condKey` 가 raw 정수 (라벨 아님) 를 사용해 `bb_position == 1` (ABOVE_UPPER) 과 `bb_position == 0` (WITHIN) 이 별개 key. `sma_cross vs bb_position` 같은 value 도 metric 이 key 에 포함되어 구분. 회귀 테스트 `diff.test.ts:195-217` 커버.

## Validation 3단 방어
- API PUT (`[id]/route.ts:73`) — 저장 전
- API POST parser (`validateParsedStrategy`) — AI 생성 후
- 스캐너 (`every(validateCondition)` custom-strategy-alert.ts:208) — 실행 직전

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (669 tests, +60 신규: types 26 + evaluator 29 + diff 5)
- [x] `npm run build` 통과
- [x] pr-review-toolkit self-review P1/P2 = 0

## Closes
Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)