### PR TITLE
fix(alert,admin): live tail 자정 grace + custom_strategy NaN RSI (Codex #462 P2)

### DIFF
--- a/src/app/api/admin/mcp-logs/stream/route.ts
+++ b/src/app/api/admin/mcp-logs/stream/route.ts
@@ -32,6 +32,16 @@ function encodeEvent(entry: LogEntry): string {
   return `data: ${JSON.stringify(entry)}\n\n`
 }
 
+/**
+ * Codex #462 P2: `YYYY-MM-DD` 문자열 date 를 days 만큼 이동 (KST 벽시계 기준).
+ * grace window 감지에서 어제 파일명 (`mcp-YYYY-MM-DD.log`) 을 유도.
+ */
+function kstDayOffset(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const shifted = new Date(Date.UTC(y, m - 1, d) + days * 24 * 60 * 60 * 1000)
+  return shifted.toISOString().slice(0, 10)
+}
+
 export async function GET(req: NextRequest) {
   const url = req.nextUrl
   const level = url.searchParams.get('level')?.trim() || undefined
@@ -47,7 +57,18 @@ export async function GET(req: NextRequest) {
   }
 
   const filter: Filter = { level, msg, tool, traceId }
-  const initialDate = todayKst()
+
+  // Codex #462 P2: pino 로거의 5분 주기 rotation check 로 인해 00:00~00:05 KST
+  // grace window 에서는 여전히 어제 파일이 write 대상이다. `todayKst()` 로 무조건
+  // 시딩하면 그 창의 write 를 놓친다 (오늘 파일 미존재 + rotation branch 미 트리거).
+  // 실제 active file 을 존재 여부로 선택 — 오늘 없고 어제 있으면 어제로 시작,
+  // 이후 poll 이 오늘 파일 등장을 감지해 rotation 처리.
+  const today = todayKst()
+  const yesterday = kstDayOffset(today, -1)
+  const initialDate =
+    fs.existsSync(logFilePath(today, false)) ? today :
+    fs.existsSync(logFilePath(yesterday, false)) ? yesterday :
+    today
 
   const encoder = new TextEncoder()
 

--- a/src/bot/notifications/custom-strategy-alert.ts
+++ b/src/bot/notifications/custom-strategy-alert.ts
@@ -269,7 +269,11 @@ async function runScan(chatIds: number[]): Promise<void> {
         snapshot: {
           price: priceRow?.price ?? null,
           changePercent: priceRow?.changePercent ?? null,
-          rsi: taReport?.indicators.rsi14.value ?? null,
+          // Codex #462 P2: `??` 는 NaN 을 null 로 fallback 하지 않음 (NaN 은 non-null).
+          // TA 엔진이 짧은 데이터로 NaN 반환하면 그대로 JSON 저장 → Prisma createMany 가
+          // 전체 batch 를 reject → 발송된 alert 가 이력 저장 실패. buildTaContext 와
+          // 동일한 `Number.isFinite` 정규화로 방어.
+          rsi: Number.isFinite(taReport?.indicators.rsi14.value) ? taReport!.indicators.rsi14.value : null,
           macdCrossover: taReport?.indicators.macd.crossover ?? null,
           bbPosition: taReport?.indicators.bollingerBands.position ?? null,
         },


### PR DESCRIPTION
## Summary
Codex bot 이 release PR #462 에서 발견한 P2 2건. 이전 fix branch 를 착각으로 재사용해 새 branch 로 정리 (사용자 지적).

## Fix

**P2-1 (live tail 자정 grace window):**
pino 로거 5분 rotation check 로 00:00~00:05 KST 는 어제 파일이 write 대상인데 `todayKst()` 로 시딩하면 오늘 파일 미존재 → rotation branch 미 트리거 → grace window write 완전 손실.

`initialDate` 를 active file 존재 여부로 결정:
- 오늘 파일 존재 → today
- 오늘 없고 어제 있음 (grace) → yesterday
- 둘 다 없음 → today (default)

`kstDayOffset` inline 헬퍼로 어제 date 계산.

**P2-2 (custom_strategy snapshot.rsi NaN):**
`??` 는 NaN 을 null fallback 하지 않음. TA 엔진 NaN 반환 → Prisma createMany non-finite 거부 → 발송 성공한 alert 이 history 에서 실종.

`Number.isFinite(...)? ... : null` 정규화 (`buildTaContext` 와 동일).

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (686 tests)
- [x] `npm run build` 통과

통합 테스트 (fs mock + setInterval / orchestrator) 부담이 커 상세 주석으로 defensive 계약 문서화.

머지 시 release PR #462 (dev → main) 자동 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)