### PR TITLE
fix(briefing): 모닝 브리핑 fallback 도 describeAdvisorError (Codex #478 P2)

### DIFF
--- a/src/bot/notifications/briefing.ts
+++ b/src/bot/notifications/briefing.ts
@@ -6,7 +6,7 @@
  */
 
 import { getBot } from '@/bot/index'
-import { askAdvisor } from '@/lib/ai/claude-advisor'
+import { askAdvisor, describeAdvisorError } from '@/lib/ai/claude-advisor'
 import { markdownToTelegramHtml } from '@/bot/utils/markdown'
 import { sendHtml } from '@/bot/utils/telegram'
 import { sanitizeError } from '@/bot/utils/error'
@@ -67,8 +67,15 @@ export async function sendBriefing(
   } catch (error) {
     console.error(`[briefing] 브리핑 생성 실패: ${sanitizeError(error)}`)
 
+    // Phase 40-B (#469, Codex #478 P2): AdvisorError code 별 fallback (auth/quota/
+    // server 원인 힌트). describeAdvisorError 는 AdvisorError/AdvisorTimeoutError/
+    // Error 모두 받아 code 없는 일반 Error 는 unknown 으로 처리. 이 경우 기존
+    // hint (`/ai 에서 직접 질문해주세요`) 를 붙여 사용자 액션 제시.
     const label = session === 'KR' ? '🇰🇷 한국장' : '🇺🇸 미국장'
-    const fallback = `📊 ${label} 모닝 브리핑 생성에 실패했습니다.\n/ai 에서 직접 질문해주세요.`
+    const advisorMsg = error instanceof Error ? describeAdvisorError(error) : ''
+    const fallback =
+      `📊 ${label} 모닝 브리핑 생성에 실패했습니다.\n` +
+      `${advisorMsg}\n/ai 에서 직접 질문해주세요.`
     for (const chatId of chatIds) {
       try {
         await sendHtml(bot, chatId, fallback)


### PR DESCRIPTION
## Summary
Codex bot 이 release PR #478 에서 발견한 P2. 40-B (#469) 에서 3개 caller 만 갱신했지만 `notifications/briefing.ts` (한국장 08:30 · 미국장 23:00 자동 브리핑 + `/brief` 수동) 는 놓침 → 봇의 주요 브리핑 flow 가 여전히 generic fallback.

## Fix
`describeAdvisorError(error)` 결과를 fallback 상단에 삽입, 기존 hint 는 사용자 재시도 유도용 유지:

```
📊 🇰🇷 한국장 모닝 브리핑 생성에 실패했습니다.
🤖 AI 어드바이저 인증 갱신 필요 — 관리자에게 문의해주세요.
/ai 에서 직접 질문해주세요.
```

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (734 tests)
- [x] `npm run build` 통과

머지 시 release PR #478 자동 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)