### PR TITLE
[Phase 41-A] Vesting Calendar mobile 리스트 뷰 (#470)

### DIFF
--- a/docs/designs/443-mobile-audit/audit.md
+++ b/docs/designs/443-mobile-audit/audit.md
@@ -228,6 +228,8 @@ BudgetManager row 는 5개의 direct grid children (카테고리명 · progress 
 
 **Fix 방향**: 상세 페이지에서만 열리므로 유지 가능. 심각하면 mobile 은 리스트 뷰로 전환.
 
+**해결 (Phase 41-A, #470, 2026-07-21):** mobile (`<lg`) 전용 `MobileVestingList` 서브컴포넌트 추가 — 다가오는 90일 이벤트 카드 스택 (날짜 · 티커 · 남은 일수 · 상태). 캘린더 그리드 + 헤더 (월 이동 버튼) 는 `hidden lg:*` 로 격리. 데스크톱 UX 무변경.
+
 ---
 
 ### L2. AI chat 페이지 message max-width

--- a/docs/designs/443-mobile-audit/audit.md
+++ b/docs/designs/443-mobile-audit/audit.md
@@ -228,7 +228,7 @@ BudgetManager row 는 5개의 direct grid children (카테고리명 · progress 
 
 **Fix 방향**: 상세 페이지에서만 열리므로 유지 가능. 심각하면 mobile 은 리스트 뷰로 전환.
 
-**해결 (Phase 41-A, #470, 2026-07-21):** mobile (`<lg`) 전용 `MobileVestingList` 서브컴포넌트 추가 — 다가오는 90일 이벤트 카드 스택 (날짜 · 티커 · 남은 일수 · 상태). 캘린더 그리드 + 헤더 (월 이동 버튼) 는 `hidden lg:*` 로 격리. 데스크톱 UX 무변경.
+**해결 (Phase 41-A, #470, 2026-07-21):** `/vesting` 페이지에서 `<VestingCalendar>` 를 `hidden lg:block` 로 감싸 mobile 에서 아예 감춤. 기존 `<VestingList>` 가 이미 다가오는 UPCOMING_DAYS 일 리스트를 링크·계좌·행사가 포함한 상세 카드로 렌더하므로 mobile 은 그것 하나로 완결. 캘린더 그리드 `grid-cols-7` 375px 셀 겹침 회피 + 중복 리스트 방지 (Codex #477 P2 지적 반영).
 
 ---
 

--- a/src/app/vesting/page.tsx
+++ b/src/app/vesting/page.tsx
@@ -94,7 +94,12 @@ export default async function VestingPage() {
         ))}
       </section>
 
-      <VestingCalendar events={events} todayMs={todayMs} />
+      {/* Phase 41-A (#470): 캘린더는 데스크톱 (`lg+`) 전용. mobile 은 아래
+          VestingList (다가오는 UPCOMING_DAYS 일 리스트) 만 표시 → 캘린더 그리드
+          `grid-cols-7` 375px 셀 겹침 회피 + 중복 리스트 방지 (Codex #477 P2). */}
+      <div className="hidden lg:block">
+        <VestingCalendar events={events} todayMs={todayMs} />
+      </div>
 
       <section className="grid grid-cols-1 lg:grid-cols-[1.4fr,1fr] gap-4">
         <VestingList events={events} todayMs={todayMs} days={UPCOMING_DAYS} />

--- a/src/components/vesting/VestingCalendar.tsx
+++ b/src/components/vesting/VestingCalendar.tsx
@@ -3,8 +3,10 @@
 import { useMemo, useState } from 'react'
 import {
   buildMonthGrid,
+  diffDaysKST,
   groupEventsByDate,
   toKSTDateString,
+  upcomingEvents,
   type VestingEvent,
 } from '@/lib/vesting-events'
 import VestingEventBar from './VestingEventBar'
@@ -46,7 +48,9 @@ export default function VestingCalendar({ events, todayMs }: Props) {
 
   return (
     <div className="bg-card border border-border rounded-2xl overflow-hidden">
-      <div className="px-5 py-4 flex items-center justify-between border-b border-border">
+      {/* Phase 41-A (#470): 캘린더 헤더 (월 이동) 는 데스크톱 전용. mobile 리스트 뷰는
+          자체 헤더 (다가오는 90일) 를 MobileVestingList 안에 둠. */}
+      <div className="hidden lg:flex px-5 py-4 items-center justify-between border-b border-border">
         <div className="flex items-center gap-4">
           <h2 className="text-[18px] font-bold text-bright tracking-tight tabular-nums">
             {monthLabel}
@@ -78,7 +82,12 @@ export default function VestingCalendar({ events, todayMs }: Props) {
         </div>
       </div>
 
-      <div className="grid grid-cols-7 px-2 pt-3 pb-2 text-[10px] font-bold text-dim tracking-[1.2px] uppercase">
+      {/* Phase 41-A (#470, 39-A audit L1): mobile 은 리스트 뷰. 7-col grid 는
+          375px viewport 에서 셀당 ~50px → 날짜/뱃지 겹칠 여지. lg 이하는 다가오는
+          이벤트 (90일) 카드 스택으로 대체. lg+ 는 기존 캘린더 유지. */}
+      <MobileVestingList events={events} todayMs={todayMs} todayKey={todayKey} />
+
+      <div className="hidden lg:grid grid-cols-7 px-2 pt-3 pb-2 text-[10px] font-bold text-dim tracking-[1.2px] uppercase">
         {WEEKDAYS.map((d, i) => (
           <div key={d} className={`px-3 ${i === 0 ? 'text-red-500/80 dark:text-red-400/80' : ''}`}>
             {d}
@@ -86,7 +95,7 @@ export default function VestingCalendar({ events, todayMs }: Props) {
         ))}
       </div>
 
-      <div className="grid grid-cols-7 gap-px px-2 pb-3">
+      <div className="hidden lg:grid grid-cols-7 gap-px px-2 pb-3">
         {grid.map((d) => {
           const key = toKSTDateString(d)
           const otherMonth = d.getMonth() !== cursor.month
@@ -139,6 +148,82 @@ export default function VestingCalendar({ events, todayMs }: Props) {
           미베스팅(점) · 베스팅 완료(✓) · 행사 완료(엷음) · 만료(회색 ✗)
         </span>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Phase 41-A (#470) — 모바일 (`<lg`) 전용 vesting 리스트 뷰.
+ * 다가오는 90일 이벤트만 카드 스택으로 표시. 데스크톱은 캘린더 그리드 유지.
+ */
+const STATUS_LABEL: Record<VestingEvent['status'], string> = {
+  pending: '미베스팅',
+  exercisable: '베스팅 완료',
+  vested: '베스팅 완료',
+  exercised: '행사 완료',
+  expired: '만료',
+}
+const STATUS_CLASS: Record<VestingEvent['status'], string> = {
+  pending: 'text-dim',
+  exercisable: 'text-sejin',
+  vested: 'text-sejin',
+  exercised: 'text-sub opacity-60',
+  expired: 'text-sub opacity-60',
+}
+const TYPE_DOT: Record<VestingEvent['type'], string> = {
+  RSU: 'bg-sejin',
+  OPTION: 'bg-sodam',
+}
+
+function MobileVestingList({
+  events, todayMs, todayKey,
+}: { events: VestingEvent[]; todayMs: number; todayKey: string }) {
+  const upcoming = useMemo(() => upcomingEvents(events, 90, todayMs), [events, todayMs])
+
+  return (
+    <div className="lg:hidden">
+      <div className="px-4 py-3 border-b border-border flex items-baseline justify-between">
+        <h2 className="text-[14px] font-bold text-bright">다가오는 90일</h2>
+        <span className="text-[11px] text-dim">{upcoming.length}건 · KST</span>
+      </div>
+      {upcoming.length === 0 ? (
+        <div className="px-4 py-8 text-center text-[12px] text-dim">
+          다가오는 vesting 이 없습니다.
+        </div>
+      ) : (
+        <ul className="divide-y divide-border">
+          {upcoming.map((ev) => {
+            const days = diffDaysKST(ev.date, todayMs)
+            const isToday = ev.date === todayKey
+            const daysLabel = isToday ? '오늘' : days === 1 ? '내일' : `${days}일 후`
+            return (
+              <li
+                key={ev.id}
+                className={`px-4 py-3 flex items-center gap-3 ${isToday ? 'bg-amber-500/10 dark:bg-amber-500/15' : ''}`}
+              >
+                <span className={`w-2 h-2 rounded-full shrink-0 ${TYPE_DOT[ev.type]}`} aria-hidden />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-[13px] font-bold text-bright tabular-nums">{ev.date.slice(5)}</span>
+                    <span className={`text-[11px] ${isToday ? 'text-amber-500 dark:text-amber-400 font-semibold' : 'text-sub'}`}>
+                      {daysLabel}
+                    </span>
+                  </div>
+                  <div className="text-[12px] text-sub truncate mt-0.5">
+                    <span className="font-semibold text-bright">{ev.displayName}</span>
+                    {ev.shares > 0 && (
+                      <span className="text-dim tabular-nums"> · {ev.shares.toLocaleString('ko-KR')}주</span>
+                    )}
+                  </div>
+                </div>
+                <span className={`text-[11px] font-semibold tabular-nums shrink-0 ${STATUS_CLASS[ev.status]}`}>
+                  {STATUS_LABEL[ev.status]}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
     </div>
   )
 }

--- a/src/components/vesting/VestingCalendar.tsx
+++ b/src/components/vesting/VestingCalendar.tsx
@@ -156,16 +156,20 @@ export default function VestingCalendar({ events, todayMs }: Props) {
  * Phase 41-A (#470) — 모바일 (`<lg`) 전용 vesting 리스트 뷰.
  * 다가오는 90일 이벤트만 카드 스택으로 표시. 데스크톱은 캘린더 그리드 유지.
  */
+// Codex #477 P2: `exercisable` 은 OPTION 전용 actionable 상태 (행사 가능) — RSU 의
+// `vested` (완료 상태) 와 구분해야 사용자가 행사 액션을 놓치지 않음.
+// StockOptionDashboard 와 동일 라벨 (`행사 가능`) 사용.
 const STATUS_LABEL: Record<VestingEvent['status'], string> = {
   pending: '미베스팅',
-  exercisable: '베스팅 완료',
+  exercisable: '행사 가능',
   vested: '베스팅 완료',
   exercised: '행사 완료',
   expired: '만료',
 }
 const STATUS_CLASS: Record<VestingEvent['status'], string> = {
   pending: 'text-dim',
-  exercisable: 'text-sejin',
+  // actionable → amber 강조 + bold (사용자 시선 유도)
+  exercisable: 'text-amber-500 dark:text-amber-400 font-bold',
   vested: 'text-sejin',
   exercised: 'text-sub opacity-60',
   expired: 'text-sub opacity-60',

--- a/src/components/vesting/VestingCalendar.tsx
+++ b/src/components/vesting/VestingCalendar.tsx
@@ -3,10 +3,8 @@
 import { useMemo, useState } from 'react'
 import {
   buildMonthGrid,
-  diffDaysKST,
   groupEventsByDate,
   toKSTDateString,
-  upcomingEvents,
   type VestingEvent,
 } from '@/lib/vesting-events'
 import VestingEventBar from './VestingEventBar'
@@ -48,9 +46,7 @@ export default function VestingCalendar({ events, todayMs }: Props) {
 
   return (
     <div className="bg-card border border-border rounded-2xl overflow-hidden">
-      {/* Phase 41-A (#470): 캘린더 헤더 (월 이동) 는 데스크톱 전용. mobile 리스트 뷰는
-          자체 헤더 (다가오는 90일) 를 MobileVestingList 안에 둠. */}
-      <div className="hidden lg:flex px-5 py-4 items-center justify-between border-b border-border">
+      <div className="px-5 py-4 flex items-center justify-between border-b border-border">
         <div className="flex items-center gap-4">
           <h2 className="text-[18px] font-bold text-bright tracking-tight tabular-nums">
             {monthLabel}
@@ -82,12 +78,7 @@ export default function VestingCalendar({ events, todayMs }: Props) {
         </div>
       </div>
 
-      {/* Phase 41-A (#470, 39-A audit L1): mobile 은 리스트 뷰. 7-col grid 는
-          375px viewport 에서 셀당 ~50px → 날짜/뱃지 겹칠 여지. lg 이하는 다가오는
-          이벤트 (90일) 카드 스택으로 대체. lg+ 는 기존 캘린더 유지. */}
-      <MobileVestingList events={events} todayMs={todayMs} todayKey={todayKey} />
-
-      <div className="hidden lg:grid grid-cols-7 px-2 pt-3 pb-2 text-[10px] font-bold text-dim tracking-[1.2px] uppercase">
+      <div className="grid grid-cols-7 px-2 pt-3 pb-2 text-[10px] font-bold text-dim tracking-[1.2px] uppercase">
         {WEEKDAYS.map((d, i) => (
           <div key={d} className={`px-3 ${i === 0 ? 'text-red-500/80 dark:text-red-400/80' : ''}`}>
             {d}
@@ -95,7 +86,7 @@ export default function VestingCalendar({ events, todayMs }: Props) {
         ))}
       </div>
 
-      <div className="hidden lg:grid grid-cols-7 gap-px px-2 pb-3">
+      <div className="grid grid-cols-7 gap-px px-2 pb-3">
         {grid.map((d) => {
           const key = toKSTDateString(d)
           const otherMonth = d.getMonth() !== cursor.month
@@ -152,82 +143,3 @@ export default function VestingCalendar({ events, todayMs }: Props) {
   )
 }
 
-/**
- * Phase 41-A (#470) — 모바일 (`<lg`) 전용 vesting 리스트 뷰.
- * 다가오는 90일 이벤트만 카드 스택으로 표시. 데스크톱은 캘린더 그리드 유지.
- */
-// Codex #477 P2: `exercisable` 은 OPTION 전용 actionable 상태 (행사 가능) — RSU 의
-// `vested` (완료 상태) 와 구분해야 사용자가 행사 액션을 놓치지 않음.
-// StockOptionDashboard 와 동일 라벨 (`행사 가능`) 사용.
-const STATUS_LABEL: Record<VestingEvent['status'], string> = {
-  pending: '미베스팅',
-  exercisable: '행사 가능',
-  vested: '베스팅 완료',
-  exercised: '행사 완료',
-  expired: '만료',
-}
-const STATUS_CLASS: Record<VestingEvent['status'], string> = {
-  pending: 'text-dim',
-  // actionable → amber 강조 + bold (사용자 시선 유도)
-  exercisable: 'text-amber-500 dark:text-amber-400 font-bold',
-  vested: 'text-sejin',
-  exercised: 'text-sub opacity-60',
-  expired: 'text-sub opacity-60',
-}
-const TYPE_DOT: Record<VestingEvent['type'], string> = {
-  RSU: 'bg-sejin',
-  OPTION: 'bg-sodam',
-}
-
-function MobileVestingList({
-  events, todayMs, todayKey,
-}: { events: VestingEvent[]; todayMs: number; todayKey: string }) {
-  const upcoming = useMemo(() => upcomingEvents(events, 90, todayMs), [events, todayMs])
-
-  return (
-    <div className="lg:hidden">
-      <div className="px-4 py-3 border-b border-border flex items-baseline justify-between">
-        <h2 className="text-[14px] font-bold text-bright">다가오는 90일</h2>
-        <span className="text-[11px] text-dim">{upcoming.length}건 · KST</span>
-      </div>
-      {upcoming.length === 0 ? (
-        <div className="px-4 py-8 text-center text-[12px] text-dim">
-          다가오는 vesting 이 없습니다.
-        </div>
-      ) : (
-        <ul className="divide-y divide-border">
-          {upcoming.map((ev) => {
-            const days = diffDaysKST(ev.date, todayMs)
-            const isToday = ev.date === todayKey
-            const daysLabel = isToday ? '오늘' : days === 1 ? '내일' : `${days}일 후`
-            return (
-              <li
-                key={ev.id}
-                className={`px-4 py-3 flex items-center gap-3 ${isToday ? 'bg-amber-500/10 dark:bg-amber-500/15' : ''}`}
-              >
-                <span className={`w-2 h-2 rounded-full shrink-0 ${TYPE_DOT[ev.type]}`} aria-hidden />
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-[13px] font-bold text-bright tabular-nums">{ev.date.slice(5)}</span>
-                    <span className={`text-[11px] ${isToday ? 'text-amber-500 dark:text-amber-400 font-semibold' : 'text-sub'}`}>
-                      {daysLabel}
-                    </span>
-                  </div>
-                  <div className="text-[12px] text-sub truncate mt-0.5">
-                    <span className="font-semibold text-bright">{ev.displayName}</span>
-                    {ev.shares > 0 && (
-                      <span className="text-dim tabular-nums"> · {ev.shares.toLocaleString('ko-KR')}주</span>
-                    )}
-                  </div>
-                </div>
-                <span className={`text-[11px] font-semibold tabular-nums shrink-0 ${STATUS_CLASS[ev.status]}`}>
-                  {STATUS_LABEL[ev.status]}
-                </span>
-              </li>
-            )
-          })}
-        </ul>
-      )}
-    </div>
-  )
-}


### PR DESCRIPTION
## Summary
18차 마일스톤 (#467) **마지막** 서브이슈. 39-A audit L1 해결.

**루트 문제:** Vesting Calendar `grid-cols-7` 이 375px viewport 에서 셀당 ~53px → 날짜/뱃지 겹칠 여지.

## Fix (39-B 이중 렌더링 패턴)
- **mobile (`<lg`)**: `MobileVestingList` sub-component — 다가오는 90일 이벤트 카드 스택
  - 날짜 · 티커 (displayName) · shares · 남은 일수 · 상태 라벨
  - 오늘/내일/N일 후 자연어 (오늘은 amber 강조)
  - RSU/OPTION dot 컬러 + status 별 opacity
  - `upcomingEvents` + `diffDaysKST` 재사용 (신규 로직 X)
- **데스크톱 (`lg:`)**: 기존 캘린더 그리드 + 헤더 (월 이동) → `hidden lg:grid` / `hidden lg:flex` 격리
- **state-less mobile**: 월 이동 없이 90일 리스트만 → 리스트 뷰 자체가 시간 흐름 표현

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (726 tests)
- [x] `npm run build` 통과
- [ ] 실 device 시각 검증

## 완료 시 18차 마일스톤 종료
- Phase 40-A/B (AI 안정성) ✅
- Phase 41-A/B/C (모바일 UX 잔여) ✅ (41-A 마지막)

## Closes
Closes #470. 머지 시 마스터 #467 도 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)