### PR TITLE
[Phase 41-B] AI chat 코드블록/링크 mobile 오버플로 방지 (#471)

### DIFF
--- a/src/app/ai/AIClient.tsx
+++ b/src/app/ai/AIClient.tsx
@@ -177,7 +177,7 @@ export default function AIClient() {
                   </div>
                 )}
                 <div
-                  className={`max-w-[85%] sm:max-w-[75%] rounded-2xl px-4 py-3 text-[13px] leading-relaxed
+                  className={`min-w-0 max-w-[85%] sm:max-w-[75%] rounded-2xl px-4 py-3 text-[13px] leading-relaxed
                     ${msg.role === 'user'
                       ? 'bg-sejin/15 text-bright rounded-br-md'
                       : 'bg-card border border-border text-text rounded-bl-md'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,15 +133,6 @@ body {
   overflow-wrap: anywhere;
   word-break: break-word;
 }
-/* Phase 41-B (#471): 마크다운 테이블은 mobile 에서만 좌우 스크롤 컨테이너로 (display:block
-   전환은 desktop layout 을 깨뜨릴 수 있어 media query 로 격리). */
-@media (max-width: 640px) {
-  .ai-markdown table {
-    display: block;
-    overflow-x: auto;
-    max-width: 100%;
-  }
-}
 .ai-markdown hr {
   border: none;
   border-top: 1px solid var(--border);
@@ -167,6 +158,17 @@ body {
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
+}
+/* Phase 41-B (#471): 마크다운 테이블은 mobile 에서만 좌우 스크롤 컨테이너로 (display:block
+   전환은 desktop layout 을 깨뜨릴 수 있어 media query 로 격리).
+   Codex #476 P2: 기본 rule 의 `overflow: hidden` shorthand 가 뒤늦게 override 하지
+   않도록 base rule **뒤에** 배치. `overflow-x: auto` 가 hidden 을 최종 덮음. */
+@media (max-width: 640px) {
+  .ai-markdown table {
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+  }
 }
 .ai-markdown th {
   background: var(--surface);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,6 +102,10 @@ body {
   padding: 1px 5px;
   border-radius: 4px;
   font-size: 12px;
+  /* Phase 41-B (#471): 긴 URL·변수명 등 인라인 코드가 message 컨테이너 폭을 넘어
+     좌우 스크롤 유발하지 않도록 강제 wrap. mobile 임팩트 큼 (max-w-[85%] 좁음). */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .ai-markdown pre {
   background: var(--surface-dim);
@@ -112,11 +116,31 @@ body {
   margin: 8px 0;
   font-size: 12px;
   line-height: 1.6;
+  /* Phase 41-B (#471): `overflow-x: auto` 만으로는 부모 폭을 넘어서 pre 자체가
+     확장됨 → message 컨테이너 오버플로우. max-width 를 부모 100% 로 잠금. */
+  max-width: 100%;
 }
 .ai-markdown pre code {
   background: transparent;
   padding: 0;
   color: var(--text);
+  /* pre 안 code 는 wrap 대신 스크롤 (코드 가독성 유지) — 부모 pre 의 overflow-x. */
+  overflow-wrap: normal;
+  word-break: normal;
+}
+/* Phase 41-B (#471): 긴 URL / 인라인 링크가 mobile 폭을 넘어 확장하는 것 방지. */
+.ai-markdown a {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+/* Phase 41-B (#471): 마크다운 테이블은 mobile 에서만 좌우 스크롤 컨테이너로 (display:block
+   전환은 desktop layout 을 깨뜨릴 수 있어 media query 로 격리). */
+@media (max-width: 640px) {
+  .ai-markdown table {
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+  }
 }
 .ai-markdown hr {
   border: none;


### PR DESCRIPTION
## Summary
18차 마일스톤 (#467) 서브이슈. 39-A audit L2.

**루트 문제:** `/ai` 페이지 message `max-w-[85%]` 안에 긴 코드블록 · URL · 테이블이 있으면 부모 폭 넘어 확장 → 좌우 스크롤 유발.

## Fix (globals.css `.ai-markdown` 확장)
- `pre`: `max-width: 100%` 추가 — 기존 `overflow-x: auto` 만으로는 부모 폭 초과
- `code` (인라인): `overflow-wrap: anywhere` + `word-break: break-word` — 긴 URL/변수명 강제 wrap
- `pre code` (블록): wrap 대신 스크롤 (가독성 유지)
- `a`: 링크 텍스트도 wrap
- `table`: `@media (max-width: 640px)` 안에서만 `display: block; overflow-x: auto` — desktop layout 유지, mobile 만 스크롤

## AIClient.tsx
- Message flex 자식에 `min-w-0` — flex 안전장치

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (726 tests)
- [x] `npm run build` 통과
- [ ] 실 device 시각 검증 (긴 코드블록/URL 있는 AI 응답)

## Closes
Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)