### PR TITLE
Release v0.16.1 — mcp-logs KST 표시 hotfix

### DIFF
--- a/src/app/admin/mcp-logs/LiveTailPanel.tsx
+++ b/src/app/admin/mcp-logs/LiveTailPanel.tsx
@@ -14,7 +14,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { recentLogDates } from '@/lib/mcp-logs/constants'
+import { recentLogDates, formatKstTime } from '@/lib/mcp-logs/constants'
 
 interface LiveTailPanelProps {
   date: string
@@ -212,7 +212,7 @@ export default function LiveTailPanel({
                     <div className="flex flex-wrap items-center gap-2 text-[11px]">
                       {/* lineNo 는 poll batch 마다 1 부터 재시작해 스냅샷의 파일 라인
                           번호 (L{n}) 와 오해 유발 (Codex #454 P1). live tail 은 표시 안함. */}
-                      <span className="text-sub tabular-nums">{r.time?.slice(11, 19)}</span>
+                      <span className="text-sub tabular-nums" title="KST">{formatKstTime(r.time)}</span>
                       <span className={`px-2 py-0.5 rounded border font-semibold ${levelCls}`}>{r.level}</span>
                       {r.msg && (
                         <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">

--- a/src/app/admin/mcp-logs/McpLogsClient.tsx
+++ b/src/app/admin/mcp-logs/McpLogsClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates } from '@/lib/mcp-logs/constants'
+import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates, formatKstTime } from '@/lib/mcp-logs/constants'
 import LiveTailPanel from './LiveTailPanel'
 
 interface LogRow {
@@ -382,7 +382,7 @@ export default function McpLogsClient() {
                 <li key={`${r.lineNo ?? idx}`} className="px-5 py-3 hover:bg-surface-dim transition-colors">
                   <div className="flex flex-wrap items-center gap-2 text-[11px]">
                     <span className="text-dim font-mono">L{r.lineNo}</span>
-                    <span className="text-sub tabular-nums">{r.time?.slice(11, 19)}</span>
+                    <span className="text-sub tabular-nums" title="KST">{formatKstTime(r.time)}</span>
                     <span className={`px-2 py-0.5 rounded border font-semibold ${levelCls}`}>{r.level}</span>
                     {r.msg && (
                       <span className="px-2 py-0.5 rounded bg-surface-dim border border-border text-bright font-mono">

--- a/src/lib/mcp-logs/__tests__/constants.test.ts
+++ b/src/lib/mcp-logs/__tests__/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates } from '../constants'
+import { KNOWN_MSGS, MSG_LABELS, LEVEL_ORDER, recentLogDates, formatKstTime } from '../constants'
 
 describe('KNOWN_MSGS', () => {
   it('실제 서버에서 emit 되는 모든 msg 를 포함 (Codex #425 P2 회귀 방지)', () => {
@@ -61,5 +61,30 @@ describe('recentLogDates', () => {
 
   it('N=0 → 빈 배열', () => {
     expect(recentLogDates(0)).toEqual([])
+  })
+})
+
+// pino UTC ISO → KST HH:mm:ss 표시 (mcp-logs UI 용).
+describe('formatKstTime', () => {
+  it('UTC ISO → KST 시각 (+9h)', () => {
+    // 2026-07-21 00:15:30 UTC → 2026-07-21 09:15:30 KST
+    expect(formatKstTime('2026-07-21T00:15:30.123Z')).toBe('09:15:30')
+  })
+
+  it('KST 자정 넘김 (UTC 15:00 → KST 다음날 00:00)', () => {
+    expect(formatKstTime('2026-07-20T15:00:00.000Z')).toBe('00:00:00')
+  })
+
+  it('KST 저녁 (UTC 12:00 → KST 21:00)', () => {
+    expect(formatKstTime('2026-07-21T12:34:56.000Z')).toBe('21:34:56')
+  })
+
+  it('undefined / 빈 문자열 → 빈 문자열', () => {
+    expect(formatKstTime(undefined)).toBe('')
+    expect(formatKstTime('')).toBe('')
+  })
+
+  it('잘못된 ISO → 빈 문자열 (crash 방지)', () => {
+    expect(formatKstTime('not-a-date')).toBe('')
   })
 })

--- a/src/lib/mcp-logs/constants.ts
+++ b/src/lib/mcp-logs/constants.ts
@@ -66,3 +66,16 @@ export function recentLogDates(days: number, now: number = Date.now()): string[]
   }
   return out
 }
+
+/**
+ * pino ISO 8601 UTC time 문자열을 KST `HH:mm:ss` 로 변환 (mcp-logs 표시용).
+ * 이전에는 `iso.slice(11, 19)` 로 UTC 시각을 그대로 노출 → 사용자 혼동.
+ * pure — 잘못된 입력은 빈 문자열.
+ */
+export function formatKstTime(iso: string | undefined): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  return kst.toISOString().slice(11, 19)
+}


### PR DESCRIPTION
## Patch — v0.16.0 이후 hotfix 1건

**커밋 범위:** v0.16.0..dev

### Fix
- **#481** `/admin/mcp-logs` 리스트 + 실시간 tail 의 time 표시를 UTC → KST 로 변경
  - `formatKstTime(iso)` pure 헬퍼 추가 (`src/lib/mcp-logs/constants.ts`)
  - McpLogsClient / LiveTailPanel 두 사용처 갱신
  - 회귀 테스트 +5 (자정 넘김 · undefined · 잘못된 ISO 방어)

## Breaking changes
없음.

## Migration
없음.

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run test:run` 통과 (739 tests)
- [x] `npm run build` 통과
- [ ] main 머지 후 v0.16.1 태그 push + GitHub Release + 서버 배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)