### PR TITLE
fix(alert): 재발송 시 message HTML escape (Codex #462 P2)

### DIFF
--- a/src/bot/notifications/__tests__/alert-dispatcher.test.ts
+++ b/src/bot/notifications/__tests__/alert-dispatcher.test.ts
@@ -176,7 +176,7 @@ describe('redispatchAlert', () => {
 
   // Codex #462 P2 회귀 방지 — 사용자 입력 (custom strategy name 등) 에 HTML
   // metacharacter 가 들어와도 Telegram HTML parser 를 부수지 않고 plaintext 로 안전 전달.
-  it('HTML metacharacter 를 포함한 message → 전부 escape 후 sendHtml 호출', async () => {
+  it('raw HTML metacharacter 를 포함한 message → 전부 escape 후 sendHtml 호출', async () => {
     vi.mocked(sendHtml).mockResolvedValue(undefined as never)
     const dangerous = { message: 'SOXL < 40 & QQQ > 500 (사용자 & 이름)' }
     await redispatchAlert(dangerous, [42], fakeBot)
@@ -184,6 +184,21 @@ describe('redispatchAlert', () => {
       fakeBot,
       42,
       'SOXL &lt; 40 &amp; QQQ &gt; 500 (사용자 &amp; 이름)',
+    )
+  })
+
+  // Codex #463 P2 회귀 방지 — price-alert 계열 (target/stop/watch_buy/watch_zone) 은
+  // storage 시점에 이미 escapeHtml 된 message 를 저장. decode→escape round-trip 으로
+  // double-encode (`&amp;` → `&amp;amp;`) 방지.
+  it('pre-escaped message (A &amp; B) → decode 후 재escape 로 round-trip 보존', async () => {
+    vi.mocked(sendHtml).mockResolvedValue(undefined as never)
+    const preEscaped = { message: '🎯 A &amp; B (AAPL) 목표가 도달: 100 (목표 &lt;100&gt;)' }
+    await redispatchAlert(preEscaped, [42], fakeBot)
+    // 원본 그대로 (round-trip). `&amp;` 를 `&amp;amp;` 로 double-encode 하지 않음.
+    expect(sendHtml).toHaveBeenCalledWith(
+      fakeBot,
+      42,
+      '🎯 A &amp; B (AAPL) 목표가 도달: 100 (목표 &lt;100&gt;)',
     )
   })
 

--- a/src/bot/notifications/__tests__/alert-dispatcher.test.ts
+++ b/src/bot/notifications/__tests__/alert-dispatcher.test.ts
@@ -25,6 +25,10 @@ vi.mock('../../index', () => ({
 }))
 vi.mock('@/bot/utils/telegram', () => ({
   sendHtml: vi.fn(),
+  // Codex #462 P2: redispatchAlert 이 escapeHtml 을 호출하므로 mock 도 노출 필요.
+  // 실제 로직 (`&` → `&amp;` 등) 을 그대로 replay 해 회귀 테스트가 정확한 escape
+  // 결과를 assert 할 수 있게 함.
+  escapeHtml: (t: string) => t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
 }))
 
 import {
@@ -153,9 +157,12 @@ describe('redispatchAlert', () => {
   })
 
   const fakeBot = {} as Bot
+  // Codex #462 P2: 저장된 message 는 plain-text 요약. sendHtml 에 그대로 넘기면
+  // HTML metacharacter (`<`, `>`, `&`) 가 있는 이름 (예: `SOXL < 40`) 이 Telegram
+  // HTML parser 에서 거부되거나 예상 못한 마크업 렌더. redispatchAlert 는 escape 후 전송.
   const row = { message: '<b>hi</b>' }
 
-  it('모든 chat 성공 → status=sent, successCount=totalChats', async () => {
+  it('모든 chat 성공 → status=sent, successCount=totalChats. escape 후 전송', async () => {
     vi.mocked(sendHtml).mockResolvedValue(undefined as never)
     const res = await redispatchAlert(row, [1, 2, 3], fakeBot)
     expect(res.status).toBe('sent')
@@ -163,7 +170,21 @@ describe('redispatchAlert', () => {
     expect(res.totalChats).toBe(3)
     expect(res.lastError).toBeUndefined()
     expect(sendHtml).toHaveBeenCalledTimes(3)
-    expect(sendHtml).toHaveBeenNthCalledWith(1, fakeBot, 1, '<b>hi</b>')
+    // Raw `<b>hi</b>` 가 아니라 escape 된 `&lt;b&gt;hi&lt;/b&gt;` 로 전송돼야 (Codex #462 P2)
+    expect(sendHtml).toHaveBeenNthCalledWith(1, fakeBot, 1, '&lt;b&gt;hi&lt;/b&gt;')
+  })
+
+  // Codex #462 P2 회귀 방지 — 사용자 입력 (custom strategy name 등) 에 HTML
+  // metacharacter 가 들어와도 Telegram HTML parser 를 부수지 않고 plaintext 로 안전 전달.
+  it('HTML metacharacter 를 포함한 message → 전부 escape 후 sendHtml 호출', async () => {
+    vi.mocked(sendHtml).mockResolvedValue(undefined as never)
+    const dangerous = { message: 'SOXL < 40 & QQQ > 500 (사용자 & 이름)' }
+    await redispatchAlert(dangerous, [42], fakeBot)
+    expect(sendHtml).toHaveBeenCalledWith(
+      fakeBot,
+      42,
+      'SOXL &lt; 40 &amp; QQQ &gt; 500 (사용자 &amp; 이름)',
+    )
   })
 
   it('모든 chat 실패 → status=failed, lastError 세팅', async () => {

--- a/src/bot/notifications/__tests__/alert-dispatcher.test.ts
+++ b/src/bot/notifications/__tests__/alert-dispatcher.test.ts
@@ -160,7 +160,9 @@ describe('redispatchAlert', () => {
   // Codex #462 P2: 저장된 message 는 plain-text 요약. sendHtml 에 그대로 넘기면
   // HTML metacharacter (`<`, `>`, `&`) 가 있는 이름 (예: `SOXL < 40`) 이 Telegram
   // HTML parser 에서 거부되거나 예상 못한 마크업 렌더. redispatchAlert 는 escape 후 전송.
-  const row = { message: '<b>hi</b>' }
+  // Codex #463 P2 (2차): kind 기반 gating — raw kind (custom_strategy 등) 는 그대로
+  // escape, pre-escaped kind (target_hit 등) 는 decode 후 재escape 로 round-trip.
+  const row = { message: '<b>hi</b>', kind: 'custom_strategy' }
 
   it('모든 chat 성공 → status=sent, successCount=totalChats. escape 후 전송', async () => {
     vi.mocked(sendHtml).mockResolvedValue(undefined as never)
@@ -176,9 +178,9 @@ describe('redispatchAlert', () => {
 
   // Codex #462 P2 회귀 방지 — 사용자 입력 (custom strategy name 등) 에 HTML
   // metacharacter 가 들어와도 Telegram HTML parser 를 부수지 않고 plaintext 로 안전 전달.
-  it('raw HTML metacharacter 를 포함한 message → 전부 escape 후 sendHtml 호출', async () => {
+  it('raw kind + HTML metacharacter → 전부 escape 후 sendHtml 호출', async () => {
     vi.mocked(sendHtml).mockResolvedValue(undefined as never)
-    const dangerous = { message: 'SOXL < 40 & QQQ > 500 (사용자 & 이름)' }
+    const dangerous = { message: 'SOXL < 40 & QQQ > 500 (사용자 & 이름)', kind: 'custom_strategy' }
     await redispatchAlert(dangerous, [42], fakeBot)
     expect(sendHtml).toHaveBeenCalledWith(
       fakeBot,
@@ -187,18 +189,35 @@ describe('redispatchAlert', () => {
     )
   })
 
-  // Codex #463 P2 회귀 방지 — price-alert 계열 (target/stop/watch_buy/watch_zone) 은
-  // storage 시점에 이미 escapeHtml 된 message 를 저장. decode→escape round-trip 으로
-  // double-encode (`&amp;` → `&amp;amp;`) 방지.
-  it('pre-escaped message (A &amp; B) → decode 후 재escape 로 round-trip 보존', async () => {
+  // Codex #463 P2 (1차) 회귀 방지 — pre-escaped kind (target_hit 등) 는 decode→escape
+  // round-trip 으로 double-encode 방지.
+  it('pre-escaped kind (target_hit) — decode 후 재escape 로 round-trip 보존', async () => {
     vi.mocked(sendHtml).mockResolvedValue(undefined as never)
-    const preEscaped = { message: '🎯 A &amp; B (AAPL) 목표가 도달: 100 (목표 &lt;100&gt;)' }
+    const preEscaped = {
+      message: '🎯 A &amp; B (AAPL) 목표가 도달: 100 (목표 &lt;100&gt;)',
+      kind: 'target_hit',
+    }
     await redispatchAlert(preEscaped, [42], fakeBot)
-    // 원본 그대로 (round-trip). `&amp;` 를 `&amp;amp;` 로 double-encode 하지 않음.
     expect(sendHtml).toHaveBeenCalledWith(
       fakeBot,
       42,
       '🎯 A &amp; B (AAPL) 목표가 도달: 100 (목표 &lt;100&gt;)',
+    )
+  })
+
+  // Codex #463 P2 (2차) 회귀 방지 — raw kind 에서 사용자가 literal `&amp;` 를 이름에
+  // 넣었으면 decode 하지 않고 그대로 escape 해야 원본 문자 (`&amp;` 리터럴) 보존.
+  it('raw kind + literal HTML entity (custom_strategy 이름) → decode 하지 않음', async () => {
+    vi.mocked(sendHtml).mockResolvedValue(undefined as never)
+    // 사용자가 정말 `&amp;` 라는 리터럴 문자열을 전략 이름으로 사용한 경우
+    const literalEntity = { message: 'A &amp; B 전략 (AAPL) — AND 조건 만족', kind: 'custom_strategy' }
+    await redispatchAlert(literalEntity, [42], fakeBot)
+    // decode 하지 않고 그대로 escape → `&amp;` 가 `&amp;amp;` 로 정확 escape,
+    // Telegram 은 `&amp;` 리터럴 표시 (사용자 원본 존중).
+    expect(sendHtml).toHaveBeenCalledWith(
+      fakeBot,
+      42,
+      'A &amp;amp; B 전략 (AAPL) — AND 조건 만족',
     )
   })
 

--- a/src/bot/notifications/alert-dispatcher.ts
+++ b/src/bot/notifications/alert-dispatcher.ts
@@ -49,6 +49,25 @@ export function createRetryRateLimiter(cooldownMs: number = RETRY_COOLDOWN_MS): 
 export const globalRetryLimiter = createRetryRateLimiter()
 
 /**
+ * HTML entity → literal char (재발송 preprocessing 전용, Codex #463 P2).
+ * `escapeHtml` 의 역함수 (5개 entity: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`).
+ * `&amp;` 를 먼저 처리하면 `&amp;lt;` 같은 nested 는 `&lt;` → `<` 두 스텝이 되지만,
+ * 저장 시엔 nested 가 발생하지 않으므로 순서 무관. 정규식 하나로 처리:
+ */
+export function decodeHtmlEntities(s: string): string {
+  return s.replace(/&(amp|lt|gt|quot|#39);/g, (_, e) => {
+    switch (e) {
+      case 'amp': return '&'
+      case 'lt': return '<'
+      case 'gt': return '>'
+      case 'quot': return '"'
+      case '#39': return "'"
+      default: return _
+    }
+  })
+}
+
+/**
  * 원본 AlertHistory row 를 재발송 대상 subset 으로 좁힌 인터페이스.
  * Prisma AlertHistory 모델과 호환 (Date → firedAt 필드는 미사용이라 생략).
  */
@@ -78,13 +97,18 @@ export async function redispatchAlert(
   chatIds: number[],
   bot: Bot = getBot(),
 ): Promise<RedispatchResult> {
-  // Codex #462 P2: `AlertHistory.message` 는 raw plain-text 요약 (예: custom_strategy
-  // 는 `${s.name} (${s.ticker}) — ...` 그대로). 원본 발송 경로는 사용자 입력
-  // (s.name, holding.name 등) 을 escapeHtml 후 HTML 템플릿에 삽입하지만 이력용
-  // message 는 escape 없이 저장. 그 상태로 sendHtml (parse_mode=HTML) 에 넘기면
-  // `<`, `>`, `&` 를 포함한 이름 (예: `SOXL < 40`) 이 Telegram HTML parser 에서
-  // 거부되거나 예상 못한 마크업 렌더. escape 후 재발송해 plaintext 안전 보장.
-  const safeMessage = escapeHtml(row.message)
+  // Codex #462 · #463 P2: `AlertHistory.message` 저장 상태가 kind 별로 mixed —
+  //   - price-alert target_hit/stop_loss/watch_buy/watch_zone: 이미 escapeHtml
+  //     된 값이 stored 됨 (`A &amp; B`)
+  //   - custom_strategy · drop · surge: raw 로 stored (`SOXL < 40`)
+  // sendHtml (parse_mode=HTML) 로 그대로 넘기면 전자는 정상, 후자는 parser 오류.
+  // 단순 escape 는 전자에 double-encode 유발 (`&amp;amp;`).
+  //
+  // **Fix**: 저장된 message 를 먼저 entity decode 하고 (round-trip), 다시 escape
+  // 해 uniform plaintext 로 전달. pre-escaped: decode→escape = 원본 복원. raw:
+  // decode(no-op)→escape = 안전 escape. 저장 정규화는 별도 이슈로 미룸.
+  const decoded = decodeHtmlEntities(row.message)
+  const safeMessage = escapeHtml(decoded)
   let successCount = 0
   let lastError: string | undefined
   for (const chatId of chatIds) {

--- a/src/bot/notifications/alert-dispatcher.ts
+++ b/src/bot/notifications/alert-dispatcher.ts
@@ -92,23 +92,31 @@ export interface RedispatchResult {
  * 순수 재발송 — 지정 chatIds 로 sendHtml 호출 후 성공 카운트/에러 반환.
  * DB 기록은 caller (route handler) 가 수행 — pure/impure 분리로 테스트 용이.
  */
+/**
+ * Codex #463 P2 (2차): 저장 시점에 escapeHtml 을 이미 적용하는 kind 화이트리스트.
+ * price-alert.ts 에서 `${escapeHtml(name)}` 로 build 후 그대로 store 되는 kind 들.
+ * 나머지 (custom_strategy · drop · surge · fx · ta_signal 등) 는 raw 로 store.
+ */
+const PRE_ESCAPED_KINDS = new Set<string>(['target_hit', 'stop_loss', 'watch_buy', 'watch_zone'])
+
 export async function redispatchAlert(
-  row: Pick<RedispatchTargetRow, 'message'>,
+  row: Pick<RedispatchTargetRow, 'message' | 'kind'>,
   chatIds: number[],
   bot: Bot = getBot(),
 ): Promise<RedispatchResult> {
-  // Codex #462 · #463 P2: `AlertHistory.message` 저장 상태가 kind 별로 mixed —
-  //   - price-alert target_hit/stop_loss/watch_buy/watch_zone: 이미 escapeHtml
-  //     된 값이 stored 됨 (`A &amp; B`)
-  //   - custom_strategy · drop · surge: raw 로 stored (`SOXL < 40`)
-  // sendHtml (parse_mode=HTML) 로 그대로 넘기면 전자는 정상, 후자는 parser 오류.
-  // 단순 escape 는 전자에 double-encode 유발 (`&amp;amp;`).
+  // Codex #462 · #463 P2 (2차): 저장 상태가 kind 별로 mixed —
+  //   - PRE_ESCAPED_KINDS: `A &amp; B` (이미 escape 된 상태로 store)
+  //   - 그 외: `SOXL < 40` (raw)
   //
-  // **Fix**: 저장된 message 를 먼저 entity decode 하고 (round-trip), 다시 escape
-  // 해 uniform plaintext 로 전달. pre-escaped: decode→escape = 원본 복원. raw:
-  // decode(no-op)→escape = 안전 escape. 저장 정규화는 별도 이슈로 미룸.
-  const decoded = decodeHtmlEntities(row.message)
-  const safeMessage = escapeHtml(decoded)
+  // sendHtml (parse_mode=HTML) 로 raw 를 그대로 넘기면 parser 오류. 하지만 모든
+  // kind 를 decode→escape round-trip 하면 raw 케이스에서 사용자가 literal `&amp;`
+  // 를 이름으로 넣었을 때 decoder 가 `&` 로 오해석 → 원본과 다른 문자 렌더.
+  //
+  // **Fix (kind gating):** pre-escaped kind 만 decode 후 재escape (원본 복원).
+  // raw kind 는 그대로 escape (안전 처리 + 사용자 literal entity 존중).
+  const isPreEscaped = PRE_ESCAPED_KINDS.has(row.kind)
+  const normalized = isPreEscaped ? decodeHtmlEntities(row.message) : row.message
+  const safeMessage = escapeHtml(normalized)
   let successCount = 0
   let lastError: string | undefined
   for (const chatId of chatIds) {

--- a/src/bot/notifications/alert-dispatcher.ts
+++ b/src/bot/notifications/alert-dispatcher.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Bot } from 'grammy'
-import { sendHtml } from '@/bot/utils/telegram'
+import { sendHtml, escapeHtml } from '@/bot/utils/telegram'
 import { computeDeliveryStatus, recordAlertHistory, type AlertKind } from './alert-history'
 import { getBot } from '../index'
 import type { AlertHistoryContext } from '@/lib/alert-history/context'
@@ -78,11 +78,18 @@ export async function redispatchAlert(
   chatIds: number[],
   bot: Bot = getBot(),
 ): Promise<RedispatchResult> {
+  // Codex #462 P2: `AlertHistory.message` 는 raw plain-text 요약 (예: custom_strategy
+  // 는 `${s.name} (${s.ticker}) — ...` 그대로). 원본 발송 경로는 사용자 입력
+  // (s.name, holding.name 등) 을 escapeHtml 후 HTML 템플릿에 삽입하지만 이력용
+  // message 는 escape 없이 저장. 그 상태로 sendHtml (parse_mode=HTML) 에 넘기면
+  // `<`, `>`, `&` 를 포함한 이름 (예: `SOXL < 40`) 이 Telegram HTML parser 에서
+  // 거부되거나 예상 못한 마크업 렌더. escape 후 재발송해 plaintext 안전 보장.
+  const safeMessage = escapeHtml(row.message)
   let successCount = 0
   let lastError: string | undefined
   for (const chatId of chatIds) {
     try {
-      await sendHtml(bot, chatId, row.message)
+      await sendHtml(bot, chatId, safeMessage)
       successCount++
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary
Codex bot 이 release PR #462 에서 발견한 P2 fix. v0.15.0 릴리즈 스코프에 포함.

**루트 원인:** `AlertHistory.message` 는 raw plain-text 요약 저장. 재발송 시 `sendHtml` (parse_mode=HTML) 가 raw 를 HTML 로 해석 → 사용자 이름에 `<`, `>`, `&` 포함 시 Telegram HTML parser 거부/오렌더.

**Fix:** `redispatchAlert` 이 `sendHtml` 호출 전 `escapeHtml` 적용.

## 회귀 방지
- 기존 assert 갱신 (`<b>hi</b>` → `&lt;b&gt;hi&lt;/b&gt;`)
- 신규: `<`, `>`, `&` 3종 metacharacter 모두 정확 escape

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (679 tests, +1 신규)
- [x] `npm run build` 통과

## Closes
Codex #462 P2 반영. 이 PR 머지 후 release PR #462 (dev → main) 이 자동 업데이트되어 v0.15.0 릴리즈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)