### PR TITLE
fix(ai): num_turns 로 브리핑 tool 미호출 감지 (#483)

### DIFF
--- a/src/bot/commands/briefing.ts
+++ b/src/bot/commands/briefing.ts
@@ -80,7 +80,7 @@ function fireTickerAnalysis(ctx: Context, chatId: number, ticker: string): void 
     '- 종합 판단 + 주의사항',
   ].join('\n')
 
-  askAdvisor(prompt, { model: 'sonnet', timeout: 300_000, maxBudgetUsd: 1.0, caller: 'bot:brief_command' })
+  askAdvisor(prompt, { model: 'sonnet', timeout: 300_000, maxBudgetUsd: 1.0, caller: 'bot:brief_command', expectsTools: true })
     .then(async (result) => {
       const html = markdownToTelegramHtml(result.response)
       if (html.length <= 4096) {

--- a/src/bot/notifications/active-review.ts
+++ b/src/bot/notifications/active-review.ts
@@ -110,6 +110,8 @@ async function sendReview(
       timeout: 300_000,
       maxBudgetUsd: 1.0,
       caller: 'cron:active_review',
+      // #483: 능동 리뷰는 보유 종목·TA·전략 MCP 도구 사용 필수.
+      expectsTools: true,
     })
 
     const html = markdownToTelegramHtml(result.response)

--- a/src/bot/notifications/briefing.ts
+++ b/src/bot/notifications/briefing.ts
@@ -50,6 +50,11 @@ export async function sendBriefing(
       timeout: 300_000,
       maxBudgetUsd: 1.0,
       caller: 'cron:briefing',
+      // #483: 브리핑은 MCP 도구 (get_all_strategies / get_portfolio 등) 사용이
+      // 필수. tools/list 는 성공했으나 tool 을 한 번도 호출하지 않고 "도구 접근
+      // 불가" 안내 텍스트만 리턴하는 케이스를 no_tool_used AdvisorError 로
+      // 재분류 → catch 블록 fallback + monitor alert 동작.
+      expectsTools: true,
     })
 
     const html = markdownToTelegramHtml(result.response)

--- a/src/bot/notifications/monthly-report.ts
+++ b/src/bot/notifications/monthly-report.ts
@@ -36,7 +36,13 @@ export async function sendMonthlyReport(chatIds: number[]): Promise<void> {
     `6. 주요 관찰 사항 및 다음 달 체크포인트`
 
   try {
-    const result = await askAdvisor(prompt, { model: 'sonnet', timeout: 300_000, caller: 'cron:monthly_report' })
+    const result = await askAdvisor(prompt, {
+      model: 'sonnet',
+      timeout: 300_000,
+      caller: 'cron:monthly_report',
+      // #483: 월간 리포트도 포트폴리오/거래/배당/소비/증여세 MCP 도구 사용 필수.
+      expectsTools: true,
+    })
 
     const html = markdownToTelegramHtml(result.response)
 

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -142,6 +142,17 @@ describe('describeAdvisorError', () => {
     expect(msg).toContain('관리자')
   })
 
+  // #483 회귀 방지 — MCP 도구 미호출 감지 fallback 메시지
+  it('no_tool_used → 도구 미호출 안내 (관리자 문의)', () => {
+    const err = new AdvisorError('x', undefined, 'no_tool_used')
+    const msg = describeAdvisorError(err)
+    expect(msg).toContain('데이터 도구를 호출하지 않았습니다')
+    expect(msg).toContain('관리자')
+    // detail (num_turns, stop_reason 등) 은 사용자에게 노출되지 않아야
+    expect(msg).not.toContain('num_turns')
+    expect(msg).not.toContain('stop_reason')
+  })
+
   it('AdvisorError/Timeout 이 아닌 일반 Error → unknown 처리', () => {
     const err = new Error('random')
     const msg = describeAdvisorError(err)
@@ -172,7 +183,7 @@ describe('AdvisorError.code 계약', () => {
   })
 
   it('code 명시 시 그대로', () => {
-    for (const c of ['auth_expired', 'quota_exceeded', 'server_down', 'parse_error'] as const) {
+    for (const c of ['auth_expired', 'quota_exceeded', 'server_down', 'parse_error', 'no_tool_used'] as const) {
       expect(new AdvisorError('x', undefined, c).code).toBe(c)
     }
   })

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -13,6 +13,7 @@ import {
   classifyAdvisorError,
   describeAdvisorError,
   extractAdvisorErrorText,
+  hasNoToolResponse,
 } from '../claude-advisor'
 
 describe('classifyAdvisorError', () => {
@@ -229,5 +230,45 @@ describe('extractAdvisorErrorText', () => {
     // Codex #479 P2 시나리오 — Claude API 429 는 result 없이 api_error_status 만 채워짐
     const text = extractAdvisorErrorText({ result: '', api_error_status: 429 })
     expect(classifyAdvisorError(text)).toBe('quota_exceeded')
+  })
+})
+
+// Codex PR #484 P1 회귀 방지 — 응답 텍스트 fingerprint 로 도구 미사용 감지.
+// num_turns 만으로는 부정확 (Claude 가 WebSearch 만 부르고 MCP tool skip 해도
+// num_turns >= 2). semantic 검증 fallback.
+describe('hasNoToolResponse', () => {
+  it('실제 발송된 실패 응답 (2026-08-18 브리핑) 감지', () => {
+    const actual = `⚠️ 도구 연결 문제 안내
+
+죄송하지만 현재 세션에서 myFinance 데이터 도구(포트폴리오, 전략, 기술적분석 등)가 연결되지 않아 아래 항목을 확인할 수 없었습니다:
+
+- 📊 get_all_strategies (전체 종목 전략)
+- 💼 get_portfolio (계좌별 보유 현황)`
+    expect(hasNoToolResponse(actual)).toBe(true)
+  })
+
+  it('다양한 실패 pattern 변형 감지', () => {
+    expect(hasNoToolResponse('도구가 연결되지 않아서')).toBe(true)
+    expect(hasNoToolResponse('데이터 도구가 연결되지 않았습니다')).toBe(true)
+    expect(hasNoToolResponse('도구 연결 문제로')).toBe(true)
+    expect(hasNoToolResponse('도구 연결 불가')).toBe(true)
+    expect(hasNoToolResponse('MCP 연결 실패')).toBe(true)
+    expect(hasNoToolResponse('도구 접근 불가')).toBe(true)
+    expect(hasNoToolResponse('MCP 접근 문제')).toBe(true)
+  })
+
+  it('정상 응답은 false (false positive 방지)', () => {
+    // 실제 정상 브리핑에 나올 수 있는 문구들
+    expect(hasNoToolResponse('AAPL 현재가는 $180 입니다.')).toBe(false)
+    expect(hasNoToolResponse('세진 계좌 총 평가금 3,200만원')).toBe(false)
+    expect(hasNoToolResponse('RSI 65, MACD 상승 전환')).toBe(false)
+    expect(hasNoToolResponse('오늘 시장 하락. 관망 권장.')).toBe(false)
+    // 도구 이름이 언급되더라도 "연결 문제" 서술이 없으면 통과
+    expect(hasNoToolResponse('get_portfolio 결과: 3개 계좌')).toBe(false)
+  })
+
+  it('빈 입력 → false', () => {
+    expect(hasNoToolResponse('')).toBe(false)
+    expect(hasNoToolResponse(undefined)).toBe(false)
   })
 })

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -11,9 +11,11 @@ import {
   AdvisorError,
   AdvisorTimeoutError,
   classifyAdvisorError,
+  countMcpMyFinanceCalls,
   describeAdvisorError,
   extractAdvisorErrorText,
   hasNoToolResponse,
+  parseClaudeStreamJson,
 } from '../claude-advisor'
 
 describe('classifyAdvisorError', () => {
@@ -270,5 +272,103 @@ describe('hasNoToolResponse', () => {
   it('빈 입력 → false', () => {
     expect(hasNoToolResponse('')).toBe(false)
     expect(hasNoToolResponse(undefined)).toBe(false)
+  })
+})
+
+// Codex PR #484 P1 (3차) 회귀 방지 — stream-json 파싱 + mcp tool 카운트.
+// tool_use event 를 정확히 추출해 WebSearch-only 우회 케이스도 감지 가능해야.
+describe('parseClaudeStreamJson', () => {
+  it('assistant tool_use event 를 순서대로 수집 + 마지막 result event 반환', () => {
+    // 실제 stream-json 형식의 축약 fixture — 각 라인이 JSON event.
+    const stream = [
+      '{"type":"system","subtype":"init","session_id":"abc"}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__myfinance__get_all_strategies"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__myfinance__get_portfolio"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WebSearch"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"브리핑..."}]}}',
+      '{"type":"result","is_error":false,"result":"브리핑...","num_turns":7,"session_id":"abc","duration_ms":12000,"total_cost_usd":0.5}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls).toEqual([
+      'mcp__myfinance__get_all_strategies',
+      'mcp__myfinance__get_portfolio',
+      'WebSearch',
+    ])
+    expect(parsed.finalResult?.is_error).toBe(false)
+    expect(parsed.finalResult?.num_turns).toBe(7)
+    expect(parsed.finalResult?.result).toBe('브리핑...')
+    expect(parsed.finalResult?.session_id).toBe('abc')
+  })
+
+  it('assistant event 안에 tool_use 가 없는 (thinking/text 만) 케이스 = 빈 배열', () => {
+    const stream = [
+      '{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"..."}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"OK"}]}}',
+      '{"type":"result","is_error":false,"result":"OK","num_turns":1}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls).toEqual([])
+    expect(parsed.finalResult?.num_turns).toBe(1)
+  })
+
+  it('malformed 라인은 skip, 빈 라인/공백 라인도 skip', () => {
+    const stream = [
+      '',
+      '   ',
+      'not json at all',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"X"}]}}',
+      '{ broken json',
+      '{"type":"result","is_error":false,"result":"","num_turns":2}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls).toEqual(['X'])
+    expect(parsed.finalResult?.num_turns).toBe(2)
+  })
+
+  it('result event 없으면 finalResult undefined', () => {
+    const stream = [
+      '{"type":"system","subtype":"init"}',
+      '{"type":"assistant","message":{"content":[]}}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.finalResult).toBeUndefined()
+    expect(parsed.toolCalls).toEqual([])
+  })
+
+  it('빈 stdout → 빈 결과', () => {
+    const parsed = parseClaudeStreamJson('')
+    expect(parsed.toolCalls).toEqual([])
+    expect(parsed.finalResult).toBeUndefined()
+  })
+})
+
+describe('countMcpMyFinanceCalls', () => {
+  it('mcp__myfinance__* prefix 만 카운트 (WebSearch/WebFetch 등 제외)', () => {
+    const calls = [
+      'mcp__myfinance__get_portfolio',
+      'WebSearch',
+      'mcp__myfinance__get_all_strategies',
+      'WebFetch',
+      'mcp__myfinance__get_technical_analysis',
+      'Read',
+    ]
+    expect(countMcpMyFinanceCalls(calls)).toBe(3)
+  })
+
+  it('다른 MCP 서버 tool 은 제외', () => {
+    expect(countMcpMyFinanceCalls(['mcp__other__foo', 'mcp__external__bar'])).toBe(0)
+  })
+
+  it('WebSearch-only (Codex 지적 시나리오) = 0', () => {
+    // Codex PR #484 P1 3차: Claude 가 WebSearch 만 부르고 MCP tool 은 skip 하면
+    // num_turns >= 2 이지만 MCP count 는 0 → guard 가 정확히 감지.
+    expect(countMcpMyFinanceCalls(['WebSearch', 'WebSearch', 'WebFetch'])).toBe(0)
+  })
+
+  it('빈 배열 → 0', () => {
+    expect(countMcpMyFinanceCalls([])).toBe(0)
   })
 })

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -12,6 +12,7 @@ import {
   AdvisorTimeoutError,
   classifyAdvisorError,
   countMcpMyFinanceCalls,
+  countSuccessfulMcpMyFinanceCalls,
   describeAdvisorError,
   extractAdvisorErrorText,
   hasNoToolResponse,
@@ -278,24 +279,26 @@ describe('hasNoToolResponse', () => {
 // Codex PR #484 P1 (3차) 회귀 방지 — stream-json 파싱 + mcp tool 카운트.
 // tool_use event 를 정확히 추출해 WebSearch-only 우회 케이스도 감지 가능해야.
 describe('parseClaudeStreamJson', () => {
-  it('assistant tool_use event 를 순서대로 수집 + 마지막 result event 반환', () => {
-    // 실제 stream-json 형식의 축약 fixture — 각 라인이 JSON event.
+  it('assistant tool_use + user tool_result 를 id 로 correlate (is_error 반영)', () => {
+    // Codex PR #484 P1 4차 시나리오: tool_use.id ↔ tool_result.tool_use_id
+    // 매칭 → 각 호출의 실제 성공 여부까지 파악.
     const stream = [
       '{"type":"system","subtype":"init","session_id":"abc"}',
-      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__myfinance__get_all_strategies"}]}}',
-      '{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}',
-      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__myfinance__get_portfolio"}]}}',
-      '{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}',
-      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WebSearch"}]}}',
-      '{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"mcp__myfinance__get_all_strategies"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"[...]","is_error":false}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"mcp__myfinance__get_portfolio"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t2","content":"MCP error","is_error":true}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t3","name":"WebSearch"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t3","content":"..."}]}}',
       '{"type":"assistant","message":{"content":[{"type":"text","text":"브리핑..."}]}}',
       '{"type":"result","is_error":false,"result":"브리핑...","num_turns":7,"session_id":"abc","duration_ms":12000,"total_cost_usd":0.5}',
     ].join('\n')
     const parsed = parseClaudeStreamJson(stream)
     expect(parsed.toolCalls).toEqual([
-      'mcp__myfinance__get_all_strategies',
-      'mcp__myfinance__get_portfolio',
-      'WebSearch',
+      { id: 't1', name: 'mcp__myfinance__get_all_strategies', isError: false },
+      { id: 't2', name: 'mcp__myfinance__get_portfolio', isError: true },
+      // WebSearch tool_result 는 is_error 없음 → undefined
+      { id: 't3', name: 'WebSearch', isError: undefined },
     ])
     expect(parsed.finalResult?.is_error).toBe(false)
     expect(parsed.finalResult?.num_turns).toBe(7)
@@ -319,13 +322,35 @@ describe('parseClaudeStreamJson', () => {
       '',
       '   ',
       'not json at all',
-      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"X"}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x1","name":"X"}]}}',
       '{ broken json',
       '{"type":"result","is_error":false,"result":"","num_turns":2}',
     ].join('\n')
     const parsed = parseClaudeStreamJson(stream)
-    expect(parsed.toolCalls).toEqual(['X'])
+    expect(parsed.toolCalls).toEqual([{ id: 'x1', name: 'X', isError: undefined }])
     expect(parsed.finalResult?.num_turns).toBe(2)
+  })
+
+  it('tool_use id 없어도 name 은 수집 (id 없으면 tool_result 매칭 안 됨)', () => {
+    const stream = [
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"NoId"}]}}',
+      '{"type":"result","is_error":false,"result":"","num_turns":1}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls).toEqual([{ id: undefined, name: 'NoId', isError: undefined }])
+  })
+
+  it('tool_result 가 없는 tool_use → isError undefined (엄격 판정으로 실패 취급)', () => {
+    // Claude subprocess 이상 종료 시나리오 — tool_use 는 emit 됐지만 result 못 받음
+    const stream = [
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"orphan","name":"mcp__myfinance__get_portfolio"}]}}',
+      '{"type":"result","is_error":false,"result":"","num_turns":1}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls[0].isError).toBeUndefined()
+    // countSuccessfulMcpMyFinanceCalls 는 undefined 를 성공으로 안 봄 (fail-closed)
+    expect(countSuccessfulMcpMyFinanceCalls(parsed.toolCalls)).toBe(0)
+    expect(countMcpMyFinanceCalls(parsed.toolCalls)).toBe(1)
   })
 
   it('result event 없으면 finalResult undefined', () => {
@@ -345,30 +370,68 @@ describe('parseClaudeStreamJson', () => {
   })
 })
 
-describe('countMcpMyFinanceCalls', () => {
+describe('countMcpMyFinanceCalls (시도 카운트)', () => {
   it('mcp__myfinance__* prefix 만 카운트 (WebSearch/WebFetch 등 제외)', () => {
     const calls = [
-      'mcp__myfinance__get_portfolio',
-      'WebSearch',
-      'mcp__myfinance__get_all_strategies',
-      'WebFetch',
-      'mcp__myfinance__get_technical_analysis',
-      'Read',
+      { name: 'mcp__myfinance__get_portfolio', isError: false },
+      { name: 'WebSearch' },
+      { name: 'mcp__myfinance__get_all_strategies', isError: true },  // 실패해도 시도로 카운트
+      { name: 'WebFetch' },
+      { name: 'mcp__myfinance__get_technical_analysis', isError: false },
+      { name: 'Read' },
     ]
     expect(countMcpMyFinanceCalls(calls)).toBe(3)
   })
 
   it('다른 MCP 서버 tool 은 제외', () => {
-    expect(countMcpMyFinanceCalls(['mcp__other__foo', 'mcp__external__bar'])).toBe(0)
+    expect(countMcpMyFinanceCalls([{ name: 'mcp__other__foo' }, { name: 'mcp__external__bar' }])).toBe(0)
   })
 
-  it('WebSearch-only (Codex 지적 시나리오) = 0', () => {
-    // Codex PR #484 P1 3차: Claude 가 WebSearch 만 부르고 MCP tool 은 skip 하면
-    // num_turns >= 2 이지만 MCP count 는 0 → guard 가 정확히 감지.
-    expect(countMcpMyFinanceCalls(['WebSearch', 'WebSearch', 'WebFetch'])).toBe(0)
+  it('WebSearch-only (Codex 3차 시나리오) = 0', () => {
+    expect(countMcpMyFinanceCalls([{ name: 'WebSearch' }, { name: 'WebSearch' }, { name: 'WebFetch' }])).toBe(0)
   })
 
   it('빈 배열 → 0', () => {
     expect(countMcpMyFinanceCalls([])).toBe(0)
+  })
+})
+
+// Codex PR #484 P1 4차 회귀 방지 — 성공 카운트는 isError === false 만.
+describe('countSuccessfulMcpMyFinanceCalls (성공 카운트)', () => {
+  it('mcp__myfinance__* 중 isError === false 만 카운트', () => {
+    const calls = [
+      { name: 'mcp__myfinance__get_portfolio', isError: false },
+      { name: 'mcp__myfinance__get_all_strategies', isError: true },  // 실패
+      { name: 'mcp__myfinance__get_technical_analysis', isError: false },
+      { name: 'WebSearch', isError: false },  // 성공이어도 mcp 아니라 제외
+    ]
+    expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(2)
+  })
+
+  it('4차 시나리오: tool_use 는 있지만 모두 tool_result is_error=true = 0', () => {
+    // Codex 지적: tool_use 카운트만 하면 통과. 성공 카운트로 정확 감지.
+    const calls = [
+      { name: 'mcp__myfinance__get_portfolio', isError: true },
+      { name: 'mcp__myfinance__get_all_strategies', isError: true },
+    ]
+    expect(countMcpMyFinanceCalls(calls)).toBe(2)  // 시도는 있음
+    expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(0)  // 하지만 성공 0
+  })
+
+  it('isError undefined (매칭 실패/이상 상태) 는 성공으로 카운트 안 함 (fail-closed)', () => {
+    const calls = [
+      { name: 'mcp__myfinance__get_portfolio', isError: undefined },
+      { name: 'mcp__myfinance__get_portfolio' },  // undefined 와 동일
+    ]
+    expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(0)
+  })
+
+  it('일부 성공 + 일부 실패 = 성공만 카운트', () => {
+    const calls = [
+      { name: 'mcp__myfinance__get_portfolio', isError: false },
+      { name: 'mcp__myfinance__get_all_strategies', isError: true },
+      { name: 'mcp__myfinance__get_prices', isError: false },
+    ]
+    expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(2)
   })
 })

--- a/src/lib/ai/__tests__/claude-advisor.test.ts
+++ b/src/lib/ai/__tests__/claude-advisor.test.ts
@@ -295,10 +295,10 @@ describe('parseClaudeStreamJson', () => {
     ].join('\n')
     const parsed = parseClaudeStreamJson(stream)
     expect(parsed.toolCalls).toEqual([
-      { id: 't1', name: 'mcp__myfinance__get_all_strategies', isError: false },
-      { id: 't2', name: 'mcp__myfinance__get_portfolio', isError: true },
-      // WebSearch tool_result 는 is_error 없음 → undefined
-      { id: 't3', name: 'WebSearch', isError: undefined },
+      { id: 't1', name: 'mcp__myfinance__get_all_strategies', hasResult: true, isError: false },
+      { id: 't2', name: 'mcp__myfinance__get_portfolio', hasResult: true, isError: true },
+      // WebSearch tool_result 는 is_error 없음 → undefined (정상 성공)
+      { id: 't3', name: 'WebSearch', hasResult: true, isError: undefined },
     ])
     expect(parsed.finalResult?.is_error).toBe(false)
     expect(parsed.finalResult?.num_turns).toBe(7)
@@ -327,7 +327,7 @@ describe('parseClaudeStreamJson', () => {
       '{"type":"result","is_error":false,"result":"","num_turns":2}',
     ].join('\n')
     const parsed = parseClaudeStreamJson(stream)
-    expect(parsed.toolCalls).toEqual([{ id: 'x1', name: 'X', isError: undefined }])
+    expect(parsed.toolCalls).toEqual([{ id: 'x1', name: 'X', hasResult: false, isError: undefined }])
     expect(parsed.finalResult?.num_turns).toBe(2)
   })
 
@@ -337,20 +337,36 @@ describe('parseClaudeStreamJson', () => {
       '{"type":"result","is_error":false,"result":"","num_turns":1}',
     ].join('\n')
     const parsed = parseClaudeStreamJson(stream)
-    expect(parsed.toolCalls).toEqual([{ id: undefined, name: 'NoId', isError: undefined }])
+    expect(parsed.toolCalls).toEqual([{ id: undefined, name: 'NoId', hasResult: false, isError: undefined }])
   })
 
-  it('tool_result 가 없는 tool_use → isError undefined (엄격 판정으로 실패 취급)', () => {
+  it('orphan tool_use (tool_result 없음) → hasResult=false → 성공 아님', () => {
     // Claude subprocess 이상 종료 시나리오 — tool_use 는 emit 됐지만 result 못 받음
     const stream = [
       '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"orphan","name":"mcp__myfinance__get_portfolio"}]}}',
       '{"type":"result","is_error":false,"result":"","num_turns":1}',
     ].join('\n')
     const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls[0].hasResult).toBe(false)
     expect(parsed.toolCalls[0].isError).toBeUndefined()
-    // countSuccessfulMcpMyFinanceCalls 는 undefined 를 성공으로 안 봄 (fail-closed)
+    // hasResult=false 이면 성공 카운트 안 됨 (fail-closed)
     expect(countSuccessfulMcpMyFinanceCalls(parsed.toolCalls)).toBe(0)
     expect(countMcpMyFinanceCalls(parsed.toolCalls)).toBe(1)
+  })
+
+  // Codex PR #484 P1 (5차) 회귀 방지 — is_error 필드 생략된 tool_result 는 성공.
+  // src/mcp/utils.ts 의 성공 응답 (`toolResult`) 은 is_error 없이 content 만 반환.
+  it('tool_result 에 is_error 필드 없음 = 정상 성공 (Anthropic 스키마 optional)', () => {
+    const stream = [
+      // 실제 MCP 성공 응답 형식 — is_error 필드 없음
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"s1","name":"mcp__myfinance__get_portfolio"}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"s1","content":"[{...portfolio data...}]"}]}}',
+      '{"type":"result","is_error":false,"result":"브리핑","num_turns":2}',
+    ].join('\n')
+    const parsed = parseClaudeStreamJson(stream)
+    expect(parsed.toolCalls[0].hasResult).toBe(true)
+    expect(parsed.toolCalls[0].isError).toBeUndefined()  // 생략 = 성공
+    expect(countSuccessfulMcpMyFinanceCalls(parsed.toolCalls)).toBe(1)  // 정확히 성공으로 카운트
   })
 
   it('result event 없으면 finalResult undefined', () => {
@@ -373,22 +389,29 @@ describe('parseClaudeStreamJson', () => {
 describe('countMcpMyFinanceCalls (시도 카운트)', () => {
   it('mcp__myfinance__* prefix 만 카운트 (WebSearch/WebFetch 등 제외)', () => {
     const calls = [
-      { name: 'mcp__myfinance__get_portfolio', isError: false },
-      { name: 'WebSearch' },
-      { name: 'mcp__myfinance__get_all_strategies', isError: true },  // 실패해도 시도로 카운트
-      { name: 'WebFetch' },
-      { name: 'mcp__myfinance__get_technical_analysis', isError: false },
-      { name: 'Read' },
+      { name: 'mcp__myfinance__get_portfolio', hasResult: true, isError: false },
+      { name: 'WebSearch', hasResult: true },
+      { name: 'mcp__myfinance__get_all_strategies', hasResult: true, isError: true },  // 실패해도 시도로 카운트
+      { name: 'WebFetch', hasResult: true },
+      { name: 'mcp__myfinance__get_technical_analysis', hasResult: true, isError: false },
+      { name: 'Read', hasResult: true },
     ]
     expect(countMcpMyFinanceCalls(calls)).toBe(3)
   })
 
   it('다른 MCP 서버 tool 은 제외', () => {
-    expect(countMcpMyFinanceCalls([{ name: 'mcp__other__foo' }, { name: 'mcp__external__bar' }])).toBe(0)
+    expect(countMcpMyFinanceCalls([
+      { name: 'mcp__other__foo', hasResult: true },
+      { name: 'mcp__external__bar', hasResult: true },
+    ])).toBe(0)
   })
 
   it('WebSearch-only (Codex 3차 시나리오) = 0', () => {
-    expect(countMcpMyFinanceCalls([{ name: 'WebSearch' }, { name: 'WebSearch' }, { name: 'WebFetch' }])).toBe(0)
+    expect(countMcpMyFinanceCalls([
+      { name: 'WebSearch', hasResult: true },
+      { name: 'WebSearch', hasResult: true },
+      { name: 'WebFetch', hasResult: true },
+    ])).toBe(0)
   })
 
   it('빈 배열 → 0', () => {
@@ -396,41 +419,51 @@ describe('countMcpMyFinanceCalls (시도 카운트)', () => {
   })
 })
 
-// Codex PR #484 P1 4차 회귀 방지 — 성공 카운트는 isError === false 만.
+// Codex PR #484 P1 (4차/5차) 회귀 방지.
 describe('countSuccessfulMcpMyFinanceCalls (성공 카운트)', () => {
-  it('mcp__myfinance__* 중 isError === false 만 카운트', () => {
+  it('mcp__myfinance__* 중 hasResult=true && isError !== true 만 카운트', () => {
     const calls = [
-      { name: 'mcp__myfinance__get_portfolio', isError: false },
-      { name: 'mcp__myfinance__get_all_strategies', isError: true },  // 실패
-      { name: 'mcp__myfinance__get_technical_analysis', isError: false },
-      { name: 'WebSearch', isError: false },  // 성공이어도 mcp 아니라 제외
+      { name: 'mcp__myfinance__get_portfolio', hasResult: true, isError: false },    // 성공
+      { name: 'mcp__myfinance__get_all_strategies', hasResult: true, isError: true },  // 실패
+      { name: 'mcp__myfinance__get_technical_analysis', hasResult: true },  // is_error 생략 = 성공 (5차)
+      { name: 'WebSearch', hasResult: true, isError: false },  // mcp 아님 → 제외
     ]
     expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(2)
   })
 
   it('4차 시나리오: tool_use 는 있지만 모두 tool_result is_error=true = 0', () => {
-    // Codex 지적: tool_use 카운트만 하면 통과. 성공 카운트로 정확 감지.
     const calls = [
-      { name: 'mcp__myfinance__get_portfolio', isError: true },
-      { name: 'mcp__myfinance__get_all_strategies', isError: true },
+      { name: 'mcp__myfinance__get_portfolio', hasResult: true, isError: true },
+      { name: 'mcp__myfinance__get_all_strategies', hasResult: true, isError: true },
     ]
     expect(countMcpMyFinanceCalls(calls)).toBe(2)  // 시도는 있음
     expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(0)  // 하지만 성공 0
   })
 
-  it('isError undefined (매칭 실패/이상 상태) 는 성공으로 카운트 안 함 (fail-closed)', () => {
+  it('5차 시나리오: is_error 생략된 정상 응답을 성공으로 카운트', () => {
+    // src/mcp/utils.ts 의 toolResult 는 is_error 없이 content 만 반환.
+    // 이걸 실패로 판정하면 모든 정상 브리핑이 no_tool_used 로 fail.
     const calls = [
-      { name: 'mcp__myfinance__get_portfolio', isError: undefined },
-      { name: 'mcp__myfinance__get_portfolio' },  // undefined 와 동일
+      { name: 'mcp__myfinance__get_portfolio', hasResult: true /* isError 생략 */ },
+      { name: 'mcp__myfinance__get_all_strategies', hasResult: true, isError: undefined },
+    ]
+    expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(2)  // 둘 다 성공
+  })
+
+  it('hasResult=false (orphan tool_use) 는 성공 카운트 안 함 (fail-closed)', () => {
+    const calls = [
+      { name: 'mcp__myfinance__get_portfolio', hasResult: false },  // orphan
+      { name: 'mcp__myfinance__get_all_strategies', hasResult: false, isError: undefined },
     ]
     expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(0)
   })
 
-  it('일부 성공 + 일부 실패 = 성공만 카운트', () => {
+  it('일부 성공 + 일부 실패 + 일부 orphan = 성공만 카운트', () => {
     const calls = [
-      { name: 'mcp__myfinance__get_portfolio', isError: false },
-      { name: 'mcp__myfinance__get_all_strategies', isError: true },
-      { name: 'mcp__myfinance__get_prices', isError: false },
+      { name: 'mcp__myfinance__get_portfolio', hasResult: true, isError: false },
+      { name: 'mcp__myfinance__get_all_strategies', hasResult: true, isError: true },
+      { name: 'mcp__myfinance__get_prices', hasResult: false },  // orphan
+      { name: 'mcp__myfinance__get_fx_rate', hasResult: true },  // is_error 생략 = 성공
     ]
     expect(countSuccessfulMcpMyFinanceCalls(calls)).toBe(2)
   })

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -122,40 +122,103 @@ export class AdvisorError extends Error {
  * 직접 code 지정 (예: `AdvisorError('...', undefined, 'server_down')`).
  */
 /**
- * Codex PR #484 P1: `num_turns` 는 MCP tool 사용 여부의 정확한 지표가 아님.
- * 실측: 브리핑처럼 "WebSearch 로 뉴스 검색" 을 프롬프트에 명시하면 Claude 가
- * MCP tool 은 건너뛰고 WebSearch 만 호출해도 `num_turns >= 2` 가 나옴 →
- * guard 통과되어 데이터 없는 브리핑이 여전히 발송됨. 또 `--output-format json`
- * 은 실제 호출된 tool 이름 목록을 노출하지 않음 (`iterations` 는 token 사용량
- * 뿐).
+ * Codex PR #484 P1 (3차 지적): num_turns 도, 응답 텍스트 fingerprint 도 MCP
+ * tool 실제 호출 여부의 정확한 evaluator 가 아님.
+ *   - `num_turns >= 2` 는 WebSearch 만 호출한 경우에도 성립 → 통과되면 데이터
+ *     없는 브리핑 발송.
+ *   - 응답 텍스트에 "도구 접근 불가" 안내가 없어도 (Claude 가 plausible 하지만
+ *     데이터 없는 report 를 만들면) fingerprint 매칭 실패 → 통과.
  *
- * → Structural 검증 (`num_turns === 1` = 완전 미사용) + Semantic 검증 (응답
- * 텍스트 fingerprint) 이중 방어. Semantic 은 아래 pattern.
+ * 유일한 정답: **실제 호출된 tool 이름 목록** 을 확인.
+ * `--output-format stream-json --verbose` 는 각 assistant event 의
+ * `message.content[]` 배열에 `type: 'tool_use'` + `name` 을 담음 → 파싱해서
+ * `mcp__myfinance__*` prefix 카운트가 evaluator.
  *
- * 실제 발송된 실패 응답 (2026-08-18):
- *   "⚠️ 도구 연결 문제 안내
- *    죄송하지만 현재 세션에서 myFinance 데이터 도구(포트폴리오, 전략, 기술적분석 등)
- *    가 연결되지 않아 아래 항목을 확인할 수 없었습니다:"
- *
- * Pattern 은 매우 좁게 (정상 응답에서 우연히 등장할 수 없는 조합) 잡아
- * false positive 최소화. 정상 브리핑이 "도구가 연결되지 않아" 를 언급할 이유는
- * 없음 (정상 응답은 데이터를 나열).
+ * `hasNoToolResponse` fingerprint 는 belt-and-suspenders 로 유지 — MCP tool
+ * 을 호출했더라도 응답 본문에 "도구 접근 불가" 를 쓰면 여전히 사용자에게
+ * 유해 (일부 tool 실패 시 Claude 가 이런 문구를 섞을 수 있음). 정상 응답이
+ * 이 pattern 을 언급할 이유는 없어 false positive 낮음.
  */
 const NO_TOOL_RESPONSE_PATTERNS: RegExp[] = [
-  // Claude 가 "도구 접근/연결 실패" 를 명시적으로 서술하는 패턴
   /(데이터\s*)?도구.{0,20}연결되지\s*않/,
   /(도구|MCP).{0,20}(연결|접근)\s*(문제|불가|실패)/,
   /(도구|MCP)\s*(연결|접근).{0,10}(못|안|불가)\s*(했|합|됩)/,
 ]
 
 /**
- * Pure — 응답 텍스트에서 "도구 미사용" fingerprint 감지.
- * `expectsTools: true` caller 는 이 결과가 true 일 때 `no_tool_used` 로 실패 처리.
- * 테스트 용이하도록 export.
+ * Pure — 응답 텍스트에서 "도구 미사용" fingerprint 감지 (belt-and-suspenders).
+ * 정확한 evaluator 는 `countMcpMyFinanceCalls` — 이건 보조 검증.
  */
 export function hasNoToolResponse(text: string | undefined): boolean {
   if (!text) return false
   return NO_TOOL_RESPONSE_PATTERNS.some((re) => re.test(text))
+}
+
+/**
+ * Codex PR #484 P1 (3차) — `--output-format stream-json --verbose` 응답 파싱.
+ *
+ * 각 라인은 완전한 NDJSON event. 관심 event:
+ *   - `type: 'assistant'` — `message.content[]` 배열에 여러 block. `tool_use` block 은
+ *     `name` (tool 이름) 을 담음. 이걸 수집해 caller 가 `mcp__myfinance__*` 카운트로
+ *     실제 호출 여부 판정.
+ *   - `type: 'result'` — 마지막 event. `is_error` / `result` / `num_turns` /
+ *     `session_id` / `duration_ms` / `total_cost_usd` / `api_error_status` / `errors`
+ *     등 최종 metadata. 기존 `--output-format json` 과 동일 스키마.
+ *
+ * pure 로 stdout 문자열만 받아 파싱 → 테스트 용이. malformed line 은 skip.
+ */
+export interface ParsedClaudeStream {
+  /** 마지막 result event (기존 ClaudeJsonOutput 과 동일 스키마) */
+  finalResult?: ClaudeJsonOutput
+  /** 모든 assistant tool_use event 의 `name` 목록 (호출 순서대로) */
+  toolCalls: string[]
+}
+
+interface ClaudeStreamContentBlock {
+  type?: string
+  name?: string
+}
+interface ClaudeStreamAssistantEvent {
+  type: 'assistant'
+  message?: {
+    content?: ClaudeStreamContentBlock[]
+  }
+}
+
+export function parseClaudeStreamJson(stdout: string): ParsedClaudeStream {
+  const toolCalls: string[] = []
+  let finalResult: ClaudeJsonOutput | undefined
+  const lines = stdout.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let evt: unknown
+    try {
+      evt = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (typeof evt !== 'object' || evt === null) continue
+    const type = (evt as { type?: unknown }).type
+    if (type === 'assistant') {
+      const content = (evt as ClaudeStreamAssistantEvent).message?.content
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block?.type === 'tool_use' && typeof block.name === 'string') {
+            toolCalls.push(block.name)
+          }
+        }
+      }
+    } else if (type === 'result') {
+      finalResult = evt as ClaudeJsonOutput
+    }
+  }
+  return { finalResult, toolCalls }
+}
+
+/** Pure — `mcp__myfinance__*` prefix 카운트. */
+export function countMcpMyFinanceCalls(toolCalls: string[]): number {
+  return toolCalls.filter((n) => typeof n === 'string' && n.startsWith('mcp__myfinance__')).length
 }
 
 /**
@@ -387,7 +450,12 @@ export async function askAdvisor(
   const cmdParts = [
     'claude',
     '-p', shellEscape(prompt),
-    '--output-format', 'json',
+    // Codex PR #484 P1 (3차): `--output-format json` 은 최종 result 텍스트만
+    // 노출 → 실제로 어떤 tool 이 호출됐는지 알 수 없음. `stream-json` + `--verbose`
+    // 로 각 assistant event 의 `tool_use` block 을 파싱해 `mcp__myfinance__*`
+    // 호출 횟수를 정확히 카운트 (expectsTools 검증에 사용).
+    '--output-format', 'stream-json',
+    '--verbose',
     '--model', model,
   ]
 
@@ -466,93 +534,75 @@ export async function askAdvisor(
       const stdout = Buffer.concat(chunks).toString('utf-8')
       const stderr = errBuf.toString('utf-8').trim()
 
+      // Codex PR #484 P1 (3차): stream-json 은 NDJSON. 마지막 result event 가 최종
+      // metadata. 각 assistant event 의 tool_use block 도 함께 수집해 expectsTools
+      // 검증에 사용.
+      const parsedStream = parseClaudeStreamJson(stdout)
+      const output = parsedStream.finalResult
+      const toolCalls = parsedStream.toolCalls
+
       if (code !== 0) {
-        // Codex #478 P2: `--output-format json` 은 에러도 stdout JSON 으로 반환 후
-        // exit code 를 non-zero 로 종료. stdout 파싱 없이 stderr 만 보면 대부분
-        // 비어있어 unknown 처리 → fallback UX 오분류. stdout JSON 우선 시도.
+        // stream-json 도 에러 시 result event 를 마지막에 emit 하고 exit code
+        // non-zero 로 종료. output 이 파싱 됐으면 그 안의 result/api_error_status
+        // 로 classify.
         const stderrTail = stderr.slice(-1024)
         if (stderrTail) console.error('[advisor] claude stderr:', stderrTail)
-        // stdout JSON 에서 error 문구 추출 시도. 실패해도 stderr fallback.
-        // Codex #479 P2: `result` 뿐 아니라 `api_error_status` (예: 429) · `errors`
-        // 필드까지 결합 — Claude 는 rate limit/최종 실패 시 result 비고 status 만 채움.
-        let jsonErrorText = ''
-        try {
-          const parsed = JSON.parse(stdout) as Partial<ClaudeJsonOutput>
-          if (parsed && typeof parsed === 'object') {
-            jsonErrorText = extractAdvisorErrorText(parsed)
-          }
-        } catch {
-          // stdout 이 JSON 아니거나 partial — stderr 만 사용
-        }
-        // classifyAdvisorError 는 stdout error 텍스트 + stderr 을 함께 검사 →
-        // JSON result 에 담긴 auth/quota 문구도 정확히 분류.
+        const jsonErrorText = output ? extractAdvisorErrorText(output) : ''
         const combined = [jsonErrorText, stderrTail].filter(Boolean).join('\n')
         const errorCode = classifyAdvisorError(combined || undefined)
-        // detail 은 사용자 진단 정보 우선순위: stdout JSON 문구 > stderr tail.
-        // 관리자 alert 에도 이게 더 actionable (Claude 자체의 에러 원문).
         const detail = jsonErrorText.slice(0, 1024) || stderrTail || undefined
         reject(new AdvisorError(`Claude CLI 종료 코드: ${code}`, detail, errorCode))
         return
       }
 
-      try {
-        const output: ClaudeJsonOutput = JSON.parse(stdout)
+      if (!output) {
+        // stdout 에 result event 없음 (파싱 실패 or 이상 종료)
+        reject(new AdvisorError('AI 응답을 파싱할 수 없습니다.', undefined, 'parse_error'))
+        return
+      }
 
-        if (output.is_error) {
-          // Codex #478 P2: exit code 0 인데 is_error=true 인 케이스도 classify.
-          // Codex #479 P2: `result` 가 비어있어도 `api_error_status` / `errors`
-          // 활용해 auth/quota 정확 분류.
-          const errorText = extractAdvisorErrorText(output)
-          const errorCode = classifyAdvisorError(errorText || undefined)
+      if (output.is_error) {
+        const errorText = extractAdvisorErrorText(output)
+        const errorCode = classifyAdvisorError(errorText || undefined)
+        reject(new AdvisorError(
+          `AI 응답 오류: ${output.result || `api_error_status=${output.api_error_status ?? 'unknown'}`}`,
+          errorText.slice(0, 1024) || undefined,
+          errorCode,
+        ))
+        return
+      }
+
+      const numTurns = typeof output.num_turns === 'number' ? output.num_turns : 0
+
+      // Codex PR #484 P1 (3차) — 정확한 evaluator: `mcp__myfinance__*` 호출 카운트.
+      // 이전 시도들 (num_turns / 응답 fingerprint) 은 WebSearch-only 우회에
+      // 취약. tool_use event 카운트가 유일한 정답. fingerprint 는 belt-and-
+      // suspenders 로 유지 (tool 호출 후 오류로 실패 안내가 응답에 섞이는 경우).
+      if (options.expectsTools) {
+        const mcpCount = countMcpMyFinanceCalls(toolCalls)
+        const advertisedFailure = hasNoToolResponse(output.result)
+        if (mcpCount === 0 || advertisedFailure) {
+          const preview = toolCalls.slice(0, 20).join(',')
           reject(new AdvisorError(
-            `AI 응답 오류: ${output.result || `api_error_status=${output.api_error_status ?? 'unknown'}`}`,
-            errorText.slice(0, 1024) || undefined,
-            errorCode,
+            'AI 응답이 myFinance MCP 도구를 호출하지 않았습니다.',
+            `mcp_calls=${mcpCount} total_tool_calls=${toolCalls.length} ` +
+              `tools=[${preview}] ` +
+              `num_turns=${numTurns} ` +
+              `advertised_failure=${advertisedFailure}`,
+            'no_tool_used',
           ))
           return
         }
-
-        const numTurns = typeof output.num_turns === 'number' ? output.num_turns : 0
-
-        // #483 + Codex PR #484 P1: caller 가 MCP tool 사용을 필수로 기대한 경우
-        // 이중 방어 (structural + semantic):
-        //  1. `num_turns === 1` = 어떤 tool 도 호출 안 함 (fast fail)
-        //  2. `hasNoToolResponse(result)` = Claude 가 "도구 접근 불가" 안내를
-        //     본문에 직접 서술한 케이스. 브리핑 프롬프트에 WebSearch 가 명시되어
-        //     있어 Claude 가 MCP tool 은 skip 하고 WebSearch 만 호출해도
-        //     `num_turns >= 2` 로 나옴 → 이 경우 텍스트 fingerprint 로 감지.
-        //
-        // num_turns >= 2 && !hasNoToolResponse 케이스는 실제로 tool 을 사용한
-        // 정상 응답으로 간주 (일부 tool 만 호출한 부분 성공은 통과). num_turns
-        // 필드 자체가 없으면 (구버전 CLI 등) structural 검증은 스킵되고
-        // semantic 검증만 유효.
-        if (options.expectsTools) {
-          const skippedAll = numTurns === 1
-          const advertisedFailure = hasNoToolResponse(output.result)
-          if (skippedAll || advertisedFailure) {
-            reject(new AdvisorError(
-              'AI 응답이 데이터 도구를 사용하지 않았습니다.',
-              `num_turns=${numTurns} ` +
-                `stop_reason=${JSON.stringify((output as { stop_reason?: unknown }).stop_reason ?? null)} ` +
-                `result_len=${output.result?.length ?? 0} ` +
-                `advertised_failure=${advertisedFailure}`,
-              'no_tool_used',
-            ))
-            return
-          }
-        }
-
-        resolve({
-          response: output.result,
-          model,
-          durationMs: output.duration_ms,
-          costUsd: output.total_cost_usd,
-          sessionId: output.session_id ?? '',
-          numTurns,
-        })
-      } catch {
-        reject(new AdvisorError('AI 응답을 파싱할 수 없습니다.', undefined, 'parse_error'))
       }
+
+      resolve({
+        response: output.result,
+        model,
+        durationMs: output.duration_ms,
+        costUsd: output.total_cost_usd,
+        sessionId: output.session_id ?? '',
+        numTurns,
+      })
     })
 
     child.on('error', (error) => {

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -403,10 +403,19 @@ export async function askAdvisor(
     '--mcp-config', shellEscape(mcpConfigPath),
     '--strict-mcp-config',
     '--allowedTools', shellEscape(ALLOWED_TOOLS),
-    // #483: 기존에 있던 `--tools "WebSearch,WebFetch"` 제거.
-    // `--tools` 는 built-in tool set (Bash/Read/Edit/…) 제한용이며 MCP tool 에는
-    // 영향 없음. WebSearch/WebFetch 는 이미 `--allowedTools` 에 포함되어 있어
-    // 중복. 남겨두면 built-in tool 이 예기치 않게 제한될 수 있어 제거.
+    // Codex PR #484 P1 (security): `--tools` 는 built-in Claude Code tool 의
+    // **availability allowlist** — 지정 tool 만 subprocess 에서 사용 가능.
+    // `--allowedTools` 는 permission prompt 없이 사용 가능한 tool 만 지정
+    // (permission bypass) 이며 availability 를 제한하지 않음.
+    // → 이 옵션을 없애면 `Read`/`Glob`/`Grep` 등 file system 접근 tool 이 모든
+    // `askAdvisor` 호출에서 사용 가능해짐. `Read` 는 기본 permission 이 없어
+    // `/ai` 자유 질문 or 웹 컨텐츠 injection 을 통해 `Read /path/.env` 같이
+    // 유도되면 secret 노출 가능. `--strict-mcp-config` 는 MCP 만 restrict,
+    // built-in tool 은 별도 제한 필요.
+    // WebSearch/WebFetch 만 허용하는 이유: 브리핑/AI 채팅에 필요한 웹 정보 조회
+    // 는 유지하되 file/exec 계열은 완전 차단. MCP tool 은 이 옵션과 orthogonal
+    // 이므로 영향 없음 (필드에서 실측 확인 완료).
+    '--tools', '"WebSearch,WebFetch"',
     '--max-budget-usd', String(maxBudgetUsd),
     '--permission-mode', 'dontAsk',
   )

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -155,38 +155,57 @@ export function hasNoToolResponse(text: string | undefined): boolean {
 }
 
 /**
- * Codex PR #484 P1 (3차) — `--output-format stream-json --verbose` 응답 파싱.
+ * Codex PR #484 P1 (3차/4차) — `--output-format stream-json --verbose` 응답 파싱.
  *
  * 각 라인은 완전한 NDJSON event. 관심 event:
- *   - `type: 'assistant'` — `message.content[]` 배열에 여러 block. `tool_use` block 은
- *     `name` (tool 이름) 을 담음. 이걸 수집해 caller 가 `mcp__myfinance__*` 카운트로
- *     실제 호출 여부 판정.
+ *   - `type: 'assistant'` — `message.content[]` 배열의 `tool_use` block. `id` + `name`.
+ *     시도 자체가 성공을 의미하지는 않음 (매칭되는 tool_result 를 확인해야).
+ *   - `type: 'user'` — `message.content[]` 의 `tool_result` block. `tool_use_id` 로
+ *     이전 tool_use 와 correlate. `is_error: true` 면 그 호출은 실패 (예: MCP
+ *     서버 오류, tool arg validation 실패, tool 내부 예외).
  *   - `type: 'result'` — 마지막 event. `is_error` / `result` / `num_turns` /
- *     `session_id` / `duration_ms` / `total_cost_usd` / `api_error_status` / `errors`
- *     등 최종 metadata. 기존 `--output-format json` 과 동일 스키마.
+ *     `session_id` / `duration_ms` / `total_cost_usd` / `api_error_status` / `errors`.
  *
- * pure 로 stdout 문자열만 받아 파싱 → 테스트 용이. malformed line 은 skip.
+ * 4차 지적 반영: tool_use 만 카운트하면 tool_result 가 `is_error: true` 라도
+ * "호출됨" 으로 판정되어 데이터 없는 응답이 통과. tool_use.id ↔ tool_result.
+ * tool_use_id 매칭으로 각 호출의 실제 성공 여부까지 확인.
+ *
+ * pure — 테스트 용이. malformed line 은 skip.
  */
+export interface ParsedToolCall {
+  /** Claude 가 부여한 unique id — tool_result 매칭용. 누락 가능 (구버전). */
+  id?: string
+  /** Tool 이름 (예: `mcp__myfinance__get_portfolio`, `WebSearch`, `Bash`) */
+  name: string
+  /**
+   * 매칭된 tool_result 의 is_error 값.
+   *   - `false`: 정상 완료
+   *   - `true`: 실패 (MCP 오류 · validation · 예외 등)
+   *   - `undefined`: tool_result 이벤트가 없거나 매칭 실패 (이상 상태 — 실측에선
+   *     assistant tool_use 는 반드시 이후 user tool_result 로 응답. undefined 로
+   *     남는 케이스는 subprocess 이상 종료 등)
+   */
+  isError?: boolean
+}
+
 export interface ParsedClaudeStream {
   /** 마지막 result event (기존 ClaudeJsonOutput 과 동일 스키마) */
   finalResult?: ClaudeJsonOutput
-  /** 모든 assistant tool_use event 의 `name` 목록 (호출 순서대로) */
-  toolCalls: string[]
+  /** 모든 assistant tool_use event (호출 순서대로) + 매칭된 tool_result.is_error */
+  toolCalls: ParsedToolCall[]
 }
 
 interface ClaudeStreamContentBlock {
   type?: string
   name?: string
-}
-interface ClaudeStreamAssistantEvent {
-  type: 'assistant'
-  message?: {
-    content?: ClaudeStreamContentBlock[]
-  }
+  id?: string
+  tool_use_id?: string
+  is_error?: boolean
 }
 
 export function parseClaudeStreamJson(stdout: string): ParsedClaudeStream {
-  const toolCalls: string[] = []
+  const toolCalls: ParsedToolCall[] = []
+  const byId = new Map<string, ParsedToolCall>()
   let finalResult: ClaudeJsonOutput | undefined
   const lines = stdout.split('\n')
   for (const line of lines) {
@@ -201,11 +220,32 @@ export function parseClaudeStreamJson(stdout: string): ParsedClaudeStream {
     if (typeof evt !== 'object' || evt === null) continue
     const type = (evt as { type?: unknown }).type
     if (type === 'assistant') {
-      const content = (evt as ClaudeStreamAssistantEvent).message?.content
+      const content = (evt as { message?: { content?: ClaudeStreamContentBlock[] } }).message?.content
       if (Array.isArray(content)) {
         for (const block of content) {
           if (block?.type === 'tool_use' && typeof block.name === 'string') {
-            toolCalls.push(block.name)
+            const call: ParsedToolCall = {
+              id: typeof block.id === 'string' ? block.id : undefined,
+              name: block.name,
+            }
+            toolCalls.push(call)
+            if (call.id) byId.set(call.id, call)
+          }
+        }
+      }
+    } else if (type === 'user') {
+      const content = (evt as { message?: { content?: ClaudeStreamContentBlock[] } }).message?.content
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block?.type === 'tool_result' &&
+            typeof block.tool_use_id === 'string'
+          ) {
+            const call = byId.get(block.tool_use_id)
+            // is_error 는 명시적 boolean 만 신뢰 (없으면 undefined 유지).
+            if (call && typeof block.is_error === 'boolean') {
+              call.isError = block.is_error
+            }
           }
         }
       }
@@ -216,9 +256,22 @@ export function parseClaudeStreamJson(stdout: string): ParsedClaudeStream {
   return { finalResult, toolCalls }
 }
 
-/** Pure — `mcp__myfinance__*` prefix 카운트. */
-export function countMcpMyFinanceCalls(toolCalls: string[]): number {
-  return toolCalls.filter((n) => typeof n === 'string' && n.startsWith('mcp__myfinance__')).length
+/** Pure — `mcp__myfinance__*` prefix 시도 카운트 (성공/실패 무관). */
+export function countMcpMyFinanceCalls(toolCalls: ParsedToolCall[]): number {
+  return toolCalls.filter((c) => c.name.startsWith('mcp__myfinance__')).length
+}
+
+/**
+ * Pure — `mcp__myfinance__*` 중 **성공** 한 호출 카운트.
+ * Codex PR #484 P1 (4차): tool_use 만 카운트하면 tool_result 가 실패여도
+ * "호출됨" 으로 판정되어 데이터 없는 응답 통과. 성공 = `isError === false`
+ * (명시적 성공만). `undefined` (tool_result 매칭 실패) 나 `true` 는 실패 취급 —
+ * 이상 상태에서 안전한 fail-closed default.
+ */
+export function countSuccessfulMcpMyFinanceCalls(toolCalls: ParsedToolCall[]): number {
+  return toolCalls.filter(
+    (c) => c.name.startsWith('mcp__myfinance__') && c.isError === false,
+  ).length
 }
 
 /**
@@ -574,18 +627,28 @@ export async function askAdvisor(
 
       const numTurns = typeof output.num_turns === 'number' ? output.num_turns : 0
 
-      // Codex PR #484 P1 (3차) — 정확한 evaluator: `mcp__myfinance__*` 호출 카운트.
-      // 이전 시도들 (num_turns / 응답 fingerprint) 은 WebSearch-only 우회에
-      // 취약. tool_use event 카운트가 유일한 정답. fingerprint 는 belt-and-
-      // suspenders 로 유지 (tool 호출 후 오류로 실패 안내가 응답에 섞이는 경우).
+      // Codex PR #484 P1 (3차/4차) — 정확한 evaluator: `mcp__myfinance__*` 중
+      // **성공** 한 호출이 최소 1건 있는지. 이전 시도들:
+      //   - num_turns >= 2 (3차 지적): WebSearch-only 우회 취약
+      //   - tool_use 카운트만 (3차 fix): tool_result 실패 여도 카운트되어 우회 취약
+      //   - 응답 fingerprint (2차 fix): plausible 하지만 데이터 없는 report 우회
+      //
+      // → tool_use.id ↔ tool_result.tool_use_id 매칭으로 실제 성공한 mcp 호출
+      // (`isError === false` 인 것만) 을 카운트. fingerprint 는 belt-and-
+      // suspenders 로 유지 (모든 tool 이 성공했더라도 최종 응답에 "도구 접근
+      // 불가" 안내가 섞이는 부분 실패 케이스 방어).
       if (options.expectsTools) {
-        const mcpCount = countMcpMyFinanceCalls(toolCalls)
+        const mcpAttempts = countMcpMyFinanceCalls(toolCalls)
+        const mcpSuccesses = countSuccessfulMcpMyFinanceCalls(toolCalls)
         const advertisedFailure = hasNoToolResponse(output.result)
-        if (mcpCount === 0 || advertisedFailure) {
-          const preview = toolCalls.slice(0, 20).join(',')
+        if (mcpSuccesses === 0 || advertisedFailure) {
+          const preview = toolCalls.slice(0, 20)
+            .map((c) => `${c.name}${c.isError === true ? '!err' : c.isError === undefined ? '?' : ''}`)
+            .join(',')
           reject(new AdvisorError(
-            'AI 응답이 myFinance MCP 도구를 호출하지 않았습니다.',
-            `mcp_calls=${mcpCount} total_tool_calls=${toolCalls.length} ` +
+            'AI 응답이 성공한 myFinance MCP 도구 호출을 갖지 않습니다.',
+            `mcp_success=${mcpSuccesses} mcp_attempts=${mcpAttempts} ` +
+              `total_tool_calls=${toolCalls.length} ` +
               `tools=[${preview}] ` +
               `num_turns=${numTurns} ` +
               `advertised_failure=${advertisedFailure}`,

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -44,6 +44,17 @@ export interface AdvisorOptions {
    * 어느 flow 가 실패했는지 즉시 파악 가능 (briefing / ta-signal / active-review / etc).
    */
   caller?: string
+  /**
+   * #483 — 호출부가 MCP 도구 사용을 필수로 기대하는 flow (예: 모닝 브리핑).
+   * true 이면 Claude JSON output `num_turns` 이 2 미만 (도구 미호출) 인 응답을
+   * `no_tool_used` 로 실패 처리 → caller 는 fallback + monitor alert 트리거.
+   *
+   * **왜 필요:** Claude 가 `--strict-mcp-config` + tools/list 정상 수신에도
+   * 간헐적으로 도구를 한 번도 호출하지 않고 "도구 접근 불가" 안내 텍스트만
+   * 리턴하는 케이스 발생. `is_error=false` 이므로 CLI 성공 응답으로 판정되어
+   * 그대로 사용자에게 발송됨. num_turns 기반 검증으로 감지.
+   */
+  expectsTools?: boolean
 }
 
 export interface AdvisorResult {
@@ -52,6 +63,12 @@ export interface AdvisorResult {
   durationMs: number
   costUsd: number
   sessionId: string
+  /**
+   * #483 — Claude 대화 turn 수. tool 호출이 있으면 최소 2 (assistant → tool → assistant),
+   * 없으면 1. `expectsTools` 검증에 사용. `--output-format json` 에 없거나 파싱 실패
+   * 케이스는 0.
+   */
+  numTurns: number
 }
 
 /**
@@ -70,6 +87,12 @@ export type AdvisorErrorCode =
   | 'server_down'
   | 'timeout'
   | 'parse_error'
+  /**
+   * #483 — Claude 가 MCP 도구를 한 번도 호출하지 않고 응답 종료 (num_turns=1).
+   * caller 가 `expectsTools: true` 로 opt-in 했을 때만 발생. CLI subprocess 자체는
+   * exit 0 + is_error=false 라 별도 판정 필요.
+   */
+  | 'no_tool_used'
   | 'unknown'
 
 export class AdvisorTimeoutError extends Error {
@@ -171,6 +194,8 @@ export function describeAdvisorError(err: AdvisorError | AdvisorTimeoutError | E
       return '⏱ AI 응답 시간 초과 — 잠시 후 다시 시도해주세요.'
     case 'parse_error':
       return '🤖 AI 응답을 처리할 수 없습니다 — 잠시 후 다시 시도해주세요.'
+    case 'no_tool_used':
+      return '🤖 AI 어드바이저가 데이터 도구를 호출하지 않았습니다 — 관리자에게 문의해주세요.'
     default:
       return '🤖 AI 어드바이저 일시 중단 — 관리자에게 문의해주세요.'
   }
@@ -250,6 +275,12 @@ interface ClaudeJsonOutput {
   // classify 시 이 필드도 참조해야 auth/quota 분류 가능.
   api_error_status?: number | string
   errors?: unknown
+  /**
+   * #483 — Claude 대화 turn 수. tool 사용 시 최소 2 (assistant → tool_use →
+   * assistant), 미사용 시 1. `expectsTools: true` caller 는 이 값으로 도구
+   * 미호출 응답을 감지.
+   */
+  num_turns?: number
 }
 
 /**
@@ -335,7 +366,10 @@ export async function askAdvisor(
     '--mcp-config', shellEscape(mcpConfigPath),
     '--strict-mcp-config',
     '--allowedTools', shellEscape(ALLOWED_TOOLS),
-    '--tools', '"WebSearch,WebFetch"',
+    // #483: 기존에 있던 `--tools "WebSearch,WebFetch"` 제거.
+    // `--tools` 는 built-in tool set (Bash/Read/Edit/…) 제한용이며 MCP tool 에는
+    // 영향 없음. WebSearch/WebFetch 는 이미 `--allowedTools` 에 포함되어 있어
+    // 중복. 남겨두면 built-in tool 이 예기치 않게 제한될 수 있어 제거.
     '--max-budget-usd', String(maxBudgetUsd),
     '--permission-mode', 'dontAsk',
   )
@@ -432,12 +466,30 @@ export async function askAdvisor(
           return
         }
 
+        const numTurns = typeof output.num_turns === 'number' ? output.num_turns : 0
+
+        // #483: caller 가 tool 사용을 필수로 기대한 경우 (예: 브리핑) num_turns
+        // 로 도구 미호출 여부 검증. Claude subprocess 는 성공 (is_error=false)
+        // 이지만 도구를 한 번도 안 부른 케이스 (num_turns=1) 를 실패로 재분류.
+        // - tool 호출 시 최소 2 turn (assistant → tool_use → assistant)
+        // - num_turns 필드가 없으면 (구버전 CLI 등) 검증 스킵해 하위 호환
+        if (options.expectsTools && numTurns > 0 && numTurns < 2) {
+          reject(new AdvisorError(
+            `AI 응답이 도구를 호출하지 않았습니다 (num_turns=${numTurns}).`,
+            `stop_reason=${JSON.stringify((output as { stop_reason?: unknown }).stop_reason ?? null)} ` +
+              `result_len=${output.result?.length ?? 0}`,
+            'no_tool_used',
+          ))
+          return
+        }
+
         resolve({
           response: output.result,
           model,
           durationMs: output.duration_ms,
           costUsd: output.total_cost_usd,
           sessionId: output.session_id ?? '',
+          numTurns,
         })
       } catch {
         reject(new AdvisorError('AI 응답을 파싱할 수 없습니다.', undefined, 'parse_error'))

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -122,6 +122,43 @@ export class AdvisorError extends Error {
  * 직접 code 지정 (예: `AdvisorError('...', undefined, 'server_down')`).
  */
 /**
+ * Codex PR #484 P1: `num_turns` 는 MCP tool 사용 여부의 정확한 지표가 아님.
+ * 실측: 브리핑처럼 "WebSearch 로 뉴스 검색" 을 프롬프트에 명시하면 Claude 가
+ * MCP tool 은 건너뛰고 WebSearch 만 호출해도 `num_turns >= 2` 가 나옴 →
+ * guard 통과되어 데이터 없는 브리핑이 여전히 발송됨. 또 `--output-format json`
+ * 은 실제 호출된 tool 이름 목록을 노출하지 않음 (`iterations` 는 token 사용량
+ * 뿐).
+ *
+ * → Structural 검증 (`num_turns === 1` = 완전 미사용) + Semantic 검증 (응답
+ * 텍스트 fingerprint) 이중 방어. Semantic 은 아래 pattern.
+ *
+ * 실제 발송된 실패 응답 (2026-08-18):
+ *   "⚠️ 도구 연결 문제 안내
+ *    죄송하지만 현재 세션에서 myFinance 데이터 도구(포트폴리오, 전략, 기술적분석 등)
+ *    가 연결되지 않아 아래 항목을 확인할 수 없었습니다:"
+ *
+ * Pattern 은 매우 좁게 (정상 응답에서 우연히 등장할 수 없는 조합) 잡아
+ * false positive 최소화. 정상 브리핑이 "도구가 연결되지 않아" 를 언급할 이유는
+ * 없음 (정상 응답은 데이터를 나열).
+ */
+const NO_TOOL_RESPONSE_PATTERNS: RegExp[] = [
+  // Claude 가 "도구 접근/연결 실패" 를 명시적으로 서술하는 패턴
+  /(데이터\s*)?도구.{0,20}연결되지\s*않/,
+  /(도구|MCP).{0,20}(연결|접근)\s*(문제|불가|실패)/,
+  /(도구|MCP)\s*(연결|접근).{0,10}(못|안|불가)\s*(했|합|됩)/,
+]
+
+/**
+ * Pure — 응답 텍스트에서 "도구 미사용" fingerprint 감지.
+ * `expectsTools: true` caller 는 이 결과가 true 일 때 `no_tool_used` 로 실패 처리.
+ * 테스트 용이하도록 export.
+ */
+export function hasNoToolResponse(text: string | undefined): boolean {
+  if (!text) return false
+  return NO_TOOL_RESPONSE_PATTERNS.some((re) => re.test(text))
+}
+
+/**
  * Codex #479 P2 재수정: bare `'401'` / `'403'` / `'429'` substring 매칭은
  * false positive 유발 (port 4030 · 라인 401 · request id 포함 등). Claude 가
  * 실제 뱉는 형태만 명시적으로 매칭 (regex):
@@ -468,19 +505,32 @@ export async function askAdvisor(
 
         const numTurns = typeof output.num_turns === 'number' ? output.num_turns : 0
 
-        // #483: caller 가 tool 사용을 필수로 기대한 경우 (예: 브리핑) num_turns
-        // 로 도구 미호출 여부 검증. Claude subprocess 는 성공 (is_error=false)
-        // 이지만 도구를 한 번도 안 부른 케이스 (num_turns=1) 를 실패로 재분류.
-        // - tool 호출 시 최소 2 turn (assistant → tool_use → assistant)
-        // - num_turns 필드가 없으면 (구버전 CLI 등) 검증 스킵해 하위 호환
-        if (options.expectsTools && numTurns > 0 && numTurns < 2) {
-          reject(new AdvisorError(
-            `AI 응답이 도구를 호출하지 않았습니다 (num_turns=${numTurns}).`,
-            `stop_reason=${JSON.stringify((output as { stop_reason?: unknown }).stop_reason ?? null)} ` +
-              `result_len=${output.result?.length ?? 0}`,
-            'no_tool_used',
-          ))
-          return
+        // #483 + Codex PR #484 P1: caller 가 MCP tool 사용을 필수로 기대한 경우
+        // 이중 방어 (structural + semantic):
+        //  1. `num_turns === 1` = 어떤 tool 도 호출 안 함 (fast fail)
+        //  2. `hasNoToolResponse(result)` = Claude 가 "도구 접근 불가" 안내를
+        //     본문에 직접 서술한 케이스. 브리핑 프롬프트에 WebSearch 가 명시되어
+        //     있어 Claude 가 MCP tool 은 skip 하고 WebSearch 만 호출해도
+        //     `num_turns >= 2` 로 나옴 → 이 경우 텍스트 fingerprint 로 감지.
+        //
+        // num_turns >= 2 && !hasNoToolResponse 케이스는 실제로 tool 을 사용한
+        // 정상 응답으로 간주 (일부 tool 만 호출한 부분 성공은 통과). num_turns
+        // 필드 자체가 없으면 (구버전 CLI 등) structural 검증은 스킵되고
+        // semantic 검증만 유효.
+        if (options.expectsTools) {
+          const skippedAll = numTurns === 1
+          const advertisedFailure = hasNoToolResponse(output.result)
+          if (skippedAll || advertisedFailure) {
+            reject(new AdvisorError(
+              'AI 응답이 데이터 도구를 사용하지 않았습니다.',
+              `num_turns=${numTurns} ` +
+                `stop_reason=${JSON.stringify((output as { stop_reason?: unknown }).stop_reason ?? null)} ` +
+                `result_len=${output.result?.length ?? 0} ` +
+                `advertised_failure=${advertisedFailure}`,
+              'no_tool_used',
+            ))
+            return
+          }
         }
 
         resolve({

--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -178,12 +178,18 @@ export interface ParsedToolCall {
   /** Tool 이름 (예: `mcp__myfinance__get_portfolio`, `WebSearch`, `Bash`) */
   name: string
   /**
-   * 매칭된 tool_result 의 is_error 값.
-   *   - `false`: 정상 완료
-   *   - `true`: 실패 (MCP 오류 · validation · 예외 등)
-   *   - `undefined`: tool_result 이벤트가 없거나 매칭 실패 (이상 상태 — 실측에선
-   *     assistant tool_use 는 반드시 이후 user tool_result 로 응답. undefined 로
-   *     남는 케이스는 subprocess 이상 종료 등)
+   * 매칭된 tool_result 이벤트가 수신됐는지.
+   * false 면 subprocess 이상 종료 (assistant tool_use 만 emit 되고 user
+   * tool_result 못 받음) — 이 경우 성공으로 간주하지 않음 (fail-closed).
+   */
+  hasResult: boolean
+  /**
+   * 매칭된 tool_result 의 `is_error` 필드 값 (optional).
+   *   - `undefined`: 필드가 없음 → **정상 성공** (Anthropic ToolResultBlockParam
+   *     스키마상 is_error 는 optional. `src/mcp/utils.ts` 의 성공 응답
+   *     `toolResult` 는 이 필드를 생략, 실패 `toolError` 만 `isError: true` 추가)
+   *   - `false`: 명시적 성공
+   *   - `true`: 명시적 실패 (MCP 오류 · validation · 예외 등)
    */
   isError?: boolean
 }
@@ -227,6 +233,7 @@ export function parseClaudeStreamJson(stdout: string): ParsedClaudeStream {
             const call: ParsedToolCall = {
               id: typeof block.id === 'string' ? block.id : undefined,
               name: block.name,
+              hasResult: false,
             }
             toolCalls.push(call)
             if (call.id) byId.set(call.id, call)
@@ -242,9 +249,15 @@ export function parseClaudeStreamJson(stdout: string): ParsedClaudeStream {
             typeof block.tool_use_id === 'string'
           ) {
             const call = byId.get(block.tool_use_id)
-            // is_error 는 명시적 boolean 만 신뢰 (없으면 undefined 유지).
-            if (call && typeof block.is_error === 'boolean') {
-              call.isError = block.is_error
+            if (call) {
+              // Codex PR #484 P1 (5차): result 이벤트 수신 자체는 성공 신호.
+              // is_error 는 optional (Anthropic ToolResultBlockParam 스키마) —
+              // 성공 응답은 이 필드 생략. 명시적 boolean 만 채우고 없으면
+              // undefined 유지, 성공 판정은 countSuccessful* 이 담당.
+              call.hasResult = true
+              if (typeof block.is_error === 'boolean') {
+                call.isError = block.is_error
+              }
             }
           }
         }
@@ -263,14 +276,20 @@ export function countMcpMyFinanceCalls(toolCalls: ParsedToolCall[]): number {
 
 /**
  * Pure — `mcp__myfinance__*` 중 **성공** 한 호출 카운트.
- * Codex PR #484 P1 (4차): tool_use 만 카운트하면 tool_result 가 실패여도
- * "호출됨" 으로 판정되어 데이터 없는 응답 통과. 성공 = `isError === false`
- * (명시적 성공만). `undefined` (tool_result 매칭 실패) 나 `true` 는 실패 취급 —
- * 이상 상태에서 안전한 fail-closed default.
+ *
+ * 성공 판정: `hasResult === true && isError !== true`
+ *   - matching tool_result 이벤트를 받았고 (subprocess 이상 종료 아님)
+ *   - is_error 가 명시적으로 true 가 아님 (undefined 나 false 모두 성공)
+ *
+ * Codex PR #484 P1 (5차): is_error 는 Anthropic ToolResultBlockParam 스키마상
+ * optional. 성공 응답 (`src/mcp/utils.ts` 의 `toolResult`) 은 이 필드를 생략
+ * 하고 실패 (`toolError`) 만 `isError: true` 를 추가. 4차 fix 는 undefined
+ * 를 fail-closed 로 다뤘는데 이는 **모든 정상 브리핑을 실패 처리** 하는
+ * 문제 발생 → matching result 수신 여부 (`hasResult`) 로 pivot.
  */
 export function countSuccessfulMcpMyFinanceCalls(toolCalls: ParsedToolCall[]): number {
   return toolCalls.filter(
-    (c) => c.name.startsWith('mcp__myfinance__') && c.isError === false,
+    (c) => c.name.startsWith('mcp__myfinance__') && c.hasResult && c.isError !== true,
   ).length
 }
 
@@ -643,7 +662,12 @@ export async function askAdvisor(
         const advertisedFailure = hasNoToolResponse(output.result)
         if (mcpSuccesses === 0 || advertisedFailure) {
           const preview = toolCalls.slice(0, 20)
-            .map((c) => `${c.name}${c.isError === true ? '!err' : c.isError === undefined ? '?' : ''}`)
+            .map((c) => {
+              // 진단 마커: !err = tool_result is_error=true, ?nores = matching
+              // tool_result 없음 (subprocess 이상 종료). 마커 없음 = 성공.
+              const marker = c.isError === true ? '!err' : !c.hasResult ? '?nores' : ''
+              return `${c.name}${marker}`
+            })
             .join(',')
           reject(new AdvisorError(
             'AI 응답이 성공한 myFinance MCP 도구 호출을 갖지 않습니다.',


### PR DESCRIPTION
## 요약

- 텔레그램 모닝 브리핑이 간헐적으로 "MCP 도구 접근 불가" 안내 텍스트만 발송되던 문제 감지 + fallback.
- 원인: Claude CLI subprocess 는 exit 0 + is_error=false 로 성공하지만 실제로 MCP 도구를 한 번도 호출하지 않고 종료하는 케이스 (`num_turns=1`).
- MCP 서버는 완전 정상 (2026-08-18 08:30 세션 `c05309d3` 로그 상 tools/list 성공까지 확인). Claude 쪽 판단 이슈.

## 변경

**핵심 로직 (`src/lib/ai/claude-advisor.ts`):**
- `ClaudeJsonOutput` 에 `num_turns?: number` 필드 노출 (Claude \`--output-format json\` 이 이미 제공)
- `AdvisorResult.numTurns: number` 추가 (없으면 0)
- `AdvisorOptions.expectsTools?: boolean` 추가 (caller opt-in)
- `expectsTools=true && numTurns > 0 && numTurns < 2` 시 AdvisorError (code: 'no_tool_used') reject
- `AdvisorErrorCode` 에 `'no_tool_used'` 추가
- `describeAdvisorError` → "🤖 AI 어드바이저가 데이터 도구를 호출하지 않았습니다 — 관리자에게 문의해주세요."
- `--tools "WebSearch,WebFetch"` 라인 제거 (built-in tool 제한 옵션이라 MCP 무관하고 `--allowedTools` 와 중복. 원인 후보였으나 소거 완료. 오해 소지 정리 차원)

**Caller 4개 opt-in:**
- `src/bot/notifications/briefing.ts` — 모닝 브리핑 (cron)
- `src/bot/commands/briefing.ts` — /brief 봇 command
- `src/bot/notifications/active-review.ts` — 능동 리뷰 (cron)
- `src/bot/notifications/monthly-report.ts` — 월간 리포트 (cron)

각 caller 의 기존 catch fallback (`describeAdvisorError`) + `advisor-monitor` (연속 3회 실패 시 관리자 alert) 를 그대로 재활용.

## 회귀 방지

- `src/lib/ai/__tests__/claude-advisor.test.ts`:
  - `describeAdvisorError('no_tool_used')` 매핑 검증
  - `AdvisorError` code 계약에 `'no_tool_used'` 추가
  - detail (num_turns, stop_reason) 이 사용자 fallback 메시지에 노출되지 않는지

## 원인 분석 로그

08:30 브리핑 세션 `c05309d3` 실측 (MCP 서버 로그):
\`\`\`
23:30:00.691 UTC  POST initialize                       ✅ session created
23:30:00.710 UTC  POST notifications/initialized        ✅ handshake OK
23:30:00.725 UTC  POST tools/list                       ✅ tools 목록 정상 전달 (7ms)
23:30:27.097 UTC  GET  no-body                          ← SSE close (Claude 가 26s 후 종료)
[이후 30분간 tool_call 0회 → session_sweep]
\`\`\`

비교 (2026-08-17 09:48 정상 케이스 sid `63fce...`): tools/list 직후 즉시 `get_all_strategies` → `get_portfolio` → `get_prices` → `get_fx_rate` 순차 호출.

즉 병목은 **Claude CLI 쪽 (tools/list 후 도구 미사용)** 이지 MCP 서버가 아님. `--strict-mcp-config` 는 config 로딩만 강제할 뿐 도구 호출을 강제하지 않음.

## 감지 방법 근거

`claude -p ... --output-format json` 실측 응답:
\`\`\`json
{"num_turns":1,"stop_reason":"end_turn","permission_denials":[],...}
\`\`\`
- Tool 미사용 → `num_turns: 1`
- Tool 사용 → 최소 `num_turns: 2` (assistant → tool_use → assistant)
- 필드가 없는 하위 호환 케이스는 `numTurns === 0` 으로 스킵 (검증 미적용)

## Test plan

- [x] `npm run lint` (No warnings)
- [x] `npx tsc --noEmit`
- [x] `npm run test:run` (740/740 pass)
- [x] `npm run build` (web + MCP + bot 번들 성공)
- [x] Self review (pr-review-toolkit code-reviewer) — P0/P1/P2 0건
- [ ] 배포 후 실측: 다음 브리핑에서 도구 미호출 시 fallback + 관리자 alert 발동 여부 확인

Closes #483