### PR TITLE
fix(alert): 상세 모달·리스트도 kind 기반 gating (Codex #462 P2)

### DIFF
--- a/src/app/alerts/history/AlertHistoryClient.tsx
+++ b/src/app/alerts/history/AlertHistoryClient.tsx
@@ -7,7 +7,7 @@ import {
   PieChart, Pie, Cell, Legend,
 } from 'recharts'
 import { KIND_META, kindMetaOf, STATUS_META, type AlertKind } from './kinds'
-import { formatFiredAt, stripHtml, periodFromISO } from './client-utils'
+import { formatFiredAt, messageForDisplay, periodFromISO } from './client-utils'
 import AlertHistoryDetailModal, {
   type AlertHistoryDetailRow,
 } from '@/components/alerts/AlertHistoryDetailModal'
@@ -443,7 +443,7 @@ export default function AlertHistoryClient() {
                         </span>
                       </div>
                       <div className="mt-1.5 text-[13px] text-bright whitespace-pre-line">
-                        {stripHtml(r.message)}
+                        {messageForDisplay(r.message, r.kind)}
                       </div>
                       {r.errorMessage && (
                         <div className="mt-1 text-[11px] text-red-400 font-mono">↳ {r.errorMessage}</div>

--- a/src/app/alerts/history/__tests__/client-utils.test.ts
+++ b/src/app/alerts/history/__tests__/client-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { periodFromISO, formatFiredAt, stripHtml } from '../client-utils'
+import { periodFromISO, formatFiredAt, stripHtml, messageForDisplay } from '../client-utils'
 
 describe('periodFromISO', () => {
   it('N일 전 시각을 ISO 8601 로 반환 (now 주입)', () => {
@@ -40,5 +40,29 @@ describe('stripHtml', () => {
 
   it('평문은 변경 없음', () => {
     expect(stripHtml('안녕하세요')).toBe('안녕하세요')
+  })
+})
+
+// Codex #462 P2 회귀 방지 — kind gating 으로 raw kind 의 `<...>` 이름 보존.
+describe('messageForDisplay', () => {
+  it('pre-escaped kind (target_hit 등) → stripHtml 적용', () => {
+    expect(messageForDisplay('🎯 <b>A &amp; B</b>', 'target_hit')).toBe('🎯 A & B')
+    expect(messageForDisplay('&lt;100&gt;', 'stop_loss')).toBe('<100>')
+    expect(messageForDisplay('<b>x</b>', 'watch_buy')).toBe('x')
+    expect(messageForDisplay('<b>y</b>', 'watch_zone')).toBe('y')
+  })
+
+  it('raw kind (custom_strategy) → 사용자 이름의 `< 40 >` 텍스트 preserve', () => {
+    expect(messageForDisplay('SOXL < 40 > RSI 30 이하', 'custom_strategy'))
+      .toBe('SOXL < 40 > RSI 30 이하')
+    // literal `&amp;` 도 decode 하지 않음
+    expect(messageForDisplay('A &amp; B 전략', 'custom_strategy'))
+      .toBe('A &amp; B 전략')
+  })
+
+  it('raw kind (drop/surge/fx/ta_signal) → 그대로', () => {
+    for (const kind of ['drop', 'surge', 'fx', 'ta_signal']) {
+      expect(messageForDisplay('SOXL < 40', kind)).toBe('SOXL < 40')
+    }
   })
 })

--- a/src/app/alerts/history/client-utils.ts
+++ b/src/app/alerts/history/client-utils.ts
@@ -20,6 +20,9 @@ export function formatFiredAt(iso: string): string {
 /**
  * message 는 텔레그램 발송용 HTML (자체 코드에서 escapeHtml + `<b>` 삽입).
  * 웹에서는 XSS 방어와 시각 단순성을 위해 태그 제거 + HTML 엔티티 역디코드 후 plain text.
+ * ⚠️ pre-escaped kind (price target/stop/watch_buy/watch_zone) 에만 안전 — raw kind
+ * (custom_strategy 등) 에 적용하면 사용자 이름의 `< 40 >` 을 태그로 오인해 삭제한다.
+ * 자동 gating 은 `messageForDisplay` 사용.
  */
 export function stripHtml(s: string): string {
   return s
@@ -30,4 +33,25 @@ export function stripHtml(s: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+}
+
+/**
+ * Codex #462 P2: 저장 시점에 escapeHtml 을 이미 적용하는 kind 화이트리스트
+ * (alert-dispatcher · csv-format 와 동일). price-alert.ts 에서 `${escapeHtml(name)}`
+ * 로 build 후 그대로 store 되는 4종.
+ */
+const PRE_ESCAPED_KINDS = new Set<string>(['target_hit', 'stop_loss', 'watch_buy', 'watch_zone'])
+
+/**
+ * UI 표시용 메시지 정규화 (Codex #462 P2).
+ *
+ * 저장 상태가 kind 별로 mixed:
+ *   - PRE_ESCAPED_KINDS: `A &amp; B` / `&lt;b&gt;`  → stripHtml 로 태그·엔티티 디코드
+ *   - raw (custom_strategy · drop · surge · fx · ta_signal): 사용자 입력 그대로 →
+ *     stripHtml 하면 이름의 `< 40 >` 을 태그로 오인해 삭제
+ *
+ * React 는 `{plaintext}` 를 auto-escape 하므로 raw 를 그대로 렌더해도 XSS 없음.
+ */
+export function messageForDisplay(message: string, kind: string): string {
+  return PRE_ESCAPED_KINDS.has(kind) ? stripHtml(message) : message
 }

--- a/src/components/alerts/AlertHistoryDetailModal.tsx
+++ b/src/components/alerts/AlertHistoryDetailModal.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect } from 'react'
 import { STATUS_META, kindMetaOf } from '@/app/alerts/history/kinds'
-import { formatFiredAt, stripHtml } from '@/app/alerts/history/client-utils'
+import { formatFiredAt, messageForDisplay } from '@/app/alerts/history/client-utils'
 import { conditionToString, type Condition } from '@/lib/custom-strategy/types'
 
 // 상세 모달이 필요로 하는 최소 필드셋. AlertHistoryClient 의 HistoryRow 와 호환.
@@ -96,7 +96,7 @@ export default function AlertHistoryDetailModal({ row, onClose }: Props) {
         <div className="rounded-lg bg-surface-dim border border-border p-3">
           <div className="text-[11px] text-sub mb-1">알림 메시지</div>
           <div className="text-[13px] text-bright whitespace-pre-line">
-            {stripHtml(row.message)}
+            {messageForDisplay(row.message, row.kind)}
           </div>
           {row.errorMessage && (
             <div className="mt-2 pt-2 border-t border-border text-[11px] text-red-400 font-mono">


### PR DESCRIPTION
## Summary
Codex bot 이 release PR #462 에서 발견한 P2. 이전 fix (retry #463 · CSV #464 · live tail #465) 과 **동일 root cause** 가 UI 표시 경로에도 존재.

**루트 원인:** `AlertHistoryDetailModal.tsx:99` 와 `AlertHistoryClient.tsx:446` 이 `stripHtml(row.message)` 를 kind 무관하게 호출 → raw kind (custom_strategy) 이름의 `SOXL < 40 > RSI` 를 태그로 오인해 middle 부분 삭제.

## Fix
`messageForDisplay(message, kind)` 헬퍼 추가 — 다른 fix 파일들의 `PRE_ESCAPED_KINDS` 와 동일 4-item set:
- pre-escaped kind (target_hit/stop_loss/watch_buy/watch_zone): stripHtml 적용
- raw kind: message 그대로 (React auto-escape 로 XSS 없음)

두 사용처 (Modal + List) 갱신. `stripHtml` 은 하위 호환용 유지, 문서 주석에 pre-escaped 전용 경고 추가.

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (689 tests, +3 신규)
- [x] `npm run build` 통과

## 신규 테스트
- pre-escaped kind stripHtml 적용
- raw kind (custom_strategy) 의 `< 40 >` · literal `&amp;` preserve
- raw kind 5종 (drop/surge/fx/ta_signal/custom_strategy) 그대로

머지 시 release PR #462 자동 반영. 이 fix 로 message 표시 경로 3곳 (retry send / CSV export / UI display) 모두 kind gating 통일 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)