### PR TITLE
fix(alert): CSV export kind 기반 gating (Codex #462 P2)

### DIFF
--- a/src/app/api/alerts/history/export/__tests__/csv-format.test.ts
+++ b/src/app/api/alerts/history/export/__tests__/csv-format.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from 'vitest'
 import {
   formatKstDateTime,
   stripHtmlForCsv,
+  messageForCsv,
   summarizeContext,
   toCsvRow,
   buildExportFilename,
@@ -48,7 +49,28 @@ describe('formatKstDateTime', () => {
   })
 })
 
-describe('stripHtmlForCsv', () => {
+describe('messageForCsv (Codex #462 P2)', () => {
+  it('pre-escaped kind (target_hit): entity decode', () => {
+    expect(messageForCsv('A &amp; B', 'target_hit')).toBe('A & B')
+    expect(messageForCsv('&lt;100&gt;', 'stop_loss')).toBe('<100>')
+    expect(messageForCsv('&quot;x&quot;', 'watch_buy')).toBe('"x"')
+    expect(messageForCsv('&#39;y&#39;', 'watch_zone')).toBe("'y'")
+  })
+
+  it('raw kind (custom_strategy): message 그대로', () => {
+    expect(messageForCsv('SOXL < 40 > RSI', 'custom_strategy')).toBe('SOXL < 40 > RSI')
+    // 사용자가 literal `&amp;` 를 이름에 넣어도 decode 하지 않음
+    expect(messageForCsv('A &amp; B', 'custom_strategy')).toBe('A &amp; B')
+  })
+
+  it('raw kind (drop/surge/fx/ta_signal): 그대로', () => {
+    for (const kind of ['drop', 'surge', 'fx', 'ta_signal']) {
+      expect(messageForCsv('SOXL < 40', kind)).toBe('SOXL < 40')
+    }
+  })
+})
+
+describe('stripHtmlForCsv (@deprecated Codex #462 P2)', () => {
   it('간단한 태그 제거', () => {
     expect(stripHtmlForCsv('<b>AAPL</b> 급락')).toBe('AAPL 급락')
   })
@@ -150,7 +172,8 @@ describe('toCsvRow', () => {
       ticker: 'AAPL',
       price: 150.5,
       changePercent: -6.2,
-      message: '<b>AAPL</b> 급락',
+      // raw stored message (drop 은 raw kind — HTML 태그 없음).
+      message: '🔴 AAPL (AAPL) 급락: -6.2%',
       deliveryStatus: 'sent',
       recipientCount: 2,
       errorMessage: null,
@@ -162,11 +185,48 @@ describe('toCsvRow', () => {
     expect(row[2]).toBe('AAPL')                  // ticker
     expect(row[3]).toBe('150.5')                 // price
     expect(row[4]).toBe('-6.2')                  // changePercent
-    expect(row[5]).toBe('AAPL 급락')             // message (HTML stripped)
+    expect(row[5]).toBe('🔴 AAPL (AAPL) 급락: -6.2%')  // message (raw preserved)
     expect(row[6]).toBe('sent')                  // deliveryStatus
     expect(row[7]).toBe('2')                     // recipientCount
     expect(row[8]).toBe('')                      // errorMessage (null → '')
     expect(row[9]).toContain('type=drop')        // context summary
+  })
+
+  // Codex #462 P2 회귀 방지 — raw kind (custom_strategy) 의 이름에 `<` `>` 가
+  // 포함되면 이전 stripHtmlForCsv 는 `< 40 >` 을 태그로 오해석해 삭제 → audit CSV
+  // 손상. 이제 messageForCsv 는 raw kind 를 그대로 보존.
+  it('raw kind (custom_strategy) 의 `<...>` 텍스트는 preserve', () => {
+    const row = toCsvRow({
+      firedAt: new Date('2026-07-08T00:00:00Z'),
+      kind: 'custom_strategy',
+      ticker: 'SOXL',
+      price: 40,
+      changePercent: 0,
+      message: 'SOXL < 40 > RSI 30 이하 (SOXL) — AND 조건 만족',
+      deliveryStatus: 'sent',
+      recipientCount: 1,
+      errorMessage: null,
+      contextJson: null,
+    })
+    expect(row[5]).toBe('SOXL < 40 > RSI 30 이하 (SOXL) — AND 조건 만족')
+  })
+
+  // Codex #462 P2 회귀 방지 — pre-escaped kind (target_hit 등) 은 저장 시
+  // `${escapeHtml(name)}` 로 build 됨. CSV 는 사람 읽기용이라 entity decode.
+  it('pre-escaped kind (target_hit) 의 `&amp;` 는 CSV 에서 `&` 로 decode', () => {
+    const row = toCsvRow({
+      firedAt: new Date('2026-07-08T00:00:00Z'),
+      kind: 'target_hit',
+      ticker: 'AAPL',
+      price: 200,
+      changePercent: 1.0,
+      message: '🎯 A &amp; B (AAPL) 목표가 도달: 200 (목표 &lt;200&gt;)',
+      deliveryStatus: 'sent',
+      recipientCount: 1,
+      errorMessage: null,
+      contextJson: null,
+    })
+    expect(row[5]).toBe('🎯 A & B (AAPL) 목표가 도달: 200 (목표 <200>)')
   })
 
   it('null 필드는 빈 문자열로', () => {

--- a/src/app/api/alerts/history/export/csv-format.ts
+++ b/src/app/api/alerts/history/export/csv-format.ts
@@ -38,7 +38,48 @@ export function formatKstDateTime(iso: string | Date): string {
   return `${y}-${m}-${day} ${hh}:${mm}:${ss}`
 }
 
-/** HTML 태그 제거 (message 는 HTML). CSV 는 plain text 로. */
+/**
+ * Codex #462 P2: 저장 시점에 escapeHtml 을 이미 적용하는 kind 화이트리스트
+ * (alert-dispatcher.ts 의 PRE_ESCAPED_KINDS 와 동일). price-alert.ts 에서
+ * `${escapeHtml(name)}` 로 build 후 store 되는 4종. 나머지는 raw.
+ */
+const PRE_ESCAPED_KINDS = new Set<string>(['target_hit', 'stop_loss', 'watch_buy', 'watch_zone'])
+
+/** escapeHtml 의 역함수 — 5 entity (`&amp;` `&lt;` `&gt;` `&quot;` `&#39;`) 만 decode. */
+function decodeHtmlEntities(s: string): string {
+  return s.replace(/&(amp|lt|gt|quot|#39);/g, (_, e) => {
+    switch (e) {
+      case 'amp': return '&'
+      case 'lt': return '<'
+      case 'gt': return '>'
+      case 'quot': return '"'
+      case '#39': return "'"
+      default: return _
+    }
+  })
+}
+
+/**
+ * CSV 셀용 메시지 정규화 (Codex #462 P2).
+ *
+ * 저장 상태가 kind 별로 mixed:
+ *   - PRE_ESCAPED_KINDS: `A &amp; B` 로 저장 → CSV 는 사람 읽기용이라 `A & B` 로 decode
+ *   - 그 외 (raw): 사용자 입력 그대로 → decode 하면 literal `&amp;` 를 `&` 로 오해석하거나
+ *     `SOXL < 40 > RSI` 같은 이름을 `/<[^>]+>/g` 로 잘라 audit 데이터 손상
+ *
+ * **Fix (kind gating):** pre-escaped 만 decode. raw 는 그대로 유지 → 원본 문자 보존.
+ *
+ * `<...>` 태그 strip 은 stored message 에 실제 HTML 태그가 들어가는 경로가 없으므로
+ * 삭제 (이전 regex `/<[^>]+>/g` 는 raw 이름에 대한 false positive 만 유발했음).
+ */
+export function messageForCsv(message: string, kind: string): string {
+  return PRE_ESCAPED_KINDS.has(kind) ? decodeHtmlEntities(message) : message
+}
+
+/**
+ * @deprecated Codex #462 P2: 오탐 유발 (raw 이름 `<...>` 잘림). `messageForCsv(msg, kind)` 사용.
+ * 하위 호환용 wrapper — 새 코드는 messageForCsv 로 이관.
+ */
 export function stripHtmlForCsv(html: string): string {
   return html.replace(/<[^>]+>/g, '')
 }
@@ -99,7 +140,7 @@ export function toCsvRow(row: HistoryCsvSourceRow): string[] {
     row.ticker ?? '',
     row.price != null ? String(row.price) : '',
     row.changePercent != null ? String(row.changePercent) : '',
-    stripHtmlForCsv(row.message),
+    messageForCsv(row.message, row.kind),
     row.deliveryStatus,
     String(row.recipientCount),
     row.errorMessage ?? '',


### PR DESCRIPTION
## Summary
Codex bot 이 release PR #462 에서 발견한 추가 P2. PR #463 (retry escape) 과 동일 root cause 이지만 CSV export path 라서 별도 커밋. 이전 fix branch 에 실수로 얹었던 커밋을 새 branch 로 정리.

**루트 원인:** `stripHtmlForCsv` regex `/<[^>]+>/g` 가 raw kind (custom_strategy) 이름의 `< 40 >` 을 태그로 오해석해 삭제 → audit CSV 손상.

## Fix
`messageForCsv(message, kind)` 도입 — PR #463 과 동일한 kind gating:
- pre-escaped (target_hit/stop_loss/watch_buy/watch_zone): entity decode (CSV 는 사람 읽기용)
- raw (custom_strategy/drop/surge/fx/ta_signal): 그대로 (literal `<...>` 보존)

`toCsvRow` 는 `messageForCsv(row.message, row.kind)` 사용. `stripHtmlForCsv` 는 @deprecated (하위 호환 wrapper).

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (686 tests, +5 신규)
- [x] `npm run build` 통과

## 신규 테스트
- messageForCsv unit (pre-escaped 5 entity decode / raw 5 kind 그대로)
- toCsvRow 통합 (raw `<...>` preserve + pre-escaped `&amp;` decode)

이 PR 머지 후 release PR #462 (dev → main) 이 자동 업데이트되어 v0.15.0 릴리즈 스코프에 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)