### PR TITLE
[Phase 39-B] IconButton 44×44 hitbox + 모바일 상위 페이지 개선 (#451)

### DIFF
--- a/docs/designs/443-mobile-priority/README.md
+++ b/docs/designs/443-mobile-priority/README.md
@@ -1,0 +1,22 @@
+# Phase 39-B — 모바일 상위 페이지 개선 시각 증거
+
+**대상 이슈**: #451 (17차 마일스톤 서브)
+**기반 감사**: `docs/designs/443-mobile-audit/audit.md`
+
+## 스코프 요약
+
+| 항목 | 조치 |
+|---|---|
+| **H1** — 대시보드 · 관심종목 · 가계부 테이블 수평 스크롤 pain | mobile 카드 뷰(`<lg`) + desktop 테이블(`lg:`) 분기 |
+| **M1** — 44×44 미만 아이콘 버튼 다수 | 공용 `IconButton` (44×44 고정 hitbox) 도입 + 대상 파일 일괄 교체 |
+| **M2** — `BudgetManager` grid 트랙 폭 초과 + `RecurringForm` 고정 input 폭 | grid template mobile 3col/desktop 5col 분기 + 사용·잔액 mobile 요약, input `flex-1 min-w-0` |
+| **M3** — 3-col form grids | 실제 각 grid 는 3개의 짧은 항목(계좌명 2글자, 통계 숫자)만 담으므로 375px 에서 셀 폭 ≥ 100px 확보. 보수적으로 스킵 (audit 원문 "시간 남으면") |
+
+## 스크린샷
+
+시각 캡처는 사용자가 브라우저에서 확인 후 이 폴더 하위 `screenshots/` 에 추가할 예정. 정적 코드 감사 + `IconButton` 44×44 강제 사양으로 hitbox 회귀는 unit-테스트 없이 CSS 레벨에서 잠금 상태.
+
+## 검증
+
+- `npm run lint && npx tsc --noEmit && npm run test:run && npm run build` (4-check) 필수 통과
+- `rg -n --type ts -B2 'p-1\.5|p-0\.5|w-\[26px\] h-\[26px\]|w-7 h-7' src/components/` 로 남은 sub-44 아이콘 잔여물 확인. 이번 sweep 후 잔여물은 (a) 아이콘 버튼이 아닌 다른 style hint (`p-1.5` on wrapper etc.) 만 남음.

--- a/src/components/asset/AssetForm.tsx
+++ b/src/components/asset/AssetForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import type { AssetRow } from './AssetTable'
 
 const CATEGORIES = [
@@ -117,9 +118,9 @@ export default function AssetForm({ mode, asset, onClose }: AssetFormProps) {
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{isEdit ? '자산 수정' : '자산 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/asset/AssetTable.tsx
+++ b/src/components/asset/AssetTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { formatKRW, formatDate } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 
 export interface AssetRow {
   id: string
@@ -106,24 +107,16 @@ export default function AssetTable({ assets, activeTab, onTabChange, onEdit, onD
                       {a.maturityDate ? formatDate(a.maturityDate) : '-'}
                     </td>
                     <td className="px-4 py-3 text-center whitespace-nowrap">
-                      <button
-                        onClick={() => onEdit(a)}
-                        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-text hover:bg-surface transition-all"
-                        title="수정"
-                      >
+                      <IconButton onClick={() => onEdit(a)} title="수정">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
                         </svg>
-                      </button>
-                      <button
-                        onClick={() => onDelete(a)}
-                        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        title="삭제"
-                      >
+                      </IconButton>
+                      <IconButton variant="danger" onClick={() => onDelete(a)} title="삭제">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
                         </svg>
-                      </button>
+                      </IconButton>
                     </td>
                   </tr>
                 ))}

--- a/src/components/category/CategoryEditPanel.tsx
+++ b/src/components/category/CategoryEditPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { CATEGORY_TYPES, CATEGORY_TYPE_LABELS } from '@/lib/category-utils'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import type { CategoryRow } from './CategoryTable'
 
 interface CategoryEditPanelProps {
@@ -99,11 +100,11 @@ export default function CategoryEditPanel({ category, onClose }: CategoryEditPan
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">카테고리 수정</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/category/CategoryForm.tsx
+++ b/src/components/category/CategoryForm.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { CATEGORY_TYPES, CATEGORY_TYPE_LABELS } from '@/lib/category-utils'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 
 interface CategoryFormProps {
   onClose: () => void
@@ -83,11 +84,11 @@ export default function CategoryForm({ onClose }: CategoryFormProps) {
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">카테고리 추가</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/category/CategoryTable.tsx
+++ b/src/components/category/CategoryTable.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import CategoryEditPanel from './CategoryEditPanel'
 import CategoryDeleteModal from './CategoryDeleteModal'
+import IconButton from '@/components/ui/IconButton'
 
 export interface CategoryRow {
   id: string
@@ -81,28 +82,18 @@ function CategoryRowDesktop({
       </td>
       <td className="pr-4 px-3 py-3 border-b border-border">
         <div className="flex items-center gap-1">
-          <button
-            onClick={onMoveUp}
-            disabled={isFirst || isReordering}
-            className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
-            title="위로"
-          >
+          <IconButton onClick={onMoveUp} disabled={isFirst || isReordering} title="위로">
             <ArrowUpIcon />
-          </button>
-          <button
-            onClick={onMoveDown}
-            disabled={isLast || isReordering}
-            className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
-            title="아래로"
-          >
+          </IconButton>
+          <IconButton onClick={onMoveDown} disabled={isLast || isReordering} title="아래로">
             <ArrowDownIcon />
-          </button>
-          <button onClick={() => onEdit(c)} className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all" title="수정">
+          </IconButton>
+          <IconButton onClick={() => onEdit(c)} title="수정">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" /></svg>
-          </button>
-          <button onClick={() => onDelete(c)} className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all" title="삭제">
+          </IconButton>
+          <IconButton variant="danger" onClick={() => onDelete(c)} title="삭제">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" /></svg>
-          </button>
+          </IconButton>
         </div>
       </td>
     </tr>
@@ -248,7 +239,7 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                         key={i}
                         className={`px-3 py-2.5 text-[11px] font-semibold text-sub tracking-wide uppercase border-b border-border bg-card ${
                           i === 0 || i === 4 ? 'text-center' : 'text-left'
-                        } ${i === 0 ? 'pl-4 w-16' : ''} ${i === 5 ? 'pr-4 w-28' : ''}`}
+                        } ${i === 0 ? 'pl-4 w-16' : ''} ${i === 5 ? 'pr-4 w-56' : ''}`}
                       >
                         {col}
                       </th>
@@ -326,36 +317,30 @@ export default function CategoryTable({ categories, activeTab, onTabChange }: Ca
                         )}
                       </div>
                       <div className="flex items-center gap-1">
-                        <button
+                        <IconButton
                           onClick={() => handleReorder(c.id, 'up')}
                           disabled={isFirst || reordering}
-                          className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+                          title="위로"
                         >
                           <ArrowUpIcon size={12} />
-                        </button>
-                        <button
+                        </IconButton>
+                        <IconButton
                           onClick={() => handleReorder(c.id, 'down')}
                           disabled={isLast || reordering}
-                          className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all disabled:opacity-20 disabled:cursor-not-allowed"
+                          title="아래로"
                         >
                           <ArrowDownIcon size={12} />
-                        </button>
-                        <button
-                          onClick={() => setEditItem(c)}
-                          className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                        >
+                        </IconButton>
+                        <IconButton onClick={() => setEditItem(c)} title="수정">
                           <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                             <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                           </svg>
-                        </button>
-                        <button
-                          onClick={() => setDeleteItem(c)}
-                          className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        >
+                        </IconButton>
+                        <IconButton variant="danger" onClick={() => setDeleteItem(c)} title="삭제">
                           <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                             <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                           </svg>
-                        </button>
+                        </IconButton>
                       </div>
                     </div>
                     {c.keywords.length > 0 && (

--- a/src/components/dashboard/HoldingsTable.tsx
+++ b/src/components/dashboard/HoldingsTable.tsx
@@ -72,6 +72,13 @@ export default function HoldingsTable({ holdings, priceMap, currentFxRate, hasPr
                   <div className="text-[11px] text-dim tabular-nums">
                     {h.shares}주 · 평단 {h.currency === 'USD' ? formatUSD(h.avgPriceFx ?? h.avgPrice) : formatKRW(h.avgPrice)}
                   </div>
+                  {/* Phase 39-B self-review P1: USD 종목은 평가금(KRW) 만으론 현재가(USD) 를
+                      역산 불가 → 평단 vs 현재가 비교 불가능. USD 원가 통화로 현재가 노출. */}
+                  {price && (
+                    <div className="text-[11px] text-sub tabular-nums">
+                      현재가 {h.currency === 'USD' ? formatUSD(price.price) : formatKRW(price.price)}
+                    </div>
+                  )}
                 </div>
                 <div className="text-right shrink-0">
                   <div className="text-[13px] font-semibold text-muted tabular-nums whitespace-nowrap">

--- a/src/components/dashboard/HoldingsTable.tsx
+++ b/src/components/dashboard/HoldingsTable.tsx
@@ -27,6 +27,10 @@ interface HoldingsTableProps {
   hasPriceData: boolean
 }
 
+function marketBadgeClass(market: string): string {
+  return market === 'US' ? 'text-sodam bg-sodam/10' : 'text-amber-400 bg-amber-400/10'
+}
+
 export default function HoldingsTable({ holdings, priceMap, currentFxRate, hasPriceData }: HoldingsTableProps) {
   const sorted = [...holdings].sort((a, b) => {
     const priceA = priceMap.get(a.ticker)
@@ -42,7 +46,63 @@ export default function HoldingsTable({ holdings, priceMap, currentFxRate, hasPr
         <div className="text-[13px] font-bold text-bright">보유종목</div>
         <div className="text-[12px] text-sub">{holdings.length}개</div>
       </div>
-      <div className="overflow-x-auto">
+
+      {/* Mobile 카드 뷰 (<lg) — 종목명·시장·평가금액·손익률 한눈에 */}
+      <div className="lg:hidden divide-y divide-border">
+        {sorted.map((h) => {
+          const price = priceMap.get(h.ticker)
+          const costKRW = calcCostKRW(h)
+          const currentValue = price
+            ? calcCurrentValueKRW(h, price.price, currentFxRate)
+            : costKRW
+          const pl = price
+            ? calcProfitLoss(h, price.price, currentFxRate)
+            : null
+
+          return (
+            <div key={h.id} className="px-4 py-3">
+              <div className="flex items-start justify-between gap-2 mb-1.5">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2 mb-0.5">
+                    <span className="text-[13px] font-bold text-bright truncate">{h.displayName}</span>
+                    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded shrink-0 ${marketBadgeClass(h.market)}`}>
+                      {h.market}
+                    </span>
+                  </div>
+                  <div className="text-[11px] text-dim tabular-nums">
+                    {h.shares}주 · 평단 {h.currency === 'USD' ? formatUSD(h.avgPriceFx ?? h.avgPrice) : formatKRW(h.avgPrice)}
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <div className="text-[13px] font-semibold text-muted tabular-nums whitespace-nowrap">
+                    {formatKRW(currentValue)}
+                  </div>
+                  {hasPriceData && pl && (
+                    <div className={`text-[12px] font-bold tabular-nums ${pl.returnPct >= 0 ? 'text-sejin' : 'text-red-500'}`}>
+                      {formatPercent(pl.returnPct)}
+                    </div>
+                  )}
+                </div>
+              </div>
+              {hasPriceData && pl && h.currency === 'USD' && (
+                <div className="text-[10px] text-dim leading-snug tabular-nums">
+                  주가{' '}
+                  <span className={pl.pricePL >= 0 ? 'text-sejin/65' : 'text-red-500/65'}>
+                    {formatSignedKRW(pl.pricePL)}
+                  </span>
+                  {' · 환율 '}
+                  <span className={pl.fxPL >= 0 ? 'text-sejin/65' : 'text-red-500/65'}>
+                    {formatSignedKRW(pl.fxPL)}
+                  </span>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Desktop 테이블 (lg:) */}
+      <div className="hidden lg:block overflow-x-auto">
         <table className="w-full border-collapse">
           <thead>
             <tr>
@@ -90,13 +150,7 @@ export default function HoldingsTable({ holdings, priceMap, currentFxRate, hasPr
                     <span className="font-bold text-bright">{h.displayName}</span>
                   </td>
                   <td className="px-3 py-3 text-[13px] border-b border-border">
-                    <span
-                      className={`text-[11px] font-bold px-1.5 py-0.5 rounded ${
-                        h.market === 'US'
-                          ? 'text-sodam bg-sodam/10'
-                          : 'text-amber-400 bg-amber-400/10'
-                      }`}
-                    >
+                    <span className={`text-[11px] font-bold px-1.5 py-0.5 rounded ${marketBadgeClass(h.market)}`}>
                       {h.market}
                     </span>
                   </td>

--- a/src/components/deposit/DepositEditPanel.tsx
+++ b/src/components/deposit/DepositEditPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { DEPOSIT_SOURCES } from '@/lib/deposit-utils'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import type { DepositRow } from './DepositTable'
 
 interface DepositEditPanelProps {
@@ -97,11 +98,11 @@ export default function DepositEditPanel({ deposit, onClose }: DepositEditPanelP
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">입금 수정</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/deposit/DepositTable.tsx
+++ b/src/components/deposit/DepositTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { formatKRW, formatDate } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 import DepositEditPanel from './DepositEditPanel'
 import DepositDeleteModal from './DepositDeleteModal'
 
@@ -116,24 +117,16 @@ export default function DepositTable({ deposits, total, limit, offset }: Deposit
                   </td>
                   <td className="pr-4 px-3 py-3 border-b border-border">
                     <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => setEditItem(d)}
-                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                        title="수정"
-                      >
+                      <IconButton onClick={() => setEditItem(d)} title="수정">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                         </svg>
-                      </button>
-                      <button
-                        onClick={() => setDeleteItem(d)}
-                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        title="삭제"
-                      >
+                      </IconButton>
+                      <IconButton variant="danger" onClick={() => setDeleteItem(d)} title="삭제">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                         </svg>
-                      </button>
+                      </IconButton>
                     </div>
                   </td>
                 </tr>
@@ -153,22 +146,16 @@ export default function DepositTable({ deposits, total, limit, offset }: Deposit
                   <span className="text-[11px] text-dim px-1.5 py-0.5 rounded bg-surface-dim">{d.source}</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => setEditItem(d)}
-                    className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                  >
+                  <IconButton onClick={() => setEditItem(d)} title="수정">
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                     </svg>
-                  </button>
-                  <button
-                    onClick={() => setDeleteItem(d)}
-                    className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                  >
+                  </IconButton>
+                  <IconButton variant="danger" onClick={() => setDeleteItem(d)} title="삭제">
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                     </svg>
-                  </button>
+                  </IconButton>
                 </div>
               </div>
               <div className="flex items-center justify-between text-[12px]">

--- a/src/components/dividend/DividendEditPanel.tsx
+++ b/src/components/dividend/DividendEditPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { formatUSD } from '@/lib/format'
 import { calcDividendTax, calcAmountKRW } from '@/lib/dividend-utils'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import type { DividendRow } from './DividendTable'
 
 interface DividendEditPanelProps {
@@ -126,11 +127,11 @@ export default function DividendEditPanel({ dividend, onClose }: DividendEditPan
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">배당 수정</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/dividend/DividendTable.tsx
+++ b/src/components/dividend/DividendTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { formatKRW, formatUSD, formatDate } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 import DividendEditPanel from './DividendEditPanel'
 import DividendDeleteModal from './DividendDeleteModal'
 
@@ -139,24 +140,16 @@ export default function DividendTable({ dividends, total, limit, offset }: Divid
                   </td>
                   <td className="pr-4 px-3 py-3 border-b border-border">
                     <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => setEditItem(d)}
-                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                        title="수정"
-                      >
+                      <IconButton onClick={() => setEditItem(d)} title="수정">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                         </svg>
-                      </button>
-                      <button
-                        onClick={() => setDeleteItem(d)}
-                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        title="삭제"
-                      >
+                      </IconButton>
+                      <IconButton variant="danger" onClick={() => setDeleteItem(d)} title="삭제">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                         </svg>
-                      </button>
+                      </IconButton>
                     </div>
                   </td>
                 </tr>
@@ -180,22 +173,16 @@ export default function DividendTable({ dividends, total, limit, offset }: Divid
                   )}
                 </div>
                 <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => setEditItem(d)}
-                    className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                  >
+                  <IconButton onClick={() => setEditItem(d)} title="수정">
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                     </svg>
-                  </button>
-                  <button
-                    onClick={() => setDeleteItem(d)}
-                    className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                  >
+                  </IconButton>
+                  <IconButton variant="danger" onClick={() => setDeleteItem(d)} title="삭제">
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                     </svg>
-                  </button>
+                  </IconButton>
                 </div>
               </div>
               <div className="flex items-center justify-between text-[12px]">

--- a/src/components/expense/BudgetManager.tsx
+++ b/src/components/expense/BudgetManager.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { formatKRW } from '@/lib/format'
 import { getBudgetColor } from '@/lib/budget-utils'
+import IconButton from '@/components/ui/IconButton'
 
 interface CategoryBudget {
   id: string
@@ -156,8 +157,8 @@ export default function BudgetManager({
 
           if (isEditing) {
             return (
-              <div key={b.id} className="flex items-center gap-3 px-5 py-3.5 border-b border-border bg-surface-dim">
-                <span className="text-[13px] text-bright font-medium w-[120px] shrink-0">
+              <div key={b.id} className="flex flex-wrap items-center gap-2 sm:gap-3 px-5 py-3.5 border-b border-border bg-surface-dim">
+                <span className="text-[13px] text-bright font-medium w-full sm:w-[120px] sm:shrink-0">
                   {b.categoryIcon ? `${b.categoryIcon} ` : ''}{b.categoryName}
                 </span>
                 <input
@@ -165,7 +166,7 @@ export default function BudgetManager({
                   inputMode="numeric"
                   value={editAmount}
                   onChange={(e) => setEditAmount(e.target.value.replace(/[^0-9,]/g, ''))}
-                  className="w-28 bg-surface border border-border-hover rounded-md px-2.5 py-1 text-[13px] text-bright tabular-nums text-right focus:outline-none"
+                  className="flex-1 min-w-0 sm:flex-none sm:w-28 bg-surface border border-border-hover rounded-md px-2.5 py-1 text-[13px] text-bright tabular-nums text-right focus:outline-none"
                   autoFocus
                 />
                 <span className="text-[12px] text-dim">원</span>
@@ -186,12 +187,16 @@ export default function BudgetManager({
             )
           }
 
+          const remainingColor = b.remaining >= 0
+            ? (b.pct >= 70 ? 'text-yellow-400' : 'text-emerald-400')
+            : 'text-red-400'
+
           return (
-            <div key={b.id} className="grid grid-cols-[140px_1fr_100px_100px_40px] items-center gap-3 px-5 py-3.5 border-b border-border last:border-0 hover:bg-surface-dim transition-colors">
-              <span className="text-[13px] text-bright font-medium whitespace-nowrap">
+            <div key={b.id} className="grid grid-cols-[minmax(80px,1fr)_1.5fr_auto] sm:grid-cols-[140px_1fr_100px_100px_auto] items-center gap-2 sm:gap-3 px-5 py-3.5 border-b border-border last:border-0 hover:bg-surface-dim transition-colors">
+              <span className="text-[13px] text-bright font-medium truncate">
                 {b.categoryIcon ? `${b.categoryIcon} ` : ''}{b.categoryName}
               </span>
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-1 min-w-0">
                 <div className="h-1.5 bg-surface-dim rounded-full overflow-hidden">
                   <div className={`h-full rounded-full ${colorMap[color]}`} style={{ width: `${Math.min(b.pct, 100)}%` }} />
                 </div>
@@ -201,32 +206,29 @@ export default function BudgetManager({
                     {b.pct}%{b.pct >= 100 ? ' 초과' : ''}
                   </span>
                 </div>
+                {/* Mobile 전용 요약 — 사용 / 잔액 (sm 이상은 별도 컬럼으로 노출) */}
+                <div className="flex justify-between text-[11px] tabular-nums sm:hidden">
+                  <span className="text-red-400">사용 {formatKRW(b.spent)}</span>
+                  <span className={remainingColor}>잔액 {formatKRW(b.remaining)}</span>
+                </div>
               </div>
-              <span className="text-[12px] font-semibold text-red-400 text-right tabular-nums whitespace-nowrap">
+              <span className="hidden sm:inline text-[12px] font-semibold text-red-400 text-right tabular-nums whitespace-nowrap">
                 {formatKRW(b.spent)}
               </span>
-              <span className={`text-[12px] font-semibold text-right tabular-nums whitespace-nowrap ${b.remaining >= 0 ? (b.pct >= 70 ? 'text-yellow-400' : 'text-emerald-400') : 'text-red-400'}`}>
+              <span className={`hidden sm:inline text-[12px] font-semibold text-right tabular-nums whitespace-nowrap ${remainingColor}`}>
                 {formatKRW(b.remaining)}
               </span>
               <div className="flex gap-0.5 justify-center">
-                <button
-                  onClick={() => handleEdit(b)}
-                  className="inline-flex items-center justify-center w-[26px] h-[26px] rounded-md text-dim hover:text-text hover:bg-surface transition-all"
-                  title="수정"
-                >
+                <IconButton onClick={() => handleEdit(b)} title="수정">
                   <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                     <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
                   </svg>
-                </button>
-                <button
-                  onClick={() => handleDelete(b.id)}
-                  className="inline-flex items-center justify-center w-[26px] h-[26px] rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                  title="삭제"
-                >
+                </IconButton>
+                <IconButton variant="danger" onClick={() => handleDelete(b.id)} title="삭제">
                   <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                     <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
                   </svg>
-                </button>
+                </IconButton>
               </div>
             </div>
           )
@@ -250,11 +252,11 @@ export default function BudgetManager({
 
         {/* 추가 영역 */}
         {showAdd && (
-          <div className="flex items-center gap-3 px-5 py-3.5 border-b border-border bg-surface-dim">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3 px-5 py-3.5 border-b border-border bg-surface-dim">
             <select
               value={addCategoryId}
               onChange={(e) => setAddCategoryId(e.target.value)}
-              className="w-[140px] bg-surface-dim border border-border rounded-md px-2.5 py-1.5 text-[13px] text-bright focus:outline-none"
+              className="w-full sm:w-[140px] bg-surface-dim border border-border rounded-md px-2.5 py-1.5 text-[13px] text-bright focus:outline-none"
             >
               <option value="">카테고리 선택</option>
               {unsetCategories.map((c) => (
@@ -267,7 +269,7 @@ export default function BudgetManager({
               value={addAmount}
               onChange={(e) => setAddAmount(e.target.value.replace(/[^0-9,]/g, ''))}
               placeholder="금액"
-              className="w-28 bg-surface border border-border-hover rounded-md px-2.5 py-1.5 text-[13px] text-bright tabular-nums text-right focus:outline-none"
+              className="flex-1 min-w-0 sm:flex-none sm:w-28 bg-surface border border-border-hover rounded-md px-2.5 py-1.5 text-[13px] text-bright tabular-nums text-right focus:outline-none"
             />
             <span className="text-[12px] text-dim">원</span>
             <button

--- a/src/components/expense/RecurringForm.tsx
+++ b/src/components/expense/RecurringForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import type { RecurringRow } from './RecurringTable'
 
 interface CategoryOption {
@@ -111,9 +112,9 @@ export default function RecurringForm({ mode, item, prefill, categories, onClose
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{isEdit ? '반복 거래 수정' : '반복 거래 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">
@@ -157,7 +158,7 @@ export default function RecurringForm({ mode, item, prefill, categories, onClose
             {frequency === 'monthly' && (
               <>
                 <select value={dayOfMonth} onChange={(e) => setDayOfMonth(Number(e.target.value))}
-                  className={`${inputClasses} w-[120px] appearance-none cursor-pointer`}
+                  className={`${inputClasses} w-full sm:w-[120px] appearance-none cursor-pointer`}
                   style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 14px center' }}>
                   {Array.from({ length: 31 }, (_, i) => <option key={i + 1} value={i + 1}>{i + 1}일</option>)}
                 </select>
@@ -183,12 +184,12 @@ export default function RecurringForm({ mode, item, prefill, categories, onClose
               <>
                 <div className="flex gap-2">
                   <select value={monthOfYear} onChange={(e) => setMonthOfYear(Number(e.target.value))}
-                    className={`${inputClasses} w-[100px] appearance-none cursor-pointer`}
+                    className={`${inputClasses} flex-1 min-w-0 sm:flex-none sm:w-[100px] appearance-none cursor-pointer`}
                     style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 14px center' }}>
                     {Array.from({ length: 12 }, (_, i) => <option key={i + 1} value={i + 1}>{i + 1}월</option>)}
                   </select>
                   <select value={dayOfMonth} onChange={(e) => setDayOfMonth(Number(e.target.value))}
-                    className={`${inputClasses} w-[80px] appearance-none cursor-pointer`}
+                    className={`${inputClasses} flex-1 min-w-0 sm:flex-none sm:w-[80px] appearance-none cursor-pointer`}
                     style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236e6e82' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E")`, backgroundRepeat: 'no-repeat', backgroundPosition: 'right 14px center' }}>
                     {Array.from({ length: 31 }, (_, i) => <option key={i + 1} value={i + 1}>{i + 1}일</option>)}
                   </select>

--- a/src/components/expense/RecurringTable.tsx
+++ b/src/components/expense/RecurringTable.tsx
@@ -2,6 +2,7 @@
 
 import { formatKRW, formatDate } from '@/lib/format'
 import { formatFrequency } from '@/lib/recurring-utils'
+import IconButton from '@/components/ui/IconButton'
 
 export interface RecurringRow {
   id: string
@@ -52,7 +53,7 @@ export default function RecurringTable({ items, onEdit, onDelete, onToggle }: Re
                 <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">금액</th>
                 <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">주기</th>
                 <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">다음 실행</th>
-                <th className="px-4 py-2.5 text-center text-dim font-semibold tracking-wide uppercase w-[70px]">액션</th>
+                <th className="px-4 py-2.5 text-center text-dim font-semibold tracking-wide uppercase w-[100px]">액션</th>
               </tr>
             </thead>
             <tbody>
@@ -88,24 +89,16 @@ export default function RecurringTable({ items, onEdit, onDelete, onToggle }: Re
                     {formatDate(item.nextRunAt)}
                   </td>
                   <td className="px-4 py-3 text-center whitespace-nowrap">
-                    <button
-                      onClick={() => onEdit(item)}
-                      className="inline-flex items-center justify-center w-[26px] h-[26px] rounded-md text-dim hover:text-text hover:bg-surface transition-all"
-                      title="수정"
-                    >
+                    <IconButton onClick={() => onEdit(item)} title="수정">
                       <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                         <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
                       </svg>
-                    </button>
-                    <button
-                      onClick={() => onDelete(item)}
-                      className="inline-flex items-center justify-center w-[26px] h-[26px] rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                      title="삭제"
-                    >
+                    </IconButton>
+                    <IconButton variant="danger" onClick={() => onDelete(item)} title="삭제">
                       <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                         <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
                       </svg>
-                    </button>
+                    </IconButton>
                   </td>
                 </tr>
               ))}

--- a/src/components/expense/TransactionForm.tsx
+++ b/src/components/expense/TransactionForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 
 interface CategorySuggestion {
   categoryId: string
@@ -215,11 +216,11 @@ export default function TransactionForm({
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{isEdit ? '내역 수정' : '내역 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/expense/TransactionTable.tsx
+++ b/src/components/expense/TransactionTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { formatKRW, formatDate } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 
 export interface TransactionRow {
   id: string
@@ -25,6 +26,34 @@ interface TransactionTableProps {
   onEdit?: (tx: TransactionRow) => void
   onDelete?: (tx: TransactionRow) => void
   onRegisterRecurring?: (tx: TransactionRow) => void
+}
+
+const EditIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
+  </svg>
+)
+
+const DeleteIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
+  </svg>
+)
+
+const RecurringIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M13.5 8A5.5 5.5 0 113 5.5M3 2v3.5H6.5" />
+  </svg>
+)
+
+function amountClass(isTransfer: boolean, isExpense: boolean): string {
+  if (isTransfer) return 'text-sodam'
+  return isExpense ? 'text-red-400' : 'text-emerald-400'
+}
+
+function amountPrefix(isTransfer: boolean, isExpense: boolean, type: string | null | undefined): string {
+  if (isTransfer) return type === 'transfer_out' ? '↑' : '↓'
+  return isExpense ? '-' : '+'
 }
 
 export default function TransactionTable({
@@ -58,7 +87,61 @@ export default function TransactionTable({
         </div>
       ) : (
         <>
-          <div className="overflow-x-auto">
+          {/* Mobile 카드 뷰 (<lg) */}
+          <div className="lg:hidden divide-y divide-border">
+            {transactions.map((tx) => {
+              const isExpense = tx.categoryType === 'expense'
+              const isTransfer = tx.type === 'transfer_out' || tx.type === 'transfer_in'
+              return (
+                <div key={tx.id} className="px-4 py-3.5">
+                  <div className="flex items-start justify-between gap-2 mb-1">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[13px] text-bright break-words">
+                        {tx.description}
+                      </div>
+                      <div className="text-[11px] text-dim mt-0.5 tabular-nums">
+                        {formatDate(tx.transactedAt)} · {tx.categoryIcon ? `${tx.categoryIcon} ` : ''}{tx.categoryName}
+                      </div>
+                    </div>
+                    <div className={`text-[14px] font-semibold tabular-nums whitespace-nowrap shrink-0 ${amountClass(isTransfer, isExpense)}`}>
+                      {amountPrefix(isTransfer, isExpense, tx.type)}{formatKRW(tx.amount)}
+                    </div>
+                  </div>
+                  {(tx.type === 'transfer_out' || tx.type === 'transfer_in') && tx.linkedAssetName && (
+                    <div className="mt-1">
+                      <span className={`inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded ${
+                        tx.type === 'transfer_out' ? 'text-sodam bg-sodam/15' : 'text-teal-400 bg-teal-500/12'
+                      }`}>
+                        {tx.type === 'transfer_out' ? '출금' : '입금'} → {tx.linkedAssetName}
+                      </span>
+                    </div>
+                  )}
+                  {hasActions && (
+                    <div className="flex justify-end items-center gap-0.5 mt-1">
+                      {onEdit && (
+                        <IconButton onClick={() => onEdit(tx)} title="수정">
+                          <EditIcon />
+                        </IconButton>
+                      )}
+                      {onDelete && (
+                        <IconButton variant="danger" onClick={() => onDelete(tx)} title="삭제">
+                          <DeleteIcon />
+                        </IconButton>
+                      )}
+                      {onRegisterRecurring && tx.type !== 'transfer_out' && tx.type !== 'transfer_in' && (
+                        <IconButton variant="sodam" onClick={() => onRegisterRecurring(tx)} title="반복 등록">
+                          <RecurringIcon />
+                        </IconButton>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Desktop 테이블 (lg:) */}
+          <div className="hidden lg:block overflow-x-auto">
             <table className="w-full text-[12px]">
               <thead>
                 <tr className="border-b border-border bg-surface-dim">
@@ -67,7 +150,7 @@ export default function TransactionTable({
                   <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">내용</th>
                   <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">금액</th>
                   {hasActions && (
-                    <th className="px-4 py-2.5 text-center text-dim font-semibold tracking-wide uppercase">액션</th>
+                    <th className="px-4 py-2.5 text-center text-dim font-semibold tracking-wide uppercase w-[160px]">액션</th>
                   )}
                 </tr>
               </thead>
@@ -96,43 +179,25 @@ export default function TransactionTable({
                           </span>
                         )}
                       </td>
-                      <td className={`px-4 py-3 text-right font-semibold tabular-nums whitespace-nowrap ${isTransfer ? 'text-sodam' : isExpense ? 'text-red-400' : 'text-emerald-400'}`}>
-                        {isTransfer ? (tx.type === 'transfer_out' ? '↑' : '↓') : isExpense ? '-' : '+'}{formatKRW(tx.amount)}
+                      <td className={`px-4 py-3 text-right font-semibold tabular-nums whitespace-nowrap ${amountClass(isTransfer, isExpense)}`}>
+                        {amountPrefix(isTransfer, isExpense, tx.type)}{formatKRW(tx.amount)}
                       </td>
                       {hasActions && (
                         <td className="px-4 py-3 text-center whitespace-nowrap">
                           {onEdit && (
-                            <button
-                              onClick={() => onEdit(tx)}
-                              className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-text hover:bg-surface transition-all"
-                              title="수정"
-                            >
-                              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                                <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
-                              </svg>
-                            </button>
+                            <IconButton onClick={() => onEdit(tx)} title="수정">
+                              <EditIcon />
+                            </IconButton>
                           )}
                           {onDelete && (
-                            <button
-                              onClick={() => onDelete(tx)}
-                              className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                              title="삭제"
-                            >
-                              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                                <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
-                              </svg>
-                            </button>
+                            <IconButton variant="danger" onClick={() => onDelete(tx)} title="삭제">
+                              <DeleteIcon />
+                            </IconButton>
                           )}
                           {onRegisterRecurring && tx.type !== 'transfer_out' && tx.type !== 'transfer_in' && (
-                            <button
-                              onClick={() => onRegisterRecurring(tx)}
-                              className="inline-flex items-center justify-center w-7 h-7 rounded-md text-dim hover:text-sodam hover:bg-sodam/10 transition-all"
-                              title="반복 등록"
-                            >
-                              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                                <path d="M13.5 8A5.5 5.5 0 113 5.5M3 2v3.5H6.5" />
-                              </svg>
-                            </button>
+                            <IconButton variant="sodam" onClick={() => onRegisterRecurring(tx)} title="반복 등록">
+                              <RecurringIcon />
+                            </IconButton>
                           )}
                         </td>
                       )}

--- a/src/components/rsu/RSUDashboard.tsx
+++ b/src/components/rsu/RSUDashboard.tsx
@@ -6,6 +6,7 @@ import { formatKRW, formatDate } from '@/lib/format'
 import RSUForm from './RSUForm'
 import RSUDeleteModal from './RSUDeleteModal'
 import Disclaimer from '@/components/ui/Disclaimer'
+import IconButton from '@/components/ui/IconButton'
 
 interface RSUSchedule {
   id: string
@@ -184,20 +185,12 @@ export default function RSUDashboard({ schedules: initialSchedules, accounts = [
                       >
                         베스팅
                       </button>
-                      <button
-                        onClick={() => setEditingItem(schedule)}
-                        className="p-1.5 rounded-md text-dim hover:text-text hover:bg-surface transition-all"
-                        title="수정"
-                      >
+                      <IconButton onClick={() => setEditingItem(schedule)} title="수정">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" /></svg>
-                      </button>
-                      <button
-                        onClick={() => setDeletingItem(schedule)}
-                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        title="삭제"
-                      >
+                      </IconButton>
+                      <IconButton variant="danger" onClick={() => setDeletingItem(schedule)} title="삭제">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" /></svg>
-                      </button>
+                      </IconButton>
                     </>
                   )}
                 </>

--- a/src/components/rsu/RSUForm.tsx
+++ b/src/components/rsu/RSUForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 
 interface AccountOption {
   id: string
@@ -102,9 +103,9 @@ export default function RSUForm({ mode, item, accounts, onClose, onSaved }: RSUF
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{isEdit ? 'RSU 수정' : 'RSU 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/settings/IncomeProfileManager.tsx
+++ b/src/components/settings/IncomeProfileManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { formatKRW } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 
 interface IncomeProfile {
   id: string
@@ -57,15 +58,13 @@ export default function IncomeProfileManager() {
                   {p.inputType === 'gross' ? '세전총급여' : '과세표준'}
                 </span>
               </div>
-              <div className="flex gap-1.5">
-                <button onClick={() => { setEditingItem(p); setShowForm(true) }}
-                  className="p-1.5 rounded-md text-dim hover:text-text hover:bg-surface transition-all" title="수정">
+              <div className="flex gap-1">
+                <IconButton onClick={() => { setEditingItem(p); setShowForm(true) }} title="수정">
                   <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" /></svg>
-                </button>
-                <button onClick={() => handleDelete(p.id)}
-                  className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all" title="삭제">
+                </IconButton>
+                <IconButton variant="danger" onClick={() => handleDelete(p.id)} title="삭제">
                   <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" /></svg>
-                </button>
+                </IconButton>
               </div>
             </div>
             <div className="flex gap-6 text-[12px]">
@@ -159,9 +158,9 @@ function IncomeProfileForm({ item, onClose, onSaved }: { item: IncomeProfile | n
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{item ? '프로필 수정' : '프로필 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
-          </button>
+          </IconButton>
         </div>
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">
           <div>

--- a/src/components/stock-option/StockOptionCRUD.tsx
+++ b/src/components/stock-option/StockOptionCRUD.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import StockOptionForm from './StockOptionForm'
 import StockOptionDeleteModal from './StockOptionDeleteModal'
+import IconButton from '@/components/ui/IconButton'
 
 interface StockOptionItem {
   id: string
@@ -35,23 +36,15 @@ export default function StockOptionCRUD({ stockOptions, accounts }: StockOptionC
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 flex-wrap">
           {stockOptions.map((so) => (
-            <div key={so.id} className="inline-flex items-center gap-1.5 text-[12px] text-sub bg-surface-dim border border-border rounded-lg px-3 py-1.5">
+            <div key={so.id} className="inline-flex items-center gap-1.5 text-[12px] text-sub bg-surface-dim border border-border rounded-lg pl-3 pr-1 py-1">
               <span className="text-bright font-medium">{so.displayName}</span>
               <span>{so.totalShares}주</span>
-              <button
-                onClick={() => setEditingItem(so)}
-                className="p-0.5 rounded text-dim hover:text-text transition-all"
-                title="수정"
-              >
+              <IconButton onClick={() => setEditingItem(so)} title="수정">
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" /></svg>
-              </button>
-              <button
-                onClick={() => setDeletingItem(so)}
-                className="p-0.5 rounded text-dim hover:text-red-400 transition-all"
-                title="삭제"
-              >
+              </IconButton>
+              <IconButton variant="danger" onClick={() => setDeletingItem(so)} title="삭제">
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" /></svg>
-              </button>
+              </IconButton>
             </div>
           ))}
         </div>

--- a/src/components/stock-option/StockOptionForm.tsx
+++ b/src/components/stock-option/StockOptionForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 
 interface AccountOption { id: string; name: string }
 
@@ -104,9 +105,9 @@ export default function StockOptionForm({ mode, item, accounts, onClose, onSaved
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{isEdit ? '스톡옵션 수정' : '스톡옵션 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/trade/EditPanel.tsx
+++ b/src/components/trade/EditPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { formatUSD } from '@/lib/format'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import { formatHoldingEditDiff } from '@/lib/holding-diff'
 
 interface Trade {
@@ -126,14 +127,11 @@ export default function EditPanel({ trade, onClose }: EditPanelProps) {
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">거래 수정</h2>
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all"
-          >
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
-          </button>
+          </IconButton>
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">

--- a/src/components/trade/TradeTable.tsx
+++ b/src/components/trade/TradeTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { formatKRW, formatUSD, formatDate } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 import EditPanel from './EditPanel'
 import DeleteModal from './DeleteModal'
 
@@ -145,24 +146,16 @@ export default function TradeTable({ trades, total, limit, offset }: TradeTableP
                   </td>
                   <td className="pr-4 px-3 py-3 border-b border-border">
                     <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => setEditTrade(trade)}
-                        className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                        title="수정"
-                      >
+                      <IconButton onClick={() => setEditTrade(trade)} title="수정">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                         </svg>
-                      </button>
-                      <button
-                        onClick={() => setDeleteTrade(trade)}
-                        className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        title="삭제"
-                      >
+                      </IconButton>
+                      <IconButton variant="danger" onClick={() => setDeleteTrade(trade)} title="삭제">
                         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                           <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                         </svg>
-                      </button>
+                      </IconButton>
                     </div>
                   </td>
                 </tr>
@@ -190,22 +183,16 @@ export default function TradeTable({ trades, total, limit, offset }: TradeTableP
                   </span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => setEditTrade(trade)}
-                    className="p-1.5 rounded-md text-dim hover:text-muted hover:bg-surface transition-all"
-                  >
+                  <IconButton onClick={() => setEditTrade(trade)} title="수정">
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M11.5 1.5l3 3L5 14H2v-3L11.5 1.5z" />
                     </svg>
-                  </button>
-                  <button
-                    onClick={() => setDeleteTrade(trade)}
-                    className="p-1.5 rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all"
-                  >
+                  </IconButton>
+                  <IconButton variant="danger" onClick={() => setDeleteTrade(trade)} title="삭제">
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M2 4h12M5.333 4V2.667a1.333 1.333 0 011.334-1.334h2.666a1.333 1.333 0 011.334 1.334V4m2 0v9.333a1.333 1.333 0 01-1.334 1.334H4.667a1.333 1.333 0 01-1.334-1.334V4h9.334z" />
                     </svg>
-                  </button>
+                  </IconButton>
                 </div>
               </div>
               <div className="flex items-center justify-between text-[12px]">

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { forwardRef, type ButtonHTMLAttributes } from 'react'
+
+type IconButtonVariant = 'default' | 'danger' | 'ghost' | 'sodam'
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * 시각 스타일.
+   * - default: `text-dim` → `text-text`, `bg-surface` (테이블 액션 편집 등 일반)
+   * - danger:  `text-dim` → `text-red-400`, `bg-red-500/10` (삭제 등 파괴적 액션)
+   * - ghost:   `text-sub` → `text-bright`, `bg-surface` (form 헤더 닫기 X)
+   * - sodam:   `text-dim` → `text-sodam`, `bg-sodam/10` (예: 반복 등록 아이콘)
+   */
+  variant?: IconButtonVariant
+}
+
+const VARIANT_CLASSES: Record<IconButtonVariant, string> = {
+  default: 'text-dim hover:text-text hover:bg-surface',
+  danger: 'text-dim hover:text-red-400 hover:bg-red-500/10',
+  ghost: 'text-sub hover:text-bright hover:bg-surface',
+  sodam: 'text-dim hover:text-sodam hover:bg-sodam/10',
+}
+
+const BASE_CLASSES =
+  'inline-flex items-center justify-center w-11 h-11 rounded-md transition-all disabled:opacity-20 disabled:cursor-not-allowed'
+
+/**
+ * Phase 39-B (#451) — 44×44 hitbox 보장 아이콘 버튼.
+ * WCAG 2.5.5 / Apple HIG 44×44 준수. 아이콘 시각 크기는 children svg 그대로 유지.
+ * 색상 스킴은 variant 로 선택; 소수 예외 (예: `hover:text-muted`) 는 className 오버라이드.
+ */
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(
+  { variant = 'default', className = '', type, children, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type ?? 'button'}
+      className={`${BASE_CLASSES} ${VARIANT_CLASSES[variant]} ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+})
+
+export default IconButton

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -22,8 +22,12 @@ const VARIANT_CLASSES: Record<IconButtonVariant, string> = {
   sodam: 'text-dim hover:text-sodam hover:bg-sodam/10',
 }
 
+// Codex #460 P2: `w-11 h-11` 만으로는 flex 컨테이너 안에서 축소 가능
+// (다른 flex item 이 공간을 요구하면 브라우저가 44 이하로 shrink).
+// `shrink-0` + `min-w-11 min-h-11` 로 실제 44×44 hitbox 계약 잠금.
+// 예: CategoryTable mobile 은 4 IconButton + label 이 좁은 viewport 에서 경쟁.
 const BASE_CLASSES =
-  'inline-flex items-center justify-center w-11 h-11 rounded-md transition-all disabled:opacity-20 disabled:cursor-not-allowed'
+  'inline-flex items-center justify-center shrink-0 w-11 h-11 min-w-11 min-h-11 rounded-md transition-all disabled:opacity-20 disabled:cursor-not-allowed'
 
 /**
  * Phase 39-B (#451) — 44×44 hitbox 보장 아이콘 버튼.

--- a/src/components/watchlist/WatchlistForm.tsx
+++ b/src/components/watchlist/WatchlistForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useToast } from '@/components/ui/Toast'
+import IconButton from '@/components/ui/IconButton'
 import type { WatchlistRow } from './WatchlistTable'
 
 interface WatchlistFormProps {
@@ -94,9 +95,9 @@ export default function WatchlistForm({ mode, item, onClose, onSaved }: Watchlis
       <div className="fixed top-0 right-0 h-full w-full max-w-[420px] bg-bg-raised border-l border-border z-50 overflow-y-auto animate-slide-in">
         <div className="px-6 py-5 border-b border-border flex items-center justify-between">
           <h2 className="text-[15px] font-bold text-bright">{isEdit ? '관심종목 수정' : '관심종목 추가'}</h2>
-          <button onClick={onClose} className="p-1.5 rounded-md text-sub hover:text-bright hover:bg-surface transition-all">
+          <IconButton variant="ghost" onClick={onClose} aria-label="닫기">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M4 4l8 8M12 4l-8 8" /></svg>
-          </button>
+          </IconButton>
         </div>
         <form onSubmit={handleSubmit} className="px-6 py-5 flex flex-col gap-5">
           <div className="grid grid-cols-2 gap-3">

--- a/src/components/watchlist/WatchlistTable.tsx
+++ b/src/components/watchlist/WatchlistTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { formatKRW, formatUSD } from '@/lib/format'
+import IconButton from '@/components/ui/IconButton'
 
 function formatPrice(value: number, market: string): string {
   return market === 'US' ? formatUSD(value) : formatKRW(value)
@@ -32,6 +33,30 @@ const STRATEGY_COLORS: Record<string, string> = {
   scalp: 'bg-red-500/15 text-red-400 border-red-500/25',
 }
 
+const EditIcon = ({ size = 13 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" />
+  </svg>
+)
+
+const DeleteIcon = ({ size = 13 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" />
+  </svg>
+)
+
+function isNearTargetPrice(item: WatchlistRow): boolean {
+  return item.currentPrice !== null && item.targetBuy !== null && item.currentPrice <= item.targetBuy
+}
+
+function isInEntryRange(item: WatchlistRow): boolean {
+  return item.currentPrice !== null
+    && item.entryLow !== null
+    && item.entryHigh !== null
+    && item.currentPrice >= item.entryLow
+    && item.currentPrice <= item.entryHigh
+}
+
 export default function WatchlistTable({ items, onEdit, onDelete }: WatchlistTableProps) {
   return (
     <div className="rounded-[14px] border border-border bg-card overflow-hidden">
@@ -43,64 +68,113 @@ export default function WatchlistTable({ items, onEdit, onDelete }: WatchlistTab
       {items.length === 0 ? (
         <div className="px-5 py-10 text-center text-[13px] text-sub">관심종목이 없습니다.</div>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-[12px]">
-            <thead>
-              <tr className="border-b border-border bg-surface-dim">
-                <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">종목</th>
-                <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">전략</th>
-                <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">현재가</th>
-                <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">목표가</th>
-                <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">매수 구간</th>
-                <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">메모</th>
-                <th className="px-4 py-2.5 text-center text-dim font-semibold tracking-wide uppercase w-[70px]">액션</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((item) => {
-                const isNearTarget = item.currentPrice !== null && item.targetBuy !== null && item.currentPrice <= item.targetBuy
-                const isInRange = item.currentPrice !== null && item.entryLow !== null && item.entryHigh !== null
-                  && item.currentPrice >= item.entryLow && item.currentPrice <= item.entryHigh
-
-                return (
-                  <tr key={item.id} className="border-b border-border last:border-0 hover:bg-surface-dim transition-colors">
-                    <td className="px-4 py-3">
-                      <div className="text-bright font-medium">{item.displayName}</div>
+        <>
+          {/* Mobile 카드 뷰 (<lg) — 손가락 스와이프 없이 종목 · 전략 · 현재가 · 목표가 한눈에 */}
+          <div className="lg:hidden divide-y divide-border">
+            {items.map((item) => {
+              const highlight = isNearTargetPrice(item) || isInEntryRange(item)
+              return (
+                <div key={item.id} className="px-4 py-3.5">
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2 mb-0.5">
+                        <span className="text-[13px] font-bold text-bright truncate">{item.displayName}</span>
+                        <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold border shrink-0 ${STRATEGY_COLORS[item.strategy] ?? 'text-sub border-border'}`}>
+                          {item.strategy}
+                        </span>
+                      </div>
                       <div className="text-[11px] text-dim">{item.ticker} · {item.market}</div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold border ${STRATEGY_COLORS[item.strategy] ?? 'text-sub border-border'}`}>
-                        {item.strategy}
-                      </span>
-                    </td>
-                    <td className={`px-4 py-3 text-right font-semibold tabular-nums ${isNearTarget || isInRange ? 'text-emerald-400' : 'text-bright'}`}>
-                      {item.currentPrice !== null ? formatPrice(item.currentPrice, item.market) : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right text-sub tabular-nums">
-                      {item.targetBuy !== null ? formatPrice(item.targetBuy, item.market) : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right text-sub tabular-nums whitespace-nowrap">
-                      {item.entryLow !== null && item.entryHigh !== null
-                        ? `${formatPrice(item.entryLow, item.market)} ~ ${formatPrice(item.entryHigh, item.market)}`
-                        : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-sub max-w-[200px] truncate">
-                      {item.memo ?? '-'}
-                    </td>
-                    <td className="px-4 py-3 text-center whitespace-nowrap">
-                      <button onClick={() => onEdit(item)} className="inline-flex items-center justify-center w-[26px] h-[26px] rounded-md text-dim hover:text-text hover:bg-surface transition-all" title="수정">
-                        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M11.5 2.5l2 2M2 11l-0.5 3.5 3.5-0.5 8.5-8.5-3-3L2 11z" /></svg>
-                      </button>
-                      <button onClick={() => onDelete(item)} className="inline-flex items-center justify-center w-[26px] h-[26px] rounded-md text-dim hover:text-red-400 hover:bg-red-500/10 transition-all" title="삭제">
-                        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 4h10M6 4V3a1 1 0 011-1h2a1 1 0 011 1v1M5 4v9a1 1 0 001 1h4a1 1 0 001-1V4" /></svg>
-                      </button>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className={`text-[13px] font-semibold tabular-nums ${highlight ? 'text-emerald-400' : 'text-bright'}`}>
+                        {item.currentPrice !== null ? formatPrice(item.currentPrice, item.market) : '-'}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-[11px] text-sub tabular-nums min-w-0 flex flex-wrap gap-x-3 gap-y-0.5">
+                      {item.targetBuy !== null && (
+                        <span>목표 {formatPrice(item.targetBuy, item.market)}</span>
+                      )}
+                      {item.entryLow !== null && item.entryHigh !== null && (
+                        <span>구간 {formatPrice(item.entryLow, item.market)} ~ {formatPrice(item.entryHigh, item.market)}</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-0.5 shrink-0">
+                      <IconButton onClick={() => onEdit(item)} title="수정">
+                        <EditIcon />
+                      </IconButton>
+                      <IconButton variant="danger" onClick={() => onDelete(item)} title="삭제">
+                        <DeleteIcon />
+                      </IconButton>
+                    </div>
+                  </div>
+                  {item.memo && (
+                    <div className="text-[11px] text-dim mt-1.5 truncate">{item.memo}</div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Desktop 테이블 (lg:) */}
+          <div className="hidden lg:block overflow-x-auto">
+            <table className="w-full text-[12px]">
+              <thead>
+                <tr className="border-b border-border bg-surface-dim">
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">종목</th>
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">전략</th>
+                  <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">현재가</th>
+                  <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">목표가</th>
+                  <th className="px-4 py-2.5 text-right text-dim font-semibold tracking-wide uppercase">매수 구간</th>
+                  <th className="px-4 py-2.5 text-left text-dim font-semibold tracking-wide uppercase">메모</th>
+                  <th className="px-4 py-2.5 text-center text-dim font-semibold tracking-wide uppercase w-[110px]">액션</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item) => {
+                  const highlight = isNearTargetPrice(item) || isInEntryRange(item)
+
+                  return (
+                    <tr key={item.id} className="border-b border-border last:border-0 hover:bg-surface-dim transition-colors">
+                      <td className="px-4 py-3">
+                        <div className="text-bright font-medium">{item.displayName}</div>
+                        <div className="text-[11px] text-dim">{item.ticker} · {item.market}</div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold border ${STRATEGY_COLORS[item.strategy] ?? 'text-sub border-border'}`}>
+                          {item.strategy}
+                        </span>
+                      </td>
+                      <td className={`px-4 py-3 text-right font-semibold tabular-nums ${highlight ? 'text-emerald-400' : 'text-bright'}`}>
+                        {item.currentPrice !== null ? formatPrice(item.currentPrice, item.market) : '-'}
+                      </td>
+                      <td className="px-4 py-3 text-right text-sub tabular-nums">
+                        {item.targetBuy !== null ? formatPrice(item.targetBuy, item.market) : '-'}
+                      </td>
+                      <td className="px-4 py-3 text-right text-sub tabular-nums whitespace-nowrap">
+                        {item.entryLow !== null && item.entryHigh !== null
+                          ? `${formatPrice(item.entryLow, item.market)} ~ ${formatPrice(item.entryHigh, item.market)}`
+                          : '-'}
+                      </td>
+                      <td className="px-4 py-3 text-sub max-w-[200px] truncate">
+                        {item.memo ?? '-'}
+                      </td>
+                      <td className="px-4 py-3 text-center whitespace-nowrap">
+                        <IconButton onClick={() => onEdit(item)} title="수정">
+                          <EditIcon />
+                        </IconButton>
+                        <IconButton variant="danger" onClick={() => onDelete(item)} title="삭제">
+                          <DeleteIcon />
+                        </IconButton>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
39-A audit 청사진 (H1+M1+M2) 실행. 대시보드/거래/가계부 3개 페이지 모바일 UX 리팩터.

## 변경 규모
- **26 파일, +505 / -307**
- 신규 컴포넌트 1개: `IconButton` (44×44 hitbox 보장, 4 variants)
- IconButton sweep 20+ 사용처 (form 헤더 닫기 + 테이블 액션)
- 3개 테이블 mobile 카드 뷰: HoldingsTable · WatchlistTable · TransactionTable
- BudgetManager row 재구성: 5-child grid 유지, mobile 3col + 사용·잔액 summary
- RecurringForm fixed input width fix

## Audit 항목 반영

| 항목 | 상태 |
|---|---|
| **H1** 8+ 컬럼 테이블 수평 스크롤 | ✅ 3 테이블 카드 뷰로 해결 |
| **M1** 아이콘 <44px sweep | ✅ IconButton 도입 + 코드베이스 sweep |
| **M2** BudgetManager grid + RecurringForm fixed width | ✅ audit 옵션 (a) 마크업 적용 |
| **M3** form 3-col grids | ⏭ 스킵 (실측 셀 폭 100px+ 확보, audit "시간 남으면" 조건) |

## Self-review 반영
- **P1** HoldingsTable mobile 카드에 현재가 누락 → USD 종목 사용자가 평단과 상대 위치 파악 불가. 통화 분기 (USD/KRW) 한 줄 추가 (a99764c).

## 트레이드오프
- IconButton `hover:text-muted` → `hover:text-text` 로 통일 (일부 테이블 hover 색 미세 변경, API 단순성 우선)
- StockOptionCRUD chip 컨테이너 `pl-3 pr-1 py-1` 로 조정 (44px hitbox + chip 밸런스)
- UI 컴포넌트 테스트 인프라 부재 (testing-library 미설치) — IconButton 은 CSS 클래스 조합만이라 `w-11 h-11` 상수로 CSS 레벨 잠금
- 카드 뷰 + 테이블 이중 렌더: CSS 로만 `lg:hidden` / `hidden lg:block` 분기. 상태는 단일 스코프 → race 없음

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (678 tests)
- [x] `npm run build` 통과
- [x] pr-review-toolkit self-review P1/P2 = 0 (P1 1건 → fix)
- [ ] 실 device (또는 DevTools 375/430/768) 사용자 spot-check

## Closes
Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)