### PR TITLE
fix(ai): stdout JSON error 파싱 후 classify (Codex #478 P2)

### DIFF
--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -12,6 +12,7 @@ import {
   AdvisorTimeoutError,
   classifyAdvisorError,
   describeAdvisorError,
+  extractAdvisorErrorText,
 } from '../claude-advisor'
 
 describe('classifyAdvisorError', () => {
@@ -53,6 +54,13 @@ describe('classifyAdvisorError', () => {
   it('대소문자 무관 매치', () => {
     expect(classifyAdvisorError('NOT LOGGED IN')).toBe('auth_expired')
     expect(classifyAdvisorError('QUOTA EXCEEDED')).toBe('quota_exceeded')
+  })
+
+  // Codex #479 P2 회귀 방지 — Claude API status code 매칭
+  it('HTTP status code 로도 분류 (401/403 → auth, 429 → quota)', () => {
+    expect(classifyAdvisorError('api_error_status=401')).toBe('auth_expired')
+    expect(classifyAdvisorError('api_error_status=403')).toBe('auth_expired')
+    expect(classifyAdvisorError('api_error_status=429')).toBe('quota_exceeded')
   })
 
   it('여러 패턴 매치 시 우선순위 (auth > quota > server)', () => {
@@ -147,5 +155,41 @@ describe('AdvisorTimeoutError.code', () => {
   it('항상 timeout', () => {
     expect(new AdvisorTimeoutError(30_000).code).toBe('timeout')
     expect(new AdvisorTimeoutError(180_000).code).toBe('timeout')
+  })
+})
+
+// Codex #479 P2 회귀 방지 — Claude JSON 에서 classify 대상 문자열 조립.
+describe('extractAdvisorErrorText', () => {
+  it('result 만 있으면 그대로', () => {
+    expect(extractAdvisorErrorText({ result: 'Not logged in' })).toBe('Not logged in')
+  })
+
+  it('result 비고 api_error_status 만 있으면 status 만 리턴', () => {
+    // Claude 최종 API 실패 (rate limit 등) 시 result 는 비고 status 만 채워짐
+    expect(extractAdvisorErrorText({ result: '', api_error_status: 429 }))
+      .toBe('api_error_status=429')
+  })
+
+  it('result + api_error_status 결합', () => {
+    const text = extractAdvisorErrorText({ result: 'Some error', api_error_status: 401 })
+    expect(text).toContain('Some error')
+    expect(text).toContain('api_error_status=401')
+  })
+
+  it('errors 필드도 stringify 후 결합', () => {
+    const text = extractAdvisorErrorText({ result: 'X', errors: [{ type: 'ratelimit' }] })
+    expect(text).toContain('X')
+    expect(text).toContain('ratelimit')
+  })
+
+  it('빈 output → 빈 문자열', () => {
+    expect(extractAdvisorErrorText({})).toBe('')
+    expect(extractAdvisorErrorText({ result: '' })).toBe('')
+  })
+
+  it('classify 와 결합해 rate-limit (429 only) 정확 분류', () => {
+    // Codex #479 P2 시나리오 — Claude API 429 는 result 없이 api_error_status 만 채워짐
+    const text = extractAdvisorErrorText({ result: '', api_error_status: 429 })
+    expect(classifyAdvisorError(text)).toBe('quota_exceeded')
   })
 })

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -56,11 +56,34 @@ describe('classifyAdvisorError', () => {
     expect(classifyAdvisorError('QUOTA EXCEEDED')).toBe('quota_exceeded')
   })
 
-  // Codex #479 P2 회귀 방지 — Claude API status code 매칭
-  it('HTTP status code 로도 분류 (401/403 → auth, 429 → quota)', () => {
+  // Codex #479 P2 회귀 방지 — Claude API status code 매칭 (명시적 토큰만)
+  it('HTTP status code 매칭 (api_error_status / HTTP / status: / reason phrase)', () => {
+    // Claude JSON 형식
     expect(classifyAdvisorError('api_error_status=401')).toBe('auth_expired')
     expect(classifyAdvisorError('api_error_status=403')).toBe('auth_expired')
     expect(classifyAdvisorError('api_error_status=429')).toBe('quota_exceeded')
+    // colon 형식
+    expect(classifyAdvisorError('api_error_status:401')).toBe('auth_expired')
+    // HTTP prefix
+    expect(classifyAdvisorError('Error: HTTP 401 from Claude API')).toBe('auth_expired')
+    expect(classifyAdvisorError('HTTP/1.1 429 Too Many Requests')).toBe('quota_exceeded')
+    // status: prefix
+    expect(classifyAdvisorError('response status: 403')).toBe('auth_expired')
+    // Reason phrase
+    expect(classifyAdvisorError('got 429 Too Many Requests')).toBe('quota_exceeded')
+    expect(classifyAdvisorError('401 Unauthorized')).toBe('auth_expired')
+  })
+
+  // Codex #479 P2 재수정 회귀 방지 — bare digit substring false positive 방지
+  it('unrelated 401/403/429 숫자 sequence 는 매칭 안 함', () => {
+    // 포트 번호에 4030
+    expect(classifyAdvisorError('bind ECONNREFUSED 127.0.0.1:4030')).toBe('server_down')
+    // 라인 번호 401 (stack trace)
+    expect(classifyAdvisorError('SyntaxError at line 401 col 12')).toBe('unknown')
+    // request id 안 429
+    expect(classifyAdvisorError('request_id=abc429def')).toBe('unknown')
+    // 파일 경로 안 403
+    expect(classifyAdvisorError('cannot read /home/user/403-config.json')).toBe('unknown')
   })
 
   it('여러 패턴 매치 시 우선순위 (auth > quota > server)', () => {

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -64,9 +64,13 @@ describe('classifyAdvisorError', () => {
     expect(classifyAdvisorError('api_error_status=429')).toBe('quota_exceeded')
     // colon 형식
     expect(classifyAdvisorError('api_error_status:401')).toBe('auth_expired')
-    // HTTP prefix
+    // HTTP prefix (with or without protocol version)
     expect(classifyAdvisorError('Error: HTTP 401 from Claude API')).toBe('auth_expired')
     expect(classifyAdvisorError('HTTP/1.1 429 Too Many Requests')).toBe('quota_exceeded')
+    // Codex #479 P2 (3차): 버전 있는 curl-style 도 (reason phrase 없이) 매칭
+    expect(classifyAdvisorError('response: HTTP/1.1 401')).toBe('auth_expired')
+    expect(classifyAdvisorError('got HTTP/2 403 from server')).toBe('auth_expired')
+    expect(classifyAdvisorError('HTTP/1.1 429')).toBe('quota_exceeded')
     // status: prefix
     expect(classifyAdvisorError('response status: 403')).toBe('auth_expired')
     // Reason phrase

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -98,12 +98,32 @@ export class AdvisorError extends Error {
  * pure — 판정 규칙만 담아 test 용이. subprocess 성공/spawn 실패는 caller 에서
  * 직접 code 지정 (예: `AdvisorError('...', undefined, 'server_down')`).
  */
+/**
+ * Codex #479 P2 재수정: bare `'401'` / `'403'` / `'429'` substring 매칭은
+ * false positive 유발 (port 4030 · 라인 401 · request id 포함 등). Claude 가
+ * 실제 뱉는 형태만 명시적으로 매칭 (regex):
+ *   - `api_error_status=401` (extractAdvisorErrorText 조립 형식)
+ *   - `HTTP 401` / `HTTP/1.1 401` (curl-style)
+ *   - `status: 401` (JSON stringify or log format)
+ *   - `401 Unauthorized` / `403 Forbidden` (HTTP standard reason)
+ */
+const AUTH_STATUS_PATTERNS: RegExp[] = [
+  /api_error_status[=:]\s*(?:401|403)\b/i,
+  /\bhttp[/ ]+(?:401|403)\b/i,
+  /\bstatus[:\s]+(?:401|403)\b/i,
+  /\b(?:401|403)\s+(?:unauthorized|forbidden)\b/i,
+]
+const QUOTA_STATUS_PATTERNS: RegExp[] = [
+  /api_error_status[=:]\s*429\b/i,
+  /\bhttp[/ ]+429\b/i,
+  /\bstatus[:\s]+429\b/i,
+  /\b429\s+(?:too\s+many\s+requests|rate\s+limit)\b/i,
+]
+
 export function classifyAdvisorError(stderr: string | undefined): AdvisorErrorCode {
   if (!stderr) return 'unknown'
   const s = stderr.toLowerCase()
-  // 인증 만료 계열 — claude CLI 가 auth 실패 시 뱉는 문구들. Codex #479 P2:
-  // Claude API `api_error_status=401` / `403` 도 auth 로 분류 (rate limit 은 429 →
-  // quota_exceeded 로 이미 매칭).
+  // 인증 만료 계열 — claude CLI 가 auth 실패 시 뱉는 문구들.
   if (
     s.includes('not logged in') ||
     s.includes('unauthorized') ||
@@ -111,8 +131,7 @@ export function classifyAdvisorError(stderr: string | undefined): AdvisorErrorCo
     s.includes('please login') ||
     s.includes('session expired') ||
     s.includes('authentication') ||
-    s.includes('401') ||
-    s.includes('403')
+    AUTH_STATUS_PATTERNS.some((re) => re.test(stderr))
   ) return 'auth_expired'
   // 쿼터 초과 — MAX 플랜 usage limit
   if (
@@ -120,7 +139,7 @@ export function classifyAdvisorError(stderr: string | undefined): AdvisorErrorCo
     s.includes('rate limit') ||
     s.includes('usage limit') ||
     s.includes('too many requests') ||
-    s.includes('429')
+    QUOTA_STATUS_PATTERNS.some((re) => re.test(stderr))
   ) return 'quota_exceeded'
   // MCP 서버 접근 실패
   if (

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -107,15 +107,17 @@ export class AdvisorError extends Error {
  *   - `status: 401` (JSON stringify or log format)
  *   - `401 Unauthorized` / `403 Forbidden` (HTTP standard reason)
  */
+// Codex #479 P2 (3차): `HTTP/1.1 401` 처럼 protocol version 이 사이에 있는
+// curl-style 도 매칭 지원 — `http` (optional `/N.N` version) + 공백/slash + status.
 const AUTH_STATUS_PATTERNS: RegExp[] = [
   /api_error_status[=:]\s*(?:401|403)\b/i,
-  /\bhttp[/ ]+(?:401|403)\b/i,
+  /\bhttp(?:\/[\d.]+)?[\s/]+(?:401|403)\b/i,
   /\bstatus[:\s]+(?:401|403)\b/i,
   /\b(?:401|403)\s+(?:unauthorized|forbidden)\b/i,
 ]
 const QUOTA_STATUS_PATTERNS: RegExp[] = [
   /api_error_status[=:]\s*429\b/i,
-  /\bhttp[/ ]+429\b/i,
+  /\bhttp(?:\/[\d.]+)?[\s/]+429\b/i,
   /\bstatus[:\s]+429\b/i,
   /\b429\s+(?:too\s+many\s+requests|rate\s+limit)\b/i,
 ]

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -101,14 +101,18 @@ export class AdvisorError extends Error {
 export function classifyAdvisorError(stderr: string | undefined): AdvisorErrorCode {
   if (!stderr) return 'unknown'
   const s = stderr.toLowerCase()
-  // 인증 만료 계열 — claude CLI 가 auth 실패 시 뱉는 문구들
+  // 인증 만료 계열 — claude CLI 가 auth 실패 시 뱉는 문구들. Codex #479 P2:
+  // Claude API `api_error_status=401` / `403` 도 auth 로 분류 (rate limit 은 429 →
+  // quota_exceeded 로 이미 매칭).
   if (
     s.includes('not logged in') ||
     s.includes('unauthorized') ||
     s.includes('credentials') ||
     s.includes('please login') ||
     s.includes('session expired') ||
-    s.includes('authentication')
+    s.includes('authentication') ||
+    s.includes('401') ||
+    s.includes('403')
   ) return 'auth_expired'
   // 쿼터 초과 — MAX 플랜 usage limit
   if (
@@ -220,6 +224,28 @@ interface ClaudeJsonOutput {
   duration_ms: number
   total_cost_usd: number
   session_id: string
+  // Codex #479 P2: Claude ResultMessage 는 최종 API 실패 시 `result` 는 비고
+  // `api_error_status` 에 HTTP status (예: 429 rate limit) 를 담을 수 있음.
+  // classify 시 이 필드도 참조해야 auth/quota 분류 가능.
+  api_error_status?: number | string
+  errors?: unknown
+}
+
+/**
+ * Codex #479 P2: Claude JSON output 에서 classify 대상 문자열을 조립.
+ * result 뿐 아니라 `api_error_status` (예: `429`) 와 `errors` 필드까지 포함해
+ * `result` 가 비어있어도 auth/quota 분류가 가능하도록. pure — 테스트 용이.
+ */
+export function extractAdvisorErrorText(json: Partial<ClaudeJsonOutput>): string {
+  const parts: string[] = []
+  if (typeof json.result === 'string' && json.result) parts.push(json.result)
+  if (json.api_error_status != null) parts.push(`api_error_status=${json.api_error_status}`)
+  if (json.errors != null) {
+    try {
+      parts.push(typeof json.errors === 'string' ? json.errors : JSON.stringify(json.errors))
+    } catch { /* ignore stringify failure */ }
+  }
+  return parts.join('\n')
 }
 
 /**
@@ -346,11 +372,13 @@ export async function askAdvisor(
         const stderrTail = stderr.slice(-1024)
         if (stderrTail) console.error('[advisor] claude stderr:', stderrTail)
         // stdout JSON 에서 error 문구 추출 시도. 실패해도 stderr fallback.
+        // Codex #479 P2: `result` 뿐 아니라 `api_error_status` (예: 429) · `errors`
+        // 필드까지 결합 — Claude 는 rate limit/최종 실패 시 result 비고 status 만 채움.
         let jsonErrorText = ''
         try {
           const parsed = JSON.parse(stdout) as Partial<ClaudeJsonOutput>
-          if (parsed && typeof parsed.result === 'string') {
-            jsonErrorText = parsed.result
+          if (parsed && typeof parsed === 'object') {
+            jsonErrorText = extractAdvisorErrorText(parsed)
           }
         } catch {
           // stdout 이 JSON 아니거나 partial — stderr 만 사용
@@ -371,9 +399,15 @@ export async function askAdvisor(
 
         if (output.is_error) {
           // Codex #478 P2: exit code 0 인데 is_error=true 인 케이스도 classify.
-          // 이론상 CLI 는 대부분 non-zero exit 하지만 방어적으로 result 문구 활용.
-          const errorCode = classifyAdvisorError(output.result || undefined)
-          reject(new AdvisorError(`AI 응답 오류: ${output.result}`, output.result?.slice(0, 1024), errorCode))
+          // Codex #479 P2: `result` 가 비어있어도 `api_error_status` / `errors`
+          // 활용해 auth/quota 정확 분류.
+          const errorText = extractAdvisorErrorText(output)
+          const errorCode = classifyAdvisorError(errorText || undefined)
+          reject(new AdvisorError(
+            `AI 응답 오류: ${output.result || `api_error_status=${output.api_error_status ?? 'unknown'}`}`,
+            errorText.slice(0, 1024) || undefined,
+            errorCode,
+          ))
           return
         }
 

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -340,12 +340,29 @@ export async function askAdvisor(
       const stderr = errBuf.toString('utf-8').trim()
 
       if (code !== 0) {
-        // 디버깅 detail: stderr 끝 1KB 만 별도 프로퍼티로 전달 (message 는 사용자 노출 가능한 정적 문장)
+        // Codex #478 P2: `--output-format json` 은 에러도 stdout JSON 으로 반환 후
+        // exit code 를 non-zero 로 종료. stdout 파싱 없이 stderr 만 보면 대부분
+        // 비어있어 unknown 처리 → fallback UX 오분류. stdout JSON 우선 시도.
         const stderrTail = stderr.slice(-1024)
         if (stderrTail) console.error('[advisor] claude stderr:', stderrTail)
-        // Phase 40-B (#469): stderr pattern matching 으로 code 결정 → fallback UX 분기
-        const errorCode = classifyAdvisorError(stderrTail)
-        reject(new AdvisorError(`Claude CLI 종료 코드: ${code}`, stderrTail || undefined, errorCode))
+        // stdout JSON 에서 error 문구 추출 시도. 실패해도 stderr fallback.
+        let jsonErrorText = ''
+        try {
+          const parsed = JSON.parse(stdout) as Partial<ClaudeJsonOutput>
+          if (parsed && typeof parsed.result === 'string') {
+            jsonErrorText = parsed.result
+          }
+        } catch {
+          // stdout 이 JSON 아니거나 partial — stderr 만 사용
+        }
+        // classifyAdvisorError 는 stdout error 텍스트 + stderr 을 함께 검사 →
+        // JSON result 에 담긴 auth/quota 문구도 정확히 분류.
+        const combined = [jsonErrorText, stderrTail].filter(Boolean).join('\n')
+        const errorCode = classifyAdvisorError(combined || undefined)
+        // detail 은 사용자 진단 정보 우선순위: stdout JSON 문구 > stderr tail.
+        // 관리자 alert 에도 이게 더 actionable (Claude 자체의 에러 원문).
+        const detail = jsonErrorText.slice(0, 1024) || stderrTail || undefined
+        reject(new AdvisorError(`Claude CLI 종료 코드: ${code}`, detail, errorCode))
         return
       }
 
@@ -353,7 +370,10 @@ export async function askAdvisor(
         const output: ClaudeJsonOutput = JSON.parse(stdout)
 
         if (output.is_error) {
-          reject(new AdvisorError(`AI 응답 오류: ${output.result}`, undefined, 'unknown'))
+          // Codex #478 P2: exit code 0 인데 is_error=true 인 케이스도 classify.
+          // 이론상 CLI 는 대부분 non-zero exit 하지만 방어적으로 result 문구 활용.
+          const errorCode = classifyAdvisorError(output.result || undefined)
+          reject(new AdvisorError(`AI 응답 오류: ${output.result}`, output.result?.slice(0, 1024), errorCode))
           return
         }
 


### PR DESCRIPTION
## Summary
Codex bot 이 release PR #478 에서 발견한 P2. `--output-format json` 은 에러도 stdout JSON 으로 반환 후 exit code 를 non-zero 로 종료 (Claude Code 공식 문서). 현재 코드는 stdout 파싱 스킵 후 stderr 만 classify → 대부분 unknown 분류 → 40-A/40-B 실질 UX 무효화.

## Fix (2가지 경로)
1. **`code !== 0`**: stdout 우선 JSON 파싱 → `result` 문구 추출 → stderr tail 과 결합해 classify. detail 우선순위 JSON result > stderr (Claude 자체 에러 원문이 더 actionable)
2. **`is_error=true`** (code=0 이지만 응답 자체 에러): 이전 unknown 하드코딩 → 이제 `output.result` 로 classify

## 의미
이 fix 없이는 40-A/40-B (18차 스코프) 가 실제 배포에서 대부분의 실패를 unknown 분류 → 관리자 alert 진단 힌트 무의미, 사용자 fallback 원인 힌트 없음.

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (726 tests)
- [x] `npm run build` 통과

`classifyAdvisorError` 는 이미 pure 로 unit 커버. subprocess 통합은 mock 부담 커 스킵.

머지 시 release PR #478 자동 업데이트되어 v0.16.0 릴리즈 스코프에 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)