### PR TITLE
[Phase 40-B] AdvisorError code 별 fallback 메시지 (#469)

### DIFF
--- a/src/bot/commands/ai.ts
+++ b/src/bot/commands/ai.ts
@@ -3,6 +3,7 @@ import {
   askAdvisor,
   AdvisorTimeoutError,
   AdvisorError,
+  describeAdvisorError,
 } from '@/lib/ai/claude-advisor'
 import { prisma } from '@/lib/prisma'
 import { createTrade } from '@/lib/trade-service'
@@ -74,9 +75,10 @@ function fireAiQuestion(ctx: Context, question: string): void {
       if (error instanceof AdvisorTimeoutError) {
         await ctx.reply('⚠️ AI 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.')
       } else if (error instanceof AdvisorError) {
-        // AdvisorError.message 는 정적 한국어. detail (stderr) 는 console 로만.
-        if (error.detail) console.error(`[bot] AI advisor detail: ${error.detail}`)
-        await ctx.reply(`⚠️ ${error.message}`)
+        // Phase 40-B (#469): code 별 fallback 메시지로 사용자 UX 개선.
+        // detail (stderr) 은 console 로만 (사용자 노출 금지).
+        if (error.detail) console.error(`[bot] AI advisor detail (${error.code}): ${error.detail}`)
+        await ctx.reply(describeAdvisorError(error))
       } else {
         console.error(`[bot] AI 질문 처리 실패: ${sanitizeError(error)}`)
         await ctx.reply('⚠️ AI 질문 처리에 실패했습니다.')

--- a/src/bot/commands/briefing.ts
+++ b/src/bot/commands/briefing.ts
@@ -1,6 +1,6 @@
 import { Bot, Context } from 'grammy'
 import { sendBriefing } from '@/bot/notifications/briefing'
-import { askAdvisor, AdvisorError } from '@/lib/ai/claude-advisor'
+import { askAdvisor, AdvisorError, describeAdvisorError } from '@/lib/ai/claude-advisor'
 import { splitMessage } from '@/bot/utils/formatter'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
 
@@ -98,7 +98,9 @@ function fireTickerAnalysis(ctx: Context, chatId: number, ticker: string): void 
     })
     .catch(async (error) => {
       if (error instanceof AdvisorError) {
-        await ctx.reply(`⚠️ ${error.message}`)
+        // Phase 40-B (#469): code 별 fallback 메시지 (auth_expired 등 원인 힌트).
+        if (error.detail) console.error(`[bot] briefing advisor detail (${error.code}): ${error.detail}`)
+        await ctx.reply(describeAdvisorError(error))
       } else {
         console.error(`[bot] ${ticker} 심층 분석 실패:`, error)
         await ctx.reply(`⚠️ ${ticker} 분석에 실패했습니다. 잠시 후 다시 시도해주세요.`)

--- a/src/bot/notifications/active-review.ts
+++ b/src/bot/notifications/active-review.ts
@@ -8,7 +8,7 @@
 
 import { prisma } from '@/lib/prisma'
 import { getBot } from '@/bot/index'
-import { askAdvisor } from '@/lib/ai/claude-advisor'
+import { askAdvisor, describeAdvisorError } from '@/lib/ai/claude-advisor'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
 import { sendHtml } from '@/bot/utils/telegram'
 import { sanitizeError } from '@/bot/utils/error'
@@ -126,7 +126,11 @@ async function sendReview(
   } catch (error) {
     console.error(`[active-review] ${label} 생성 실패: ${sanitizeError(error)}`)
 
-    const fallback = `📊 ${label} 리뷰 생성에 실패했습니다.\n${fallbackHint}`
+    // Phase 40-B (#469): AdvisorError code 별 fallback 메시지 (auth_expired 등 원인 힌트).
+    // Advisor 관련이 아닌 다른 예외는 hint 유지.
+    const advisorMsg =
+      error instanceof Error && ('code' in error) ? describeAdvisorError(error) : ''
+    const fallback = `📊 ${label} 리뷰 생성에 실패했습니다.\n${advisorMsg || fallbackHint}`
     for (const chatId of chatIds) {
       try {
         await sendHtml(bot, chatId, fallback)

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Phase 40-B (#469) — AdvisorError code 판정 + fallback 메시지 unit tests.
+ *
+ * askAdvisor 자체는 subprocess 를 spawn 하는 통합 성격이라 unit 커버 대상 아님.
+ * pure 함수 (classifyAdvisorError, describeAdvisorError) 와 AdvisorError.code
+ * 계약만 여기서 검증.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  AdvisorError,
+  AdvisorTimeoutError,
+  classifyAdvisorError,
+  describeAdvisorError,
+} from '../claude-advisor'
+
+describe('classifyAdvisorError', () => {
+  it('빈 stderr → unknown', () => {
+    expect(classifyAdvisorError('')).toBe('unknown')
+    expect(classifyAdvisorError(undefined)).toBe('unknown')
+  })
+
+  it('인증 만료 계열 → auth_expired', () => {
+    expect(classifyAdvisorError('Error: not logged in')).toBe('auth_expired')
+    expect(classifyAdvisorError('401 Unauthorized')).toBe('auth_expired')
+    expect(classifyAdvisorError('Invalid credentials')).toBe('auth_expired')
+    expect(classifyAdvisorError('Please login first')).toBe('auth_expired')
+    expect(classifyAdvisorError('Session expired, please re-authenticate')).toBe('auth_expired')
+    expect(classifyAdvisorError('Authentication failed')).toBe('auth_expired')
+  })
+
+  it('쿼터 초과 계열 → quota_exceeded', () => {
+    expect(classifyAdvisorError('Daily quota exceeded')).toBe('quota_exceeded')
+    expect(classifyAdvisorError('Rate limit reached')).toBe('quota_exceeded')
+    expect(classifyAdvisorError('Usage limit exceeded')).toBe('quota_exceeded')
+    expect(classifyAdvisorError('Too many requests')).toBe('quota_exceeded')
+    expect(classifyAdvisorError('HTTP 429 Too Many Requests')).toBe('quota_exceeded')
+  })
+
+  it('MCP 서버 실패 계열 → server_down', () => {
+    expect(classifyAdvisorError('connect ECONNREFUSED 127.0.0.1:4210')).toBe('server_down')
+    expect(classifyAdvisorError('Error: connection refused')).toBe('server_down')
+    expect(classifyAdvisorError('MCP server timeout at connect')).toBe('server_down')
+    expect(classifyAdvisorError('MCP connect failed')).toBe('server_down')
+    expect(classifyAdvisorError('server not responding')).toBe('server_down')
+  })
+
+  it('알려지지 않은 stderr → unknown', () => {
+    expect(classifyAdvisorError('Random error message')).toBe('unknown')
+    expect(classifyAdvisorError('SyntaxError: unexpected token')).toBe('unknown')
+  })
+
+  it('대소문자 무관 매치', () => {
+    expect(classifyAdvisorError('NOT LOGGED IN')).toBe('auth_expired')
+    expect(classifyAdvisorError('QUOTA EXCEEDED')).toBe('quota_exceeded')
+  })
+
+  it('여러 패턴 매치 시 우선순위 (auth > quota > server)', () => {
+    // 인증 문구가 있으면 다른 것보다 우선
+    expect(classifyAdvisorError('unauthorized quota exceeded')).toBe('auth_expired')
+    // 인증 없고 quota + server 동시 → quota 우선
+    expect(classifyAdvisorError('rate limit and connection refused')).toBe('quota_exceeded')
+  })
+})
+
+describe('describeAdvisorError', () => {
+  it('auth_expired → 관리자 문의 안내', () => {
+    const err = new AdvisorError('x', undefined, 'auth_expired')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('인증 갱신')
+    expect(msg).toContain('관리자')
+    // stderr detail 이 노출되면 안 됨
+    expect(msg).not.toContain('stderr')
+  })
+
+  it('quota_exceeded → 사용량 초과 안내', () => {
+    const err = new AdvisorError('x', undefined, 'quota_exceeded')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('사용량 초과')
+    expect(msg).toContain('관리자')
+  })
+
+  it('server_down → 서버 접근 실패', () => {
+    const err = new AdvisorError('x', undefined, 'server_down')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('서버 접근 실패')
+  })
+
+  it('timeout → 시간 초과', () => {
+    const err = new AdvisorTimeoutError(60_000)
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('시간 초과')
+    expect(msg).toContain('다시 시도')
+  })
+
+  it('parse_error → 응답 처리 실패', () => {
+    const err = new AdvisorError('x', undefined, 'parse_error')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('처리할 수 없습니다')
+  })
+
+  it('unknown (기본) → 일시 중단', () => {
+    const err = new AdvisorError('x')
+    expect(err.code).toBe('unknown')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('일시 중단')
+    expect(msg).toContain('관리자')
+  })
+
+  it('AdvisorError/Timeout 이 아닌 일반 Error → unknown 처리', () => {
+    const err = new Error('random')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('일시 중단')
+  })
+
+  // Codex #473 P2 pattern — stderr detail 은 사용자 노출 금지 원칙 재확인
+  it('detail 이 있어도 fallback 메시지에는 노출 안 됨', () => {
+    const err = new AdvisorError(
+      'Claude CLI 종료 코드: 1',
+      'stderr: 401 Unauthorized - credentials expired at line ...',
+      'auth_expired',
+    )
+    const msg = describeAdvisorError(err)
+    expect(msg).not.toContain('stderr')
+    expect(msg).not.toContain('401')
+    expect(msg).not.toContain('credentials')
+  })
+})
+
+describe('AdvisorError.code 계약', () => {
+  it('기본값 unknown', () => {
+    expect(new AdvisorError('x').code).toBe('unknown')
+  })
+
+  it('detail 만 지정해도 code 는 기본값', () => {
+    expect(new AdvisorError('x', 'stderr').code).toBe('unknown')
+  })
+
+  it('code 명시 시 그대로', () => {
+    for (const c of ['auth_expired', 'quota_exceeded', 'server_down', 'parse_error'] as const) {
+      expect(new AdvisorError('x', undefined, c).code).toBe(c)
+    }
+  })
+})
+
+describe('AdvisorTimeoutError.code', () => {
+  it('항상 timeout', () => {
+    expect(new AdvisorTimeoutError(30_000).code).toBe('timeout')
+    expect(new AdvisorTimeoutError(180_000).code).toBe('timeout')
+  })
+})

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -54,7 +54,26 @@ export interface AdvisorResult {
   sessionId: string
 }
 
+/**
+ * Phase 40-B (#469) — AdvisorError 원인 분류.
+ * 사용자 UX 를 위해 fallback 메시지를 code 별로 분기.
+ * - `auth_expired`: Claude CLI 인증 만료 (stderr `not logged in` · `unauthorized` · `credentials` 등)
+ * - `quota_exceeded`: MAX 플랜 쿼터 초과 (`quota` · `rate limit` · `usage limit`)
+ * - `server_down`: MCP 서버 접근 실패 or spawn 실패 (`ECONNREFUSED` · `MCP` + `connect`)
+ * - `timeout`: 별도 `AdvisorTimeoutError` 로 이미 분리되어 있으나 monitor 관점에서 code 통일
+ * - `parse_error`: subprocess 는 성공했지만 응답 JSON 파싱 실패
+ * - `unknown`: 위 어느 패턴에도 매칭 안 됨
+ */
+export type AdvisorErrorCode =
+  | 'auth_expired'
+  | 'quota_exceeded'
+  | 'server_down'
+  | 'timeout'
+  | 'parse_error'
+  | 'unknown'
+
 export class AdvisorTimeoutError extends Error {
+  code: AdvisorErrorCode = 'timeout'
   constructor(timeoutMs: number) {
     super(`AI 응답 시간이 초과되었습니다. (${timeoutMs / 1000}초)`)
     this.name = 'AdvisorTimeoutError'
@@ -64,10 +83,71 @@ export class AdvisorTimeoutError extends Error {
 export class AdvisorError extends Error {
   /** 디버깅용 상세 (예: claude CLI stderr tail). 사용자 노출 금지. */
   detail?: string
-  constructor(message: string, detail?: string) {
+  /** Phase 40-B (#469) — 원인 분류. 미지정 시 unknown. */
+  code: AdvisorErrorCode
+  constructor(message: string, detail?: string, code: AdvisorErrorCode = 'unknown') {
     super(message)
     this.name = 'AdvisorError'
     this.detail = detail
+    this.code = code
+  }
+}
+
+/**
+ * Phase 40-B (#469) — stderr tail 을 pattern matching 해 error code 결정.
+ * pure — 판정 규칙만 담아 test 용이. subprocess 성공/spawn 실패는 caller 에서
+ * 직접 code 지정 (예: `AdvisorError('...', undefined, 'server_down')`).
+ */
+export function classifyAdvisorError(stderr: string | undefined): AdvisorErrorCode {
+  if (!stderr) return 'unknown'
+  const s = stderr.toLowerCase()
+  // 인증 만료 계열 — claude CLI 가 auth 실패 시 뱉는 문구들
+  if (
+    s.includes('not logged in') ||
+    s.includes('unauthorized') ||
+    s.includes('credentials') ||
+    s.includes('please login') ||
+    s.includes('session expired') ||
+    s.includes('authentication')
+  ) return 'auth_expired'
+  // 쿼터 초과 — MAX 플랜 usage limit
+  if (
+    s.includes('quota') ||
+    s.includes('rate limit') ||
+    s.includes('usage limit') ||
+    s.includes('too many requests') ||
+    s.includes('429')
+  ) return 'quota_exceeded'
+  // MCP 서버 접근 실패
+  if (
+    s.includes('econnrefused') ||
+    s.includes('connection refused') ||
+    (s.includes('mcp') && (s.includes('connect') || s.includes('timeout'))) ||
+    s.includes('server not responding')
+  ) return 'server_down'
+  return 'unknown'
+}
+
+/**
+ * Phase 40-B (#469) — code → 사용자에게 표시할 한국어 fallback 메시지.
+ * pure — caller (봇/웹) 는 이 결과를 그대로 사용자에게 노출 (stderr detail 유출 없음).
+ */
+export function describeAdvisorError(err: AdvisorError | AdvisorTimeoutError | Error): string {
+  const code: AdvisorErrorCode =
+    err instanceof AdvisorError || err instanceof AdvisorTimeoutError ? err.code : 'unknown'
+  switch (code) {
+    case 'auth_expired':
+      return '🤖 AI 어드바이저 인증 갱신 필요 — 관리자에게 문의해주세요.'
+    case 'quota_exceeded':
+      return '🤖 AI 어드바이저 사용량 초과 — 관리자에게 문의해주세요. 잠시 후 다시 시도해보세요.'
+    case 'server_down':
+      return '🤖 AI 어드바이저 서버 접근 실패 — 관리자에게 문의해주세요.'
+    case 'timeout':
+      return '⏱ AI 응답 시간 초과 — 잠시 후 다시 시도해주세요.'
+    case 'parse_error':
+      return '🤖 AI 응답을 처리할 수 없습니다 — 잠시 후 다시 시도해주세요.'
+    default:
+      return '🤖 AI 어드바이저 일시 중단 — 관리자에게 문의해주세요.'
   }
 }
 
@@ -263,7 +343,9 @@ export async function askAdvisor(
         // 디버깅 detail: stderr 끝 1KB 만 별도 프로퍼티로 전달 (message 는 사용자 노출 가능한 정적 문장)
         const stderrTail = stderr.slice(-1024)
         if (stderrTail) console.error('[advisor] claude stderr:', stderrTail)
-        reject(new AdvisorError(`Claude CLI 종료 코드: ${code}`, stderrTail || undefined))
+        // Phase 40-B (#469): stderr pattern matching 으로 code 결정 → fallback UX 분기
+        const errorCode = classifyAdvisorError(stderrTail)
+        reject(new AdvisorError(`Claude CLI 종료 코드: ${code}`, stderrTail || undefined, errorCode))
         return
       }
 
@@ -271,7 +353,7 @@ export async function askAdvisor(
         const output: ClaudeJsonOutput = JSON.parse(stdout)
 
         if (output.is_error) {
-          reject(new AdvisorError(`AI 응답 오류: ${output.result}`))
+          reject(new AdvisorError(`AI 응답 오류: ${output.result}`, undefined, 'unknown'))
           return
         }
 
@@ -283,13 +365,14 @@ export async function askAdvisor(
           sessionId: output.session_id ?? '',
         })
       } catch {
-        reject(new AdvisorError('AI 응답을 파싱할 수 없습니다.'))
+        reject(new AdvisorError('AI 응답을 파싱할 수 없습니다.', undefined, 'parse_error'))
       }
     })
 
     child.on('error', (error) => {
       clearTimeout(timer)
-      reject(new AdvisorError(`Claude CLI 실행 오류: ${error.message}`))
+      // Phase 40-B: spawn 실패 (ENOENT / EACCES 등) 는 서버 계열 → server_down
+      reject(new AdvisorError(`Claude CLI 실행 오류: ${error.message}`, undefined, 'server_down'))
     })
   })
 


### PR DESCRIPTION
## Summary
18차 마일스톤 (#467) 서브이슈. 40-A (#468 관리자 alert) 와 페어링해 detect + recover 사이클 완성.

**루트 문제:** subprocess 실패 시 사용자에게 `⚠️ Claude CLI 종료 코드: 1` 같은 기술 문구 노출 → 원인/재시도 시점 판단 불가 → 관리자에게 매번 문의.

## 변경
- `AdvisorError.code: AdvisorErrorCode` 필드 추가 — union type (`auth_expired` | `quota_exceeded` | `server_down` | `timeout` | `parse_error` | `unknown`)
- `classifyAdvisorError(stderr)` pure — stderr pattern matching (auth > quota > server 우선순위, 대소문자 무관)
- `describeAdvisorError(err)` pure — code → 사용자 friendly 한국어 메시지 (stderr detail 절대 노출 X)
- `askAdvisor` 내부 4개 error 발생 지점에 code 자동/명시 지정
- caller 3곳 fallback 갱신: `bot/commands/ai.ts`, `bot/commands/briefing.ts`, `bot/notifications/active-review.ts`

## 사용자 UX 예시 (인증 만료)
| 이전 | 이후 |
|---|---|
| `⚠️ Claude CLI 종료 코드: 1` | `🤖 AI 어드바이저 인증 갱신 필요 — 관리자에게 문의해주세요.` |

40-A 관리자 alert 과 결합:
- **관리자**: 3회 연속 실패 → 상세 진단 (stderr tail + 진단 후보) 텔레그램 alert
- **사용자**: 즉시 code 별 원인 힌트 fallback

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (726 tests, +19 신규)
- [x] `npm run build` 통과

## Follow-up (선택)
아직 fallback 미갱신 caller: monthly-report, ta-signal-alert, strategy parser — 각각 캐치 로직 특수 or 사용자 노출 없음. 관측 후 필요 시 별도 issue.

## Closes
Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)